### PR TITLE
Update Storage implementation in Settings.java to be compatible with latest annotation interface

### DIFF
--- a/src/com/magento/idea/magento2plugin/project/Settings.java
+++ b/src/com/magento/idea/magento2plugin/project/Settings.java
@@ -9,8 +9,7 @@ import org.jetbrains.annotations.Nullable;
 @State(
     name = "Magento2PluginSettings",
     storages = {
-        @Storage(id = "default", file = StoragePathMacros.PROJECT_FILE),
-        @Storage(id = "dir", file = StoragePathMacros.PROJECT_CONFIG_DIR + "/magento2plugin.xml", scheme = StorageScheme.DIRECTORY_BASED)
+        @Storage("magento2plugin.xml")
     }
 )
 public class Settings implements PersistentStateComponent<Settings> {


### PR DESCRIPTION
This allows the latest intellij community SDK to be used for building

`id` in Storage interface has been removed in https://github.com/JetBrains/intellij-community/commit/66bbb298b1c9a3afea8000c0a5588cedabd3d649#diff-ab396582d6774e7ffb0632b9fafe6e8aL26

`StoragePathMacros.PROJECT_FILE` and `StoragePathMacros.PROJECT_CONFIG_DIR` has been removed in https://github.com/JetBrains/intellij-community/commit/d1f3e40c4fa321aab76560eb1d99e7ad0617f214#diff-082ba6a4cca1c83eb7e5490c6b8d2bc0L49