### PR TITLE
Wrong dependency declared in composer JSON when creating a module

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModuleDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModuleDialog.java
@@ -21,17 +21,21 @@ import com.magento.idea.magento2plugin.actions.generation.generator.util.Directo
 import com.magento.idea.magento2plugin.actions.generation.generator.util.FileFromTemplateGenerator;
 import com.magento.idea.magento2plugin.actions.generation.util.NavigateToCreatedFile;
 import com.magento.idea.magento2plugin.indexes.ModuleIndex;
+import com.magento.idea.magento2plugin.magento.files.ComposerJson;
 import com.magento.idea.magento2plugin.magento.packages.Package;
 import com.magento.idea.magento2plugin.project.Settings;
 import com.magento.idea.magento2plugin.util.CamelCaseToHyphen;
+import org.apache.commons.lang.ArrayUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import java.awt.event.*;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
+import java.util.stream.IntStream;
 
 public class NewModuleDialog extends AbstractDialog implements ListSelectionListener {
     @NotNull
@@ -254,7 +258,8 @@ public class NewModuleDialog extends AbstractDialog implements ListSelectionList
 
     private void setModuleDependencies() {
         List<String> moduleNames = moduleIndex.getModuleNames();
-        Vector<String> licenseNames = new Vector<>(moduleNames.size());
+        Vector<String> licenseNames = new Vector<>(moduleNames.size() + 1);
+        licenseNames.add(ComposerJson.NO_DEPENDENCY_LABEL);
         for (String name : moduleNames) {
             licenseNames.add(name);
         }
@@ -263,7 +268,7 @@ public class NewModuleDialog extends AbstractDialog implements ListSelectionList
         moduleDependencies.addListSelectionListener(this);
     }
 
-    private void handleModuleCustomLicenseInputVisibility () {
+    private void handleModuleCustomLicenseInputVisibility() {
         boolean isCustomLicenseSelected = false;
 
         for (Object value: moduleLicense.getSelectedValuesList()) {
@@ -278,8 +283,18 @@ public class NewModuleDialog extends AbstractDialog implements ListSelectionList
         moduleLicenseCustom.setEditable(isCustomLicenseSelected);
     }
 
+    private void handleModuleSelectedDependencies() {
+        // unselect the "None" dependency when others are selected
+        int[] selectedDependencies = moduleDependencies.getSelectedIndices();
+        if (moduleDependencies.getSelectedIndices().length > 1 && moduleDependencies.isSelectedIndex(0)) {
+            selectedDependencies = ArrayUtils.remove(selectedDependencies, 0);
+            moduleDependencies.setSelectedIndices(selectedDependencies);
+        }
+    }
+
     @Override
     public void valueChanged(ListSelectionEvent listSelectionEvent) {
         handleModuleCustomLicenseInputVisibility();
+        handleModuleSelectedDependencies();
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleComposerJsonGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleComposerJsonGenerator.java
@@ -96,11 +96,11 @@ public class ModuleComposerJsonGenerator extends FileGenerator {
 
         for (int i = 0; i < dependencies.length; i++) {
             String dependency = dependencies[i].toString();
-            Pair<String, String> dependecyData = getDependencyData(dependency);
+            Pair<String, String> dependencyData = getDependencyData(dependency);
             result = result.concat("\"");
-            result = result.concat(dependecyData.getFirst());
+            result = result.concat(dependencyData.getFirst());
             result = result.concat("\"");
-            result = result.concat(": \"" + dependecyData.getSecond() + "\"");
+            result = result.concat(": \"" + dependencyData.getSecond() + "\"");
 
             if (dependencies.length != (i + 1)) {
                 result = result.concat(",");

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleComposerJsonGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleComposerJsonGenerator.java
@@ -16,6 +16,7 @@ import com.magento.idea.magento2plugin.actions.generation.generator.util.FileFro
 import com.magento.idea.magento2plugin.indexes.ModuleIndex;
 import com.magento.idea.magento2plugin.magento.files.ComposerJson;
 import com.magento.idea.magento2plugin.util.CamelCaseToHyphen;
+import com.intellij.openapi.util.Pair;
 import org.jetbrains.annotations.NotNull;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
@@ -82,20 +83,24 @@ public class ModuleComposerJsonGenerator extends FileGenerator {
         String result = "";
         Object[] dependencies = dependenciesList.toArray();
         result = result.concat(ComposerJson.DEFAULT_DEPENDENCY);
-        if (dependencies.length == 0) {
+        boolean noDependency = dependencies.length == 1 && dependencies[0].equals(ComposerJson.NO_DEPENDENCY_LABEL);
+        if (dependencies.length == 0 || noDependency) {
             result = result.concat("\n");
         } else {
             result = result.concat(",\n");
         }
 
+        if (noDependency) {
+            return result;
+        }
+
         for (int i = 0; i < dependencies.length; i++) {
             String dependency = dependencies[i].toString();
+            Pair<String, String> dependecyData = getDependencyData(dependency);
             result = result.concat("\"");
-            result = result.concat(
-                    camelCaseToHyphen.convert(dependency).replace("_-", "/")
-            );
+            result = result.concat(dependecyData.getFirst());
             result = result.concat("\"");
-            result = result.concat(": \"" + getDependencyVersion(dependency) + "\"");
+            result = result.concat(": \"" + dependecyData.getSecond() + "\"");
 
             if (dependencies.length != (i + 1)) {
                 result = result.concat(",");
@@ -107,8 +112,9 @@ public class ModuleComposerJsonGenerator extends FileGenerator {
         return result;
     }
 
-    private String getDependencyVersion(String dependency) {
+    private Pair<String, String> getDependencyData(String dependency) {
         String version = "*";
+        String moduleName = camelCaseToHyphen.convert(dependency).replace("_-", "/");
         try {
             VirtualFile virtualFile = moduleIndex.getModuleDirectoryByModuleName(dependency)
                     .findFile(ComposerJson.FILE_NAME)
@@ -116,6 +122,7 @@ public class ModuleComposerJsonGenerator extends FileGenerator {
             if (virtualFile.exists()) {
                 JsonElement jsonElement = new JsonParser().parse(new FileReader(virtualFile.getPath()));
                 JsonElement versionJsonElement = jsonElement.getAsJsonObject().get("version");
+                JsonElement nameJsonElement = jsonElement.getAsJsonObject().get("name");
                 if (versionJsonElement != null) {
                     version = versionJsonElement.getAsString();
                     int minorVersionSeparator = version.lastIndexOf(".");
@@ -123,10 +130,14 @@ public class ModuleComposerJsonGenerator extends FileGenerator {
                             .replace(minorVersionSeparator + 1, version.length(),"*")
                             .toString();
                 }
+                if (nameJsonElement != null) {
+                    moduleName = nameJsonElement.getAsString();
+                }
             }
         } catch (FileNotFoundException e) {
             // It's fine
         }
-        return version;
+
+        return Pair.create(moduleName, version);
     }
 }

--- a/src/com/magento/idea/magento2plugin/magento/files/ComposerJson.java
+++ b/src/com/magento/idea/magento2plugin/magento/files/ComposerJson.java
@@ -11,6 +11,7 @@ public class ComposerJson implements ModuleFileInterface {
     public static String FILE_NAME = "composer.json";
     public static String TEMPLATE = "Magento Module Composer";
     public static String DEFAULT_DEPENDENCY = "\"magento/framework\": \"*\"";
+    public static String NO_DEPENDENCY_LABEL = "None";
     private static ComposerJson INSTANCE = null;
 
     public static ComposerJson getInstance() {


### PR DESCRIPTION
### Description (*)

- Added option to select no dependencies;
- Corrected the dependency module name in the composer.json file

#### dependency plugin name

```json
{
  "name": "vendor/module",
  "version": "1.0.0",
  "description": "N/A",
  "type": "magento2-module",
  "require": {
    "magento/framework": "*",
    "magento/module-catalog-rule-configurable": "100.3.*",
    "module/plugin-testing-module": "1.0.*",
    "module/second-plugin-testing-module": "1.0.*"
  },
  "license": [
    ""
  ],
  "autoload": {
    "files": [
      "registration.php"
    ],
    "psr-4": {
      "Vendor\\Module\\": ""
    }
  }
}
```

#### no dependency for new module
![image](https://user-images.githubusercontent.com/13456702/79423103-ad8a5e00-7fc6-11ea-94fe-3b426a440370.png)


### Fixed Issues (if relevant)
1. magento/magento2-phpstorm-plugin#151: Wrong dependency declared in composer JSON when creating a module

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages

