### PR TITLE
[bugfix] Code generation: module block namespace is corrupt

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewBlockDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewBlockDialog.java
@@ -143,7 +143,7 @@ public class NewBlockDialog extends AbstractDialog {
             return null;
         }
         String directoryPart = getBlockDirectory().replace(File.separator, Package.FQN_SEPARATOR);
-        return parts[0] + Package.FQN_SEPARATOR + parts[1] + directoryPart;
+        return parts[0] + Package.FQN_SEPARATOR + parts[1]+ Package.FQN_SEPARATOR + directoryPart;
     }
 
     public void onCancel() {


### PR DESCRIPTION
### Description (*)
The PR fixes an issue reported in #112 and introduced in #92 

### Fixed Issues (if relevant)

1. magento/magento2-phpstorm-plugin#112 Module Block namespace is wrong when creating new module Block via form dialog.

### Steps to reproduce
Please see the original issue description.

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages

