### PR TITLE
JSGraphql configured as an optional dependency

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -35,7 +35,7 @@
     <depends>com.jetbrains.php</depends>
     <depends>JavaScript</depends>
     <depends>com.intellij.modules.platform</depends>
-    <depends>com.intellij.lang.jsgraphql</depends>
+    <depends optional="true" config-file="withJsGraphQl.xml">com.intellij.lang.jsgraphql</depends>
 
     <actions>
         <group id="MagentoGenerateGroup">
@@ -91,15 +91,12 @@
         <fileBasedIndex implementation="com.magento.idea.magento2plugin.stubs.indexes.mftf.DataIndex" />
         <fileBasedIndex implementation="com.magento.idea.magento2plugin.stubs.indexes.mftf.PageIndex" />
         <fileBasedIndex implementation="com.magento.idea.magento2plugin.stubs.indexes.mftf.StepKeyIndex" />
-        <fileBasedIndex implementation="com.magento.idea.magento2plugin.stubs.indexes.graphql.GraphQlResolverIndex" />
         <fileBasedIndex implementation="com.magento.idea.magento2plugin.stubs.indexes.js.RequireJsIndex" />
         <fileBasedIndex implementation="com.magento.idea.magento2plugin.stubs.indexes.js.MagentoLibJsIndex" />
 
         <codeInsight.lineMarkerProvider language="PHP" implementationClass="com.magento.idea.magento2plugin.php.linemarker.PluginLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="PHP" implementationClass="com.magento.idea.magento2plugin.php.linemarker.ClassConfigurationLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="PHP" implementationClass="com.magento.idea.magento2plugin.php.linemarker.WebApiLineMarkerProvider"/>
-        <codeInsight.lineMarkerProvider language="GraphQL" implementationClass="com.magento.idea.magento2plugin.graphql.linemarker.GraphQlResolverClassLineMarkerProvider"/>
-        <codeInsight.lineMarkerProvider language="PHP" implementationClass="com.magento.idea.magento2plugin.php.linemarker.GraphQlResolverUsageLineMarkerProvider"/>
 
         <directoryProjectConfigurator implementation="com.magento.idea.magento2plugin.project.ProjectDetector"/>
 

--- a/resources/META-INF/withJsGraphQl.xml
+++ b/resources/META-INF/withJsGraphQl.xml
@@ -1,0 +1,7 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <fileBasedIndex implementation="com.magento.idea.magento2plugin.stubs.indexes.graphql.GraphQlResolverIndex" />
+        <codeInsight.lineMarkerProvider language="PHP" implementationClass="com.magento.idea.magento2plugin.php.linemarker.GraphQlResolverUsageLineMarkerProvider"/>
+        <codeInsight.lineMarkerProvider language="GraphQL" implementationClass="com.magento.idea.magento2plugin.graphql.linemarker.GraphQlResolverClassLineMarkerProvider"/>
+    </extensions>
+</idea-plugin>

--- a/src/com/magento/idea/magento2plugin/php/linemarker/GraphQlResolverUsageLineMarkerProvider.java
+++ b/src/com/magento/idea/magento2plugin/php/linemarker/GraphQlResolverUsageLineMarkerProvider.java
@@ -71,7 +71,7 @@ public class GraphQlResolverUsageLineMarkerProvider implements LineMarkerProvide
 
     private static class GraphQlUsagesCollector {
 
-        private HashMap<String, List<GraphQLQuotedString>> routesCache = new HashMap<>();
+        private HashMap<String, List<GraphQLQuotedString>> graphQlCache = new HashMap<>();
 
         List<GraphQLQuotedString> getGraphQLUsages(@NotNull PhpClass phpClass) {
             List<GraphQLQuotedString> graphQLQuotedStrings = new ArrayList<>();
@@ -83,11 +83,11 @@ public class GraphQlResolverUsageLineMarkerProvider implements LineMarkerProvide
 
         List<GraphQLQuotedString> getUsages(@NotNull PhpClass phpClass) {
             String phpClassFQN = phpClass.getFQN();
-            if (!routesCache.containsKey(phpClassFQN)) {
+            if (!graphQlCache.containsKey(phpClassFQN)) {
                 List<GraphQLQuotedString> graphQLStringValues = extractGraphQLQuotesStringsForClass(phpClass);
-                routesCache.put(phpClassFQN, graphQLStringValues);
+                graphQlCache.put(phpClassFQN, graphQLStringValues);
             }
-            return routesCache.get(phpClassFQN);
+            return graphQlCache.get(phpClassFQN);
         }
 
         List<GraphQLQuotedString> extractGraphQLQuotesStringsForClass(@NotNull PhpClass phpClass) {

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/graphql/GraphQlResolverIndex.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/graphql/GraphQlResolverIndex.java
@@ -34,10 +34,10 @@ public class GraphQlResolverIndex extends ScalarIndexExtension<String> {
         return inputData -> {
             Map<String, Void> map = new HashMap<>();
 
-            GraphQLFile qraphQLFile = (GraphQLFile) inputData.getPsiFile();
-            PsiElement[] children = qraphQLFile.getChildren();
+            GraphQLFile graphQLFile = (GraphQLFile) inputData.getPsiFile();
+            PsiElement[] children = graphQLFile.getChildren();
             for (PsiElement child : children) {
-                if (!(child instanceof GraphQLObjectTypeDefinition)) {
+                if (!(child instanceof GraphQLObjectTypeDefinition) && !(child instanceof GraphQLInterfaceTypeDefinition)) {
                     continue;
                 }
                 PsiElement[] objectChildren = child.getChildren();


### PR DESCRIPTION
## Description

This PR introduces a change that makes the JSGraphQl module an optional dependency for the current plugin. With this change In case if the JSGraphQl is disabled or not installed the Magento module will still work but without GraphQL line markers and other GraphQl-related functionality.

Please note that the dependency should still exist in the `build.gradle` since it's required for the module compilation with all possible dependencies (including optional). 

## Related Issues
#43 : Line Marker. Remove GraphQlJS hard dependency 

## Manual testing scenarios

- Compile/build the module with the new configuration
- Open IDE with the module installed 
- Disable JSGraphQl module
- The Magento module should still be enabled and working
