### PR TITLE
[XmlCompletion] #91 - Added php class completion for source_model tag…

### DIFF
--- a/src/com/magento/idea/magento2plugin/completion/xml/XmlCompletionContributor.java
+++ b/src/com/magento/idea/magento2plugin/completion/xml/XmlCompletionContributor.java
@@ -103,6 +103,23 @@ public class XmlCompletionContributor extends CompletionContributor {
             new PhpConstructorArgumentCompletionProvider()
         );
 
+        // <source_model>php class completion</source_model> in system.xml files.
+        extend(CompletionType.BASIC, psiElement(XmlTokenType.XML_DATA_CHARACTERS)
+            .inside(XmlPatterns.xmlTag().withName(ModuleSystemXml.SOURCE_MODEL_ELEMENT_NAME)
+                .withParent(XmlPatterns.xmlTag().withName(ModuleSystemXml.FIELD_ELEMENT_NAME))
+            ).inFile(xmlFile().withName(string().endsWith(ModuleSystemXml.FILE_NAME))),
+            new PhpClassCompletionProvider()
+        );
+
+        // <parameter source_model="completion">...</parameter> in widget.xml files.
+        extend(CompletionType.BASIC, psiElement(XmlTokenType.XML_ATTRIBUTE_VALUE_TOKEN)
+            .inside(XmlPatterns.xmlAttribute().withName(ModuleWidgetXml.ATTRIBUTE_SOURCE_MODEL_NAME)
+                .withParent(XmlPatterns.xmlTag().withName(ModuleWidgetXml.TAG_PARAMETER_NAME).
+                    withParent(XmlPatterns.xmlTag().withName(ModuleWidgetXml.TAG_PARAMETERS_NAME)))
+            ).inFile(xmlFile().withName(string().endsWith(ModuleWidgetXml.FILE_NAME))),
+                new PhpClassCompletionProvider()
+        );
+
         // <service method="methodName"/>
         extend(CompletionType.BASIC, psiElement(XmlTokenType.XML_ATTRIBUTE_VALUE_TOKEN)
                 .inside(XmlPatterns.xmlAttribute().withName("method")

--- a/src/com/magento/idea/magento2plugin/magento/files/ModuleSystemXml.java
+++ b/src/com/magento/idea/magento2plugin/magento/files/ModuleSystemXml.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+package com.magento.idea.magento2plugin.magento.files;
+
+public class ModuleSystemXml {
+    public static final String FILE_NAME = "system.xml";
+    public static final String FIELD_ELEMENT_NAME = "field";
+    public static final String SOURCE_MODEL_ELEMENT_NAME = "source_model";
+}

--- a/src/com/magento/idea/magento2plugin/magento/files/ModuleWidgetXml.java
+++ b/src/com/magento/idea/magento2plugin/magento/files/ModuleWidgetXml.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+package com.magento.idea.magento2plugin.magento.files;
+
+public class ModuleWidgetXml {
+    public static final String FILE_NAME = "widget.xml";
+    public static final String TAG_WIDGET_NAME = "widget";
+    public static final String TAG_PARAMETERS_NAME = "parameters";
+    public static final String TAG_PARAMETER_NAME = "parameter";
+    public static final String ATTRIBUTE_SOURCE_MODEL_NAME = "source_model";
+}


### PR DESCRIPTION
Fixed #91 
This PR will add PHP classes completion for source_model tag in the system.xml file and source_model attribute inside a parameter tag of widget configuration in a widget XML file.

**Expected result for system.xml file case:**
![91-source-model-for-system-xml](https://user-images.githubusercontent.com/31848341/78414502-fc2e1480-7624-11ea-81e9-658e66bbf648.png)

**Expected result for widget.xml file case:**
![91-source-model-for-widget-xml](https://user-images.githubusercontent.com/31848341/78414507-03edb900-7625-11ea-834a-6ddf77ba65e9.png)
