### PR TITLE
MFTF. Fixed page URL reference and completion, added test coverage

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/CreateAPluginAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/CreateAPluginAction.java
@@ -44,6 +44,9 @@ public class CreateAPluginAction extends DumbAwareAction {
             Pair<PsiFile, PhpClass> pair = this.findPhpClass(event);
             PsiFile psiFile = pair.getFirst();
             PhpClass phpClass = pair.getSecond();
+            if (phpClass == null || psiFile == null) {
+                return;
+            }
             targetClass = phpClass;
             if (!(psiFile instanceof PhpFile) || phpClass.isFinal() || this.targetMethod == null) {
                 this.setStatus(event, false);

--- a/src/com/magento/idea/magento2plugin/completion/provider/mftf/ActionGroupCompletionProvider.java
+++ b/src/com/magento/idea/magento2plugin/completion/provider/mftf/ActionGroupCompletionProvider.java
@@ -1,3 +1,7 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 package com.magento.idea.magento2plugin.completion.provider.mftf;
 
 import com.intellij.codeInsight.completion.CompletionParameters;

--- a/src/com/magento/idea/magento2plugin/completion/provider/mftf/DataCompletionProvider.java
+++ b/src/com/magento/idea/magento2plugin/completion/provider/mftf/DataCompletionProvider.java
@@ -1,3 +1,7 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 package com.magento.idea.magento2plugin.completion.provider.mftf;
 
 import com.intellij.codeInsight.completion.CompletionParameters;
@@ -9,7 +13,6 @@ import com.intellij.util.ProcessingContext;
 import com.intellij.util.indexing.FileBasedIndex;
 import com.magento.idea.magento2plugin.stubs.indexes.mftf.DataIndex;
 import org.jetbrains.annotations.NotNull;
-
 import java.util.Collection;
 
 public class DataCompletionProvider extends CompletionProvider<CompletionParameters> {

--- a/src/com/magento/idea/magento2plugin/completion/provider/mftf/PageCompletionProvider.java
+++ b/src/com/magento/idea/magento2plugin/completion/provider/mftf/PageCompletionProvider.java
@@ -11,28 +11,31 @@ import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.psi.PsiElement;
 import com.intellij.util.ProcessingContext;
 import com.intellij.util.indexing.FileBasedIndex;
-import com.magento.idea.magento2plugin.stubs.indexes.mftf.SectionIndex;
+import com.magento.idea.magento2plugin.magento.files.MftfActionGroup;
+import com.magento.idea.magento2plugin.stubs.indexes.mftf.PageIndex;
 import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 
-public class SelectorCompletionProvider extends CompletionProvider<CompletionParameters> {
+public class PageCompletionProvider extends CompletionProvider<CompletionParameters> {
 
     @Override
-    protected void addCompletions(@NotNull CompletionParameters parameters,
-                                  ProcessingContext context,
-                                  @NotNull CompletionResultSet result)
-    {
+    protected void addCompletions(
+            @NotNull CompletionParameters parameters,
+            ProcessingContext context,
+            @NotNull CompletionResultSet result) {
         PsiElement position = parameters.getPosition().getOriginalElement();
 
         if (position == null) {
             return;
         }
 
-        Collection<String> selectorNames
-            = FileBasedIndex.getInstance().getAllKeys(SectionIndex.KEY, position.getProject());
+        Collection<String> allKeys
+            = FileBasedIndex.getInstance().getAllKeys(PageIndex.KEY, position.getProject());
 
-        for (String selectorName: selectorNames) {
-            result.addElement(LookupElementBuilder.create(selectorName));
+        for (String pageName: allKeys) {
+            result.addElement(LookupElementBuilder.create(
+                    pageName
+            ));
         }
     }
 }

--- a/src/com/magento/idea/magento2plugin/completion/provider/mftf/PageCompletionProvider.java
+++ b/src/com/magento/idea/magento2plugin/completion/provider/mftf/PageCompletionProvider.java
@@ -11,7 +11,7 @@ import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.psi.PsiElement;
 import com.intellij.util.ProcessingContext;
 import com.intellij.util.indexing.FileBasedIndex;
-import com.magento.idea.magento2plugin.magento.files.MftfActionGroup;
+import com.magento.idea.magento2plugin.magento.files.MftfPage;
 import com.magento.idea.magento2plugin.stubs.indexes.mftf.PageIndex;
 import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
@@ -35,6 +35,8 @@ public class PageCompletionProvider extends CompletionProvider<CompletionParamet
         for (String pageName: allKeys) {
             result.addElement(LookupElementBuilder.create(
                     pageName
+                        + MftfPage.REFERENCE_SEPARATOR
+                        + MftfPage.URL_ATTRIBUTE
             ));
         }
     }

--- a/src/com/magento/idea/magento2plugin/completion/xml/XmlCompletionContributor.java
+++ b/src/com/magento/idea/magento2plugin/completion/xml/XmlCompletionContributor.java
@@ -227,11 +227,37 @@ public class XmlCompletionContributor extends CompletionContributor {
             new ActionGroupCompletionProvider()
         );
 
+        // mftf page url completion contributor
+        extend(
+            CompletionType.BASIC,
+            psiElement(XmlTokenType.XML_ATTRIBUTE_VALUE_TOKEN)
+                .inside(
+                    XmlPatterns.xmlAttribute().withName(MftfActionGroup.URL_ATTRIBUTE)
+                    .withParent(XmlPatterns.xmlTag().withParent(
+                            XmlPatterns.xmlTag().withName(
+                        string().oneOf(MftfActionGroup.ROOT_TAG, MftfTest.ROOT_TAG)
+                    )))
+                ),
+            new PageCompletionProvider()
+        );
+        extend(
+            CompletionType.BASIC,
+            psiElement(XmlTokenType.XML_ATTRIBUTE_VALUE_TOKEN)
+                .inside(
+                    XmlPatterns.xmlAttribute().withName(MftfActionGroup.URL_ATTRIBUTE)
+                    .withParent(XmlPatterns.xmlTag().withParent(
+                        XmlPatterns.xmlTag().withParent(XmlPatterns.xmlTag().withName(
+                    string().oneOf(MftfActionGroup.ROOT_TAG, MftfTest.ROOT_TAG)
+                ))))
+            ),
+            new PageCompletionProvider()
+        );
+
         // mftf data entity completion contributor
         extend(
             CompletionType.BASIC,
             psiElement(XmlTokenType.XML_ATTRIBUTE_VALUE_TOKEN)
-                .inside(XmlPatterns.xmlAttribute().withName(string().oneOf("entity", "value", "userInput", "url"))
+                .inside(XmlPatterns.xmlAttribute().withName(string().oneOf("entity", "value", "userInput"))
             ),
             new DataCompletionProvider()
         );

--- a/src/com/magento/idea/magento2plugin/magento/files/MftfActionGroup.java
+++ b/src/com/magento/idea/magento2plugin/magento/files/MftfActionGroup.java
@@ -11,4 +11,6 @@ public class MftfActionGroup {
     public static String CREATE_DATA_TAG = "createData";
     public static String UPDATE_DATA_TAG = "updateData";
     public static String USER_INPUT_TAG = "userInput";
+    public static String ROOT_TAG = "actionGroup";
+    public static String URL_ATTRIBUTE = "url";
 }

--- a/src/com/magento/idea/magento2plugin/magento/files/MftfPage.java
+++ b/src/com/magento/idea/magento2plugin/magento/files/MftfPage.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+package com.magento.idea.magento2plugin.magento.files;
+
+public class MftfPage {
+
+    public static String ROOT_TAG = "pages";
+    public static String PAGE_TAG = "page";
+    public static String NAME_ATTRIBUTE = "name";
+    public static String REFERENCE_SEPARATOR = ".";
+}

--- a/src/com/magento/idea/magento2plugin/magento/files/MftfPage.java
+++ b/src/com/magento/idea/magento2plugin/magento/files/MftfPage.java
@@ -10,4 +10,5 @@ public class MftfPage {
     public static String PAGE_TAG = "page";
     public static String NAME_ATTRIBUTE = "name";
     public static String REFERENCE_SEPARATOR = ".";
+    public static String URL_ATTRIBUTE = "url";
 }

--- a/src/com/magento/idea/magento2plugin/magento/files/MftfTest.java
+++ b/src/com/magento/idea/magento2plugin/magento/files/MftfTest.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+package com.magento.idea.magento2plugin.magento.files;
+
+public class MftfTest {
+
+    public static String ROOT_TAG = "test";
+}

--- a/src/com/magento/idea/magento2plugin/reference/xml/XmlReferenceContributor.java
+++ b/src/com/magento/idea/magento2plugin/reference/xml/XmlReferenceContributor.java
@@ -9,9 +9,11 @@ import com.intellij.psi.PsiReferenceContributor;
 import com.intellij.psi.PsiReferenceRegistrar;
 import com.intellij.psi.xml.XmlTokenType;
 import com.magento.idea.magento2plugin.magento.files.MftfActionGroup;
+import com.magento.idea.magento2plugin.magento.files.MftfTest;
 import com.magento.idea.magento2plugin.php.util.PhpRegex;
 import com.magento.idea.magento2plugin.reference.provider.*;
 import com.magento.idea.magento2plugin.reference.provider.mftf.*;
+import com.magento.idea.magento2plugin.util.Regex;
 import org.jetbrains.annotations.NotNull;
 
 import static com.intellij.patterns.XmlPatterns.*;
@@ -161,12 +163,40 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
         // <someXmlTag userInput="{{someValue}}" />
         registrar.registerReferenceProvider(
             XmlPatterns.xmlAttributeValue().withValue(
-                    string().matches(".*\\{\\{[^\\}]+\\}\\}.*")
+                string().matches(Regex.MFTF_CURLY_BRACES)
             ).withParent(XmlPatterns.xmlAttribute().withName(
-                    MftfActionGroup.USER_INPUT_TAG
+                MftfActionGroup.USER_INPUT_TAG
             )),
             new CompositeReferenceProvider(
                 new DataReferenceProvider()
+            )
+        );
+
+        // <someXmlTag url="{{someValue}}" /> in MFTF Tests and ActionGroups
+        registrar.registerReferenceProvider(
+            XmlPatterns.xmlAttributeValue().withValue(
+                string().matches(Regex.MFTF_CURLY_BRACES)
+            ).withParent(XmlPatterns.xmlAttribute().withName(
+                MftfActionGroup.URL_ATTRIBUTE
+            ).withParent(XmlPatterns.xmlTag().withParent(XmlPatterns.xmlTag().withName(
+                string().oneOf(MftfActionGroup.ROOT_TAG, MftfTest.ROOT_TAG)
+            )))),
+            new CompositeReferenceProvider(
+                new PageReferenceProvider()
+            )
+        );
+        registrar.registerReferenceProvider(
+            XmlPatterns.xmlAttributeValue().withValue(
+                string().matches(Regex.MFTF_CURLY_BRACES)
+            ).withParent(XmlPatterns.xmlAttribute().withName(
+                MftfActionGroup.URL_ATTRIBUTE
+            ).withParent(XmlPatterns.xmlTag().withParent(XmlPatterns.xmlTag().withParent(
+                XmlPatterns.xmlTag().withName(
+                    string().oneOf(MftfActionGroup.ROOT_TAG, MftfTest.ROOT_TAG)
+                )
+            )))),
+            new CompositeReferenceProvider(
+                    new PageReferenceProvider()
             )
         );
 

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/mftf/PageIndex.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/mftf/PageIndex.java
@@ -1,9 +1,14 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 package com.magento.idea.magento2plugin.stubs.indexes.mftf;
 
 import com.intellij.ide.highlighter.XmlFileType;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.psi.xml.XmlAttribute;
 import com.intellij.psi.xml.XmlDocument;
 import com.intellij.psi.xml.XmlFile;
 import com.intellij.psi.xml.XmlTag;
@@ -11,6 +16,7 @@ import com.intellij.util.indexing.*;
 import com.intellij.util.io.DataExternalizer;
 import com.intellij.util.io.EnumeratorStringDescriptor;
 import com.intellij.util.io.KeyDescriptor;
+import com.magento.idea.magento2plugin.magento.files.MftfPage;
 import com.magento.idea.magento2plugin.project.Settings;
 import gnu.trove.THashMap;
 import org.jetbrains.annotations.NotNull;
@@ -48,7 +54,7 @@ public class PageIndex extends FileBasedIndexExtension<String, String> {
 
             XmlTag xmlRootTag = xmlDocument.getRootTag();
 
-            if (xmlRootTag == null || !xmlRootTag.getName().equals("pages")) {
+            if (xmlRootTag == null || !xmlRootTag.getName().equals(MftfPage.ROOT_TAG)) {
                 return map;
             }
 
@@ -58,14 +64,19 @@ public class PageIndex extends FileBasedIndexExtension<String, String> {
                 return map;
             }
 
-            for (XmlTag pageTag : xmlRootTag.findSubTags("page")) {
-                String name = pageTag.getAttributeValue("name");
+            for (XmlTag pageTag : xmlRootTag.findSubTags(MftfPage.PAGE_TAG)) {
+                String name = pageTag.getAttributeValue(MftfPage.NAME_ATTRIBUTE);
 
                 if (name == null || name.isEmpty()) {
                     continue;
                 }
 
                 map.put(name, name);
+                XmlAttribute[] attributes = pageTag.getAttributes();
+                for (XmlAttribute attribute: attributes) {
+                    String childAttributeName = attribute.getName();
+                    map.put(name + MftfPage.REFERENCE_SEPARATOR + childAttributeName, name);
+                }
             }
 
             return map;

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/mftf/PageIndex.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/mftf/PageIndex.java
@@ -72,11 +72,6 @@ public class PageIndex extends FileBasedIndexExtension<String, String> {
                 }
 
                 map.put(name, name);
-                XmlAttribute[] attributes = pageTag.getAttributes();
-                for (XmlAttribute attribute: attributes) {
-                    String childAttributeName = attribute.getName();
-                    map.put(name + MftfPage.REFERENCE_SEPARATOR + childAttributeName, name);
-                }
             }
 
             return map;

--- a/src/com/magento/idea/magento2plugin/util/Regex.java
+++ b/src/com/magento/idea/magento2plugin/util/Regex.java
@@ -17,4 +17,7 @@ public class Regex {
 
     public static final String DIRECTORY
             = "^(?!\\/)[a-zA-Z0-9\\/]*[^\\/]$";
+
+    public static final String MFTF_CURLY_BRACES
+            = ".*\\{\\{[^\\}]+\\}\\}.*";
 }

--- a/testData/completion/xml/MftfPageUrlCompletionRegistrar/pageUrlBeforeInTestMustProvideCompletion/TestMftfTest.xml
+++ b/testData/completion/xml/MftfPageUrlCompletionRegistrar/pageUrlBeforeInTestMustProvideCompletion/TestMftfTest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="TestAddOutOfStockProductToCompareListTest">
+        <before>
+            <amOnPage url="{{Test<caret>}}" stepKey="goToProductPage"/>
+        </before>
+    </test>
+</tests>

--- a/testData/completion/xml/MftfPageUrlCompletionRegistrar/pageUrlInActionGroupMustBeEmptyForEntity/TestActionGroup.xml
+++ b/testData/completion/xml/MftfPageUrlCompletionRegistrar/pageUrlInActionGroupMustBeEmptyForEntity/TestActionGroup.xml
@@ -8,6 +8,6 @@
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
     <actionGroup name="Test">
-        <amOnPage url="{{TestPage2.url<caret>}}" stepKey="goToProductPage"/>
+        <amOnPage url="{{AttributeSet<caret>}}" stepKey="goToProductPage"/>
     </actionGroup>
 </actionGroups>

--- a/testData/completion/xml/MftfPageUrlCompletionRegistrar/pageUrlInActionGroupMustBeEmptyForSection/TestActionGroup.xml
+++ b/testData/completion/xml/MftfPageUrlCompletionRegistrar/pageUrlInActionGroupMustBeEmptyForSection/TestActionGroup.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="Test">
+        <amOnPage url="{{Section<caret>}}" stepKey="goToProductPage"/>
+    </actionGroup>
+</actionGroups>

--- a/testData/completion/xml/MftfPageUrlCompletionRegistrar/pageUrlInActionGroupMustBeEmptyForTestDocument/TestActionGroup.xml
+++ b/testData/completion/xml/MftfPageUrlCompletionRegistrar/pageUrlInActionGroupMustBeEmptyForTestDocument/TestActionGroup.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="Test">
+        <amOnPage url="{{TestVerify<caret>}}" stepKey="goToProductPage"/>
+    </actionGroup>
+</actionGroups>

--- a/testData/completion/xml/MftfPageUrlCompletionRegistrar/pageUrlInActionGroupMustProvideCompletion/TestActionGroup.xml
+++ b/testData/completion/xml/MftfPageUrlCompletionRegistrar/pageUrlInActionGroupMustProvideCompletion/TestActionGroup.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="Test">
+        <amOnPage url="{{Test<caret>}}" stepKey="goToProductPage"/>
+    </actionGroup>
+</actionGroups>

--- a/testData/completion/xml/MftfPageUrlCompletionRegistrar/pageUrlInTestMustBeEmptyForActionGroup/TestMftfTest.xml
+++ b/testData/completion/xml/MftfPageUrlCompletionRegistrar/pageUrlInTestMustBeEmptyForActionGroup/TestMftfTest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="TestAddOutOfStockProductToCompareListTest">
+        <amOnPage url="{{ActionGroup<caret>}}" stepKey="goToProductPage"/>
+    </test>
+</tests>

--- a/testData/completion/xml/MftfPageUrlCompletionRegistrar/pageUrlInTestMustBeEmptyForSection/TestMftfTest.xml
+++ b/testData/completion/xml/MftfPageUrlCompletionRegistrar/pageUrlInTestMustBeEmptyForSection/TestMftfTest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="TestAddOutOfStockProductToCompareListTest">
+        <amOnPage url="{{Section<caret>}}" stepKey="goToProductPage"/>
+    </test>
+</tests>

--- a/testData/completion/xml/MftfPageUrlCompletionRegistrar/pageUrlInTestMustProvideCompletion/TestMftfTest.xml
+++ b/testData/completion/xml/MftfPageUrlCompletionRegistrar/pageUrlInTestMustProvideCompletion/TestMftfTest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="TestAddOutOfStockProductToCompareListTest">
+        <amOnPage url="{{Test<caret>}}" stepKey="goToProductPage"/>
+    </test>
+</tests>

--- a/testData/project/magento2/vendor/magento/module-catalog/Test/Mftf/Page/TestPage.xml
+++ b/testData/project/magento2/vendor/magento/module-catalog/Test/Mftf/Page/TestPage.xml
@@ -8,7 +8,7 @@
 
 <pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/PageObject.xsd">
-    <page name="TestAdminCategoryEditPage" url="catalog/category/edit/id/{{categoryId}}/" area="admin" module="Catalog" parameterized="true">
+    <page name="TestPage" url="test/catalog/category/edit/id/{{categoryId}}/" area="admin" module="Catalog" parameterized="true">
         <section name="TestAdminCategorySidebarActionSection"/>
         <section name="TestAdminCategoryMainActionsSection"/>
         <section name="TestAdminCategorySidebarTreeSection"/>

--- a/testData/project/magento2/vendor/magento/module-catalog/Test/Mftf/Page/TestPage2.xml
+++ b/testData/project/magento2/vendor/magento/module-catalog/Test/Mftf/Page/TestPage2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/PageObject.xsd">
+    <page name="TestPage2" urlKey="test/catalog/category/edit">
+        <section name="TestAdminCategorySidebarActionSection"/>
+    </page>
+</pages>

--- a/testData/project/magento2/vendor/magento/module-catalog/Test/Mftf/Page/TestPage2.xml
+++ b/testData/project/magento2/vendor/magento/module-catalog/Test/Mftf/Page/TestPage2.xml
@@ -8,7 +8,7 @@
 
 <pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/PageObject.xsd">
-    <page name="TestPage2" urlKey="test/catalog/category/edit">
+    <page name="TestPage2" url="test/catalog/category/edit">
         <section name="TestAdminCategorySidebarActionSection"/>
     </page>
 </pages>

--- a/testData/project/magento2/vendor/magento/module-catalog/Test/Mftf/Section/TestAdminAddProductsSection.xml
+++ b/testData/project/magento2/vendor/magento/module-catalog/Test/Mftf/Section/TestAdminAddProductsSection.xml
@@ -8,7 +8,7 @@
 
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
-    <section name="TestAdminProducts">
+    <section name="TestAdminProductsSection">
         <element name="testaddSelectedProducts" type="button" selector=".product_form_product_form_bundle-items_modal button.action-primary" timeout="30"/>
         <element name="testfilters" type="button" selector=".product_form_product_form_bundle-items_modal button[data-action='grid-filter-expand']" timeout="30"/>
         <element name="testapplyFilters" type="button" selector=".product_form_product_form_bundle-items_modal [data-action='grid-filter-apply']" timeout="30"/>

--- a/testData/project/magento2/vendor/magento/module-catalog/Test/Mftf/Section/TestAdminAddProductsToOptionPanelSection.xml
+++ b/testData/project/magento2/vendor/magento/module-catalog/Test/Mftf/Section/TestAdminAddProductsToOptionPanelSection.xml
@@ -8,7 +8,7 @@
 
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
-    <section name="TestAdminAddProductsToOptionPanel">
+    <section name="TestAdminAddProductsToOptionPanelSection">
         <element name="testaddSelectedProducts" type="button" selector=".product_form_product_form_bundle-items_modal button.action-primary" timeout="30"/>
         <element name="testfilters" type="button" selector=".product_form_product_form_bundle-items_modal button[data-action='grid-filter-expand']" timeout="30"/>
         <element name="testapplyFilters" type="button" selector=".product_form_product_form_bundle-items_modal [data-action='grid-filter-apply']" timeout="30"/>

--- a/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlBeforeInTestMustHaveReference/TestMftfTest.xml
+++ b/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlBeforeInTestMustHaveReference/TestMftfTest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="TestAddOutOfStockProductToCompareListTest">
+        <before>
+            <seeInCurrentUrl url="{{TestPage.url<caret>}}" stepKey="goToProductPage"/>
+        </before>
+    </test>
+</tests>

--- a/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlInActionGroupMustBeEmptyForSection/TestActionGroup.xml
+++ b/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlInActionGroupMustBeEmptyForSection/TestActionGroup.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="Test">
+        <amOnPage url="{{TestAdminProductsSection<caret>}}" stepKey="goToProductPage"/>
+    </actionGroup>
+</actionGroups>

--- a/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlInActionGroupMustBeEmptyForTestDocument/TestActionGroup.xml
+++ b/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlInActionGroupMustBeEmptyForTestDocument/TestActionGroup.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="Test">
+        <amOnPage url="{{TestVerifyTinyMCEv4IsNativeWYSIWYGOnProductTest<caret>}}" stepKey="goToProductPage"/>
+    </actionGroup>
+</actionGroups>

--- a/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlInActionGroupMustHaveReference/TestActionGroup.xml
+++ b/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlInActionGroupMustHaveReference/TestActionGroup.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="Test">
+        <amOnPage url="{{TestPage2.urlKey<caret>}}" stepKey="goToProductPage"/>
+    </actionGroup>
+</actionGroups>

--- a/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlInActionGroupPluginDisabled/TestActionGroup.xml
+++ b/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlInActionGroupPluginDisabled/TestActionGroup.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="Test">
+        <amOnPage url="{{TestPage2.urlKey<caret>}}" stepKey="goToProductPage"/>
+    </actionGroup>
+</actionGroups>

--- a/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlInActionGroupPluginDisabled/TestActionGroup.xml
+++ b/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlInActionGroupPluginDisabled/TestActionGroup.xml
@@ -8,6 +8,6 @@
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
     <actionGroup name="Test">
-        <amOnPage url="{{TestPage2.urlKey<caret>}}" stepKey="goToProductPage"/>
+        <amOnPage url="{{TestPage2.url<caret>}}" stepKey="goToProductPage"/>
     </actionGroup>
 </actionGroups>

--- a/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlInTestMftfSupportDisabled/TestMftfTest.xml
+++ b/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlInTestMftfSupportDisabled/TestMftfTest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="TestAddOutOfStockProductToCompareListTest">
+        <seeInCurrentUrl url="{{TestPage.url<caret>}}" stepKey="goToProductPage"/>
+    </test>
+</tests>

--- a/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlInTestMustBeEmptyForActionGroup/TestMftfTest.xml
+++ b/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlInTestMustBeEmptyForActionGroup/TestMftfTest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="TestAddOutOfStockProductToCompareListTest">
+        <amOnPage url="{{TestAdminAssignImageRolesActionGroup<caret>}}" stepKey="goToProductPage"/>
+    </test>
+</tests>

--- a/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlInTestMustBeEmptyForSection/TestMftfTest.xml
+++ b/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlInTestMustBeEmptyForSection/TestMftfTest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="TestAddOutOfStockProductToCompareListTest">
+        <amOnPage url="{{TestAdminProductsSection<caret>}}" stepKey="goToProductPage"/>
+    </test>
+</tests>

--- a/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlInTestMustHaveReference/TestMftfTest.xml
+++ b/testData/reference/xml/MftfPageUrlReferenceRegistrar/pageUrlInTestMustHaveReference/TestMftfTest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="TestAddOutOfStockProductToCompareListTest">
+        <seeInCurrentUrl url="{{TestPage.url<caret>}}" stepKey="goToProductPage"/>
+    </test>
+</tests>

--- a/tests/com/magento/idea/magento2plugin/completion/xml/MftfPageUrlCompletionRegistrarTest.java
+++ b/tests/com/magento/idea/magento2plugin/completion/xml/MftfPageUrlCompletionRegistrarTest.java
@@ -7,10 +7,8 @@ package com.magento.idea.magento2plugin.completion.xml;
 public class MftfPageUrlCompletionRegistrarTest extends CompletionXmlFixtureTestCase {
 
     private static final String[] lookupStrings = new String[] {
-        "TestPage",
         "TestPage.url",
-        "TestPage2",
-        "TestPage2.urlKey",
+        "TestPage2.url"
       };
 
     public void testPageUrlInActionGroupMustProvideCompletion() {
@@ -27,6 +25,13 @@ public class MftfPageUrlCompletionRegistrarTest extends CompletionXmlFixtureTest
     }
 
     public void testPageUrlInActionGroupMustBeEmptyForTestDocument() {
+        String filePath = this.getFixturePath("TestActionGroup.xml");
+        myFixture.copyFileToProject(filePath);
+
+        assertCompletionNotShowing(filePath);
+    }
+
+    public void testPageUrlInActionGroupMustBeEmptyForEntity() {
         String filePath = this.getFixturePath("TestActionGroup.xml");
         myFixture.copyFileToProject(filePath);
 

--- a/tests/com/magento/idea/magento2plugin/completion/xml/MftfPageUrlCompletionRegistrarTest.java
+++ b/tests/com/magento/idea/magento2plugin/completion/xml/MftfPageUrlCompletionRegistrarTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+package com.magento.idea.magento2plugin.completion.xml;
+
+public class MftfPageUrlCompletionRegistrarTest extends CompletionXmlFixtureTestCase {
+
+    private static final String[] lookupStrings = new String[] {
+        "TestPage",
+        "TestPage.url",
+        "TestPage2",
+        "TestPage2.urlKey",
+      };
+
+    public void testPageUrlInActionGroupMustProvideCompletion() {
+        String filePath = this.getFixturePath("TestActionGroup.xml");
+        myFixture.copyFileToProject(filePath);
+
+        assertFileContainsCompletions(filePath, lookupStrings);
+    }
+    public void testPageUrlInActionGroupMustBeEmptyForSection() {
+        String filePath = this.getFixturePath("TestActionGroup.xml");
+        myFixture.copyFileToProject(filePath);
+
+        assertCompletionNotShowing(filePath);
+    }
+
+    public void testPageUrlInActionGroupMustBeEmptyForTestDocument() {
+        String filePath = this.getFixturePath("TestActionGroup.xml");
+        myFixture.copyFileToProject(filePath);
+
+        assertCompletionNotShowing(filePath);
+    }
+
+    public void testPageUrlInTestMustProvideCompletion() {
+        String filePath = this.getFixturePath("TestMftfTest.xml");
+        myFixture.copyFileToProject(filePath);
+
+        assertFileContainsCompletions(filePath, lookupStrings);
+    }
+
+    public void testPageUrlBeforeInTestMustProvideCompletion() {
+        String filePath = this.getFixturePath("TestMftfTest.xml");
+        myFixture.copyFileToProject(filePath);
+
+        assertFileContainsCompletions(filePath, lookupStrings);
+    }
+
+    public void testPageUrlInTestMustBeEmptyForSection() {
+        String filePath = this.getFixturePath("TestMftfTest.xml");
+        myFixture.copyFileToProject(filePath);
+
+        assertCompletionNotShowing(filePath);
+    }
+
+    public void testPageUrlInTestMustBeEmptyForActionGroup() {
+        String filePath = this.getFixturePath("TestMftfTest.xml");
+        myFixture.copyFileToProject(filePath);
+
+        assertCompletionNotShowing(filePath);
+    }
+}

--- a/tests/com/magento/idea/magento2plugin/reference/xml/MftfPageUrlReferenceRegistrarTest.java
+++ b/tests/com/magento/idea/magento2plugin/reference/xml/MftfPageUrlReferenceRegistrarTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+package com.magento.idea.magento2plugin.reference.xml;
+
+public class MftfPageUrlReferenceRegistrarTest extends ReferenceXmlFixtureTestCase {
+
+    public void testPageUrlInActionGroupMustHaveReference() {
+        String filePath = this.getFixturePath("TestActionGroup.xml");
+        myFixture.configureByFile(filePath);
+
+        assertHasReferenceToXmlAttributeValue("TestPage2");
+    }
+
+    public void testPageUrlInActionGroupMustBeEmptyForSection() {
+        String filePath = this.getFixturePath("TestActionGroup.xml");
+        myFixture.configureByFile(filePath);
+
+        assertEmptyReference();
+    }
+
+    public void testPageUrlInActionGroupMustBeEmptyForTestDocument() {
+        String filePath = this.getFixturePath("TestActionGroup.xml");
+        myFixture.configureByFile(filePath);
+
+        assertEmptyReference();
+    }
+
+    public void testPageUrlInTestMustHaveReference() {
+        String filePath = this.getFixturePath("TestMftfTest.xml");
+        myFixture.configureByFile(filePath);
+
+        assertHasReferenceToXmlAttributeValue("TestPage");
+    }
+
+    public void testPageUrlBeforeInTestMustHaveReference() {
+        String filePath = this.getFixturePath("TestMftfTest.xml");
+        myFixture.configureByFile(filePath);
+
+        assertHasReferenceToXmlAttributeValue("TestPage");
+    }
+
+    public void testPageUrlInTestMustBeEmptyForSection() {
+        String filePath = this.getFixturePath("TestMftfTest.xml");
+        myFixture.configureByFile(filePath);
+
+        assertEmptyReference();
+    }
+
+    public void testPageUrlInTestMustBeEmptyForActionGroup() {
+        String filePath = this.getFixturePath("TestMftfTest.xml");
+        myFixture.configureByFile(filePath);
+
+        assertEmptyReference();
+    }
+
+    public void testPageUrlInActionGroupPluginDisabled() {
+        String filePath = this.getFixturePath("TestActionGroup.xml");
+        myFixture.configureByFile(filePath);
+        disablePluginAndReindex();
+
+        assertEmptyReference();
+    }
+
+    public void testPageUrlInTestMftfSupportDisabled() {
+        String filePath = this.getFixturePath("TestMftfTest.xml");
+        myFixture.configureByFile(filePath);
+        disableMftfSupportAndReindex();
+
+        assertEmptyReference();
+    }
+}


### PR DESCRIPTION
FIxed MFTF Page reference and completion, added test coverage.

### Fixed Issues (if relevant)
1. magento/magento2-phpstorm-plugin#105: MFTF: Page (URL) reference and autocomplete

### Page URL in test
![image](https://user-images.githubusercontent.com/20116393/79147457-a0a21a80-7dcc-11ea-94c1-9974ff83b582.png)

### Page URL in action group
![image](https://user-images.githubusercontent.com/20116393/79147500-b3b4ea80-7dcc-11ea-8f34-843e2f6d265a.png)
