### PR TITLE
#90 :- Completion. Add PHP classes completion to the frontend_model attribute and tag

### DIFF
--- a/src/com/magento/idea/magento2plugin/completion/xml/XmlCompletionContributor.java
+++ b/src/com/magento/idea/magento2plugin/completion/xml/XmlCompletionContributor.java
@@ -71,13 +71,6 @@ public class XmlCompletionContributor extends CompletionContributor {
                 new PhpClassCompletionProvider()
         );
 
-        // <frontend_model>completion</frontend_model>
-        extend(CompletionType.BASIC,
-                psiElement(XmlTokenType.XML_DATA_CHARACTERS)
-                        .inside(XmlPatterns.xmlTag().withName(SystemXml.XML_TAG_FRONTEND_MODEL)),
-                new PhpClassCompletionProvider()
-        );
-
         /* File Path Completion provider */
         extend(CompletionType.BASIC, psiElement(XmlTokenType.XML_ATTRIBUTE_VALUE_TOKEN)
                         .inside(XmlPatterns.xmlAttribute().withName(LayoutXml.XML_ATTRIBUTE_TEMPLATE)),
@@ -112,10 +105,17 @@ public class XmlCompletionContributor extends CompletionContributor {
 
         // <source_model>php class completion</source_model> in system.xml files.
         extend(CompletionType.BASIC, psiElement(XmlTokenType.XML_DATA_CHARACTERS)
-            .inside(XmlPatterns.xmlTag().withName(ModuleSystemXml.SOURCE_MODEL_ELEMENT_NAME)
+            .inside(XmlPatterns.xmlTag().withName(ModuleSystemXml.XML_TAG_SOURCE_MODEL)
                 .withParent(XmlPatterns.xmlTag().withName(ModuleSystemXml.FIELD_ELEMENT_NAME))
             ).inFile(xmlFile().withName(string().endsWith(ModuleSystemXml.FILE_NAME))),
             new PhpClassCompletionProvider()
+        );
+
+        // <frontend_model>completion</frontend_model>
+        extend(CompletionType.BASIC,
+                psiElement(XmlTokenType.XML_DATA_CHARACTERS)
+                        .inside(XmlPatterns.xmlTag().withName(ModuleSystemXml.XML_TAG_FRONTEND_MODEL)),
+                new PhpClassCompletionProvider()
         );
 
         // <parameter source_model="completion">...</parameter> in widget.xml files.

--- a/src/com/magento/idea/magento2plugin/completion/xml/XmlCompletionContributor.java
+++ b/src/com/magento/idea/magento2plugin/completion/xml/XmlCompletionContributor.java
@@ -71,6 +71,13 @@ public class XmlCompletionContributor extends CompletionContributor {
                 new PhpClassCompletionProvider()
         );
 
+        // <frontend_model>completion</frontend_model>
+        extend(CompletionType.BASIC,
+                psiElement(XmlTokenType.XML_DATA_CHARACTERS)
+                        .inside(XmlPatterns.xmlTag().withName(SystemXml.XML_TAG_FRONTEND_MODEL)),
+                new PhpClassCompletionProvider()
+        );
+
         /* File Path Completion provider */
         extend(CompletionType.BASIC, psiElement(XmlTokenType.XML_ATTRIBUTE_VALUE_TOKEN)
                         .inside(XmlPatterns.xmlAttribute().withName(LayoutXml.XML_ATTRIBUTE_TEMPLATE)),

--- a/src/com/magento/idea/magento2plugin/magento/files/ModuleSystemXml.java
+++ b/src/com/magento/idea/magento2plugin/magento/files/ModuleSystemXml.java
@@ -7,5 +7,6 @@ package com.magento.idea.magento2plugin.magento.files;
 public class ModuleSystemXml {
     public static final String FILE_NAME = "system.xml";
     public static final String FIELD_ELEMENT_NAME = "field";
-    public static final String SOURCE_MODEL_ELEMENT_NAME = "source_model";
+    public static final String XML_TAG_SOURCE_MODEL = "source_model";
+    public static final String XML_TAG_FRONTEND_MODEL = "frontend_model";
 }

--- a/src/com/magento/idea/magento2plugin/magento/files/SystemXml.java
+++ b/src/com/magento/idea/magento2plugin/magento/files/SystemXml.java
@@ -1,9 +1,0 @@
-/*
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
- */
-package com.magento.idea.magento2plugin.magento.files;
-
-public class SystemXml {
-    public static String XML_TAG_FRONTEND_MODEL = "frontend_model";
-}

--- a/src/com/magento/idea/magento2plugin/magento/files/SystemXml.java
+++ b/src/com/magento/idea/magento2plugin/magento/files/SystemXml.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+package com.magento.idea.magento2plugin.magento.files;
+
+public class SystemXml {
+    public static String XML_TAG_FRONTEND_MODEL = "frontend_model";
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will add PHP class completion for the `frontend_model` XML tag
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2-phpstorm-plugin#90: Completion. Add PHP classes completion to the frontend_model attribute and tag

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages

