### PR TITLE
Fixed listeners on new module form for PHPStorm

### DIFF
--- a/src/com/magento/idea/magento2plugin/generation/NewModuleForm.java
+++ b/src/com/magento/idea/magento2plugin/generation/NewModuleForm.java
@@ -163,6 +163,21 @@ public class NewModuleForm implements ListSelectionListener {
                 listener.run();
             }
         });
+        this.moduleName.getDocument().addDocumentListener(new DocumentAdapter() {
+            protected void textChanged(@NotNull DocumentEvent e) {
+                listener.run();
+            }
+        });
+        this.packageName.getDocument().addDocumentListener(new DocumentAdapter() {
+            protected void textChanged(@NotNull DocumentEvent e) {
+                listener.run();
+            }
+        });
+        this.moduleVersion.getDocument().addDocumentListener(new DocumentAdapter() {
+            protected void textChanged(@NotNull DocumentEvent e) {
+                listener.run();
+            }
+        });
     }
 
     private void fireStateChanged() {


### PR DESCRIPTION
# Description (*)
Added missed listeners for fields with validation to make the form validation to be refreshed immediately.

![image](https://user-images.githubusercontent.com/20116393/79051084-d31a0f00-7c36-11ea-970c-f55a154741d9.png)

![image](https://user-images.githubusercontent.com/20116393/79051086-d7dec300-7c36-11ea-88b2-052f9f7c9558.png)
