### PR TITLE
Show the current project's Magento version in settings window

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/util/MagentoVersion.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/util/MagentoVersion.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.actions.generation.util;
+
+import com.intellij.ide.DataManager;
+import com.intellij.json.psi.JsonFile;
+import com.intellij.json.psi.JsonObject;
+import com.intellij.openapi.actionSystem.DataConstants;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.magento.idea.magento2plugin.php.module.ComposerPackageModel;
+import com.magento.idea.magento2plugin.php.module.ComposerPackageModelImpl;
+
+public class MagentoVersion {
+    private static MagentoVersion INSTANCE = null;
+    private String version = "unknown";
+    private Project project;
+
+    public static MagentoVersion getInstance() {
+        if (null == INSTANCE) {
+            INSTANCE = new MagentoVersion();
+        }
+        return INSTANCE;
+    }
+
+    public String get() {
+        DataContext dataContext = DataManager.getInstance().getDataContext();
+        this.project = (Project) dataContext.getData(DataConstants.PROJECT);
+
+        VirtualFile file = LocalFileSystem.getInstance().findFileByPath(this.getFilePath());
+
+        if (file == null) {
+            return version;
+        }
+
+        PsiManager psiManager = PsiManager.getInstance(this.project);
+        PsiFile composerFile = psiManager.findFile(file);
+
+        if (composerFile instanceof JsonFile) {
+            JsonFile composerJsonFile = (JsonFile) composerFile;
+            JsonObject jsonObject = PsiTreeUtil.getChildOfType(composerJsonFile, JsonObject.class);
+
+            if (jsonObject == null) {
+                return version;
+            }
+
+            ComposerPackageModel composerObject = new ComposerPackageModelImpl(jsonObject);
+
+            if (composerObject.getType() != null) {
+                version = composerObject.getVersion();
+            }
+        }
+
+        return version;
+    }
+
+    private String getFilePath() {
+        String fileName = "composer.json";
+        return this.project.getBasePath() + "/" + fileName;
+    }
+}

--- a/src/com/magento/idea/magento2plugin/actions/generation/util/MagentoVersion.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/util/MagentoVersion.java
@@ -16,8 +16,11 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.util.PsiTreeUtil;
+import com.magento.idea.magento2plugin.magento.files.ComposerJson;
 import com.magento.idea.magento2plugin.php.module.ComposerPackageModel;
 import com.magento.idea.magento2plugin.php.module.ComposerPackageModelImpl;
+
+import java.io.File;
 
 public class MagentoVersion {
     private static MagentoVersion INSTANCE = null;
@@ -63,7 +66,6 @@ public class MagentoVersion {
     }
 
     private String getFilePath() {
-        String fileName = "composer.json";
-        return this.project.getBasePath() + "/" + fileName;
+        return this.project.getBasePath() + File.separator + ComposerJson.FILE_NAME;
     }
 }

--- a/src/com/magento/idea/magento2plugin/inspections/xml/CacheableFalseInDefaultLayoutInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/xml/CacheableFalseInDefaultLayoutInspection.java
@@ -24,14 +24,14 @@ public class CacheableFalseInDefaultLayoutInspection extends XmlSuppressableInsp
             @Override
             public void visitXmlAttribute(XmlAttribute attribute) {
                 String fileName = holder.getFile().getName();
-                if (!fileName.equals(LayoutXml.DefaultFileName)) return;
+                if (!fileName.equals(LayoutXml.DEFAULT_FILENAME)) return;
                 final String text = attribute.getValue();
                 final String attributeName = attribute.getName();
-                if (!attributeName.equals(LayoutXml.CacheableAttributeName)) return;
-                if (!attribute.getParent().getName().equals(LayoutXml.BlockAttributeTagName)
-                && !attribute.getParent().getName().equals(LayoutXml.ReferenceBlockAttributeTagName)) return;
+                if (!attributeName.equals(LayoutXml.CACHEABLE_ATTRIBUTE_NAME)) return;
+                if (!attribute.getParent().getName().equals(LayoutXml.BLOCK_ATTRIBUTE_TAG_NAME)
+                && !attribute.getParent().getName().equals(LayoutXml.REFERENCE_BLOCK_ATTRIBUTE_TAG_NAME)) return;
                 if (text == null) return;
-                if (text.equals(LayoutXml.CacheableAttributeFalseValue)) {
+                if (text.equals(LayoutXml.CACHEABLE_ATTRIBUTE_VALUE_FALSE)) {
                     holder.registerProblem(attribute, CacheDisableProblemDescription,
                             ProblemHighlightType.WARNING,
                             new XmlRemoveCacheableAttributeQuickFix());

--- a/src/com/magento/idea/magento2plugin/magento/files/LayoutXml.java
+++ b/src/com/magento/idea/magento2plugin/magento/files/LayoutXml.java
@@ -5,10 +5,10 @@
 package com.magento.idea.magento2plugin.magento.files;
 
 public class LayoutXml {
-    public static String DefaultFileName = "default.xml";
-    public static String CacheableAttributeName = "cacheable";
-    public static String CacheableAttributeFalseValue = "false";
-    public static String BlockAttributeTagName = "block";
-    public static String ReferenceBlockAttributeTagName = "referenceBlock";
+    public static String DEFAULT_FILENAME = "default.xml";
+    public static String CACHEABLE_ATTRIBUTE_NAME = "cacheable";
+    public static String CACHEABLE_ATTRIBUTE_VALUE_FALSE = "false";
+    public static String BLOCK_ATTRIBUTE_TAG_NAME = "block";
+    public static String REFERENCE_BLOCK_ATTRIBUTE_TAG_NAME = "referenceBlock";
     public static String XML_ATTRIBUTE_TEMPLATE = "template";
 }

--- a/src/com/magento/idea/magento2plugin/magento/packages/Package.java
+++ b/src/com/magento/idea/magento2plugin/magento/packages/Package.java
@@ -4,8 +4,6 @@
  */
 package com.magento.idea.magento2plugin.magento.packages;
 
-import java.util.ArrayList;
-
 public class Package {
     public static String PACKAGES_ROOT = "app/code";
     public static String VENDOR = "vendor";

--- a/src/com/magento/idea/magento2plugin/project/SettingsForm.form
+++ b/src/com/magento/idea/magento2plugin/project/SettingsForm.form
@@ -1,10 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-/**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
- */
--->
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.magento.idea.magento2plugin.project.SettingsForm">
   <grid id="27dc6" binding="panel1" default-binding="true" layout-manager="GridLayoutManager" row-count="2" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
@@ -15,6 +9,8 @@
     <border type="none"/>
     <children>
       <grid id="61372" layout-manager="FormLayout">
+        <rowspec value="center:max(d;4px):noGrow"/>
+        <rowspec value="top:3dlu:noGrow"/>
         <rowspec value="center:max(d;4px):noGrow"/>
         <rowspec value="top:3dlu:noGrow"/>
         <rowspec value="center:max(d;4px):noGrow"/>
@@ -44,6 +40,15 @@
             <properties>
               <horizontalAlignment value="0"/>
               <text value="Regenerate urn map"/>
+            </properties>
+          </component>
+          <component id="c2894" class="javax.swing.JLabel" binding="magentoVersion">
+            <constraints>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <forms/>
+            </constraints>
+            <properties>
+              <text value=""/>
             </properties>
           </component>
         </children>

--- a/src/com/magento/idea/magento2plugin/project/SettingsForm.form
+++ b/src/com/magento/idea/magento2plugin/project/SettingsForm.form
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.magento.idea.magento2plugin.project.SettingsForm">
   <grid id="27dc6" binding="panel1" default-binding="true" layout-manager="GridLayoutManager" row-count="2" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>

--- a/src/com/magento/idea/magento2plugin/project/SettingsForm.java
+++ b/src/com/magento/idea/magento2plugin/project/SettingsForm.java
@@ -15,11 +15,9 @@ import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.search.FilenameIndex;
+import com.magento.idea.magento2plugin.actions.generation.util.MagentoVersion;
 import com.magento.idea.magento2plugin.indexes.IndexManager;
-import com.magento.idea.magento2plugin.php.module.ComposerPackageModel;
-import com.magento.idea.magento2plugin.php.module.MagentoComponent;
-import com.magento.idea.magento2plugin.php.module.MagentoComponentManager;
-import com.magento.idea.magento2plugin.php.module.MagentoModule;
+import com.magento.idea.magento2plugin.php.module.*;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -42,6 +40,8 @@ public class SettingsForm implements Configurable {
     private JButton buttonReindex;
     private JPanel panel1;
     private JButton regenerateUrnMapButton;
+    private JLabel magentoVersion;
+    private MagentoVersion magentoVersionModel = MagentoVersion.getInstance();
 
     public SettingsForm(@NotNull final Project project) {
         this.project = project;
@@ -78,6 +78,9 @@ public class SettingsForm implements Configurable {
         regenerateUrnMapButton.addMouseListener(
             new RegenerateUrnMapListener(project)
         );
+
+        magentoVersion.setText("Magento version: ".concat(magentoVersionModel.get()));
+
         return (JComponent) panel1;
     }
 

--- a/src/com/magento/idea/magento2plugin/project/SettingsForm.java
+++ b/src/com/magento/idea/magento2plugin/project/SettingsForm.java
@@ -79,7 +79,10 @@ public class SettingsForm implements Configurable {
             new RegenerateUrnMapListener(project)
         );
 
-        magentoVersion.setText("Magento version: ".concat(magentoVersionModel.get()));
+        String version = magentoVersionModel.get();
+        if (version != null) {
+            magentoVersion.setText("Magento version: " . concat(version));
+        }
 
         return (JComponent) panel1;
     }

--- a/tests/com/magento/idea/magento2plugin/inspections/xml/CacheableFalseInDefaultLayoutInspectionTest.java
+++ b/tests/com/magento/idea/magento2plugin/inspections/xml/CacheableFalseInDefaultLayoutInspectionTest.java
@@ -29,12 +29,12 @@ public class CacheableFalseInDefaultLayoutInspectionTest extends BasePlatformTes
     }
 
     public void testWithCacheableFalseBlock() throws Exception {
-        myFixture.configureByFile(getTestName(true) + "/" + LayoutXml.DefaultFileName);
+        myFixture.configureByFile(getTestName(true) + "/" + LayoutXml.DEFAULT_FILENAME);
         myFixture.testHighlighting(true, false, false);
     }
 
     public void testWithoutCacheableFalseBlock() throws Exception {
-        myFixture.configureByFile(getTestName(true) + "/" + LayoutXml.DefaultFileName);
+        myFixture.configureByFile(getTestName(true) + "/" + LayoutXml.DEFAULT_FILENAME);
         myFixture.testHighlighting(true, true, true);
     }
 


### PR DESCRIPTION
### Description (*)
This PR adds a new util class that retrieves the Project's Magento version from the `composer.json` file in the project's root.

![image](https://user-images.githubusercontent.com/13456702/78213960-bc4c1d80-74bc-11ea-9d8d-387ecd4fd5a4.png)


### Fixed Issues (if relevant)

1. magento/magento2-phpstorm-plugin#51: Magento Versioning. Create a Util class for defining a Magento version

### Questions or comments
- [ ] Is the util file/class naming OK?
- [ ] Is the util method naming OK?
- [ ] Is there any other way to get the currently active project in the IDE other than the code below?
(uses deprecated methods)
```java
DataContext dataContext = DataManager.getInstance().getDataContext();
this.project = (Project) dataContext.getData(DataConstants.PROJECT);
```

ℹ️ Instead of using a hard dependency on https://plugins.jetbrains.com/plugin/7631-php-composer-json-support as mentioned in the issue comments, I've used the existing class `com.magento.idea.magento2plugin.php.module.ComposerPackageModelImpl` in the project to get information from a `composer.json` file.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages

