### PR TITLE
Fixed performance issues on Plugin Line Market

### DIFF
--- a/src/com/magento/idea/magento2plugin/linemarker/php/PluginLineMarkerProvider.java
+++ b/src/com/magento/idea/magento2plugin/linemarker/php/PluginLineMarkerProvider.java
@@ -10,6 +10,7 @@ import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder;
 import com.intellij.icons.AllIcons;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.indexing.FileBasedIndex;
 import com.jetbrains.php.PhpIndex;
 import com.jetbrains.php.lang.psi.elements.Method;
@@ -55,7 +56,7 @@ public class PluginLineMarkerProvider implements LineMarkerProvider {
                             .create(AllIcons.Nodes.Plugin)
                             .setTargets(results)
                             .setTooltipText("Navigate to plugins")
-                            .createLineMarkerInfo(psiElement)
+                            .createLineMarkerInfo(PsiTreeUtil.getDeepestFirst(psiElement))
                     );
                 }
             }


### PR DESCRIPTION
### Description (*)
This PR fixes the performance issue with line markers.
The issue has been caused by Plugin Line markers.
![image](https://user-images.githubusercontent.com/20116393/79498507-1b1fa400-8032-11ea-9759-5fa183743854.png)


### Fixed Issues (if relevant)
1. magento/magento2-phpstorm-plugin#31: Line markers. Fix performance warnings

### For QA
Visit any target class. The console should not have the following errors:
![image](https://user-images.githubusercontent.com/20116393/79498955-db0cf100-8032-11ea-9851-24bb694fbe30.png)


