### PR TITLE
Fixed error on around plugin

### DIFF
--- a/src/com/magento/idea/magento2plugin/inspections/php/PluginInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/php/PluginInspection.java
@@ -20,6 +20,7 @@ import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor;
 import com.magento.idea.magento2plugin.inspections.php.util.PhpClassImplementsInterfaceUtil;
 import com.magento.idea.magento2plugin.magento.files.Plugin;
+import com.magento.idea.magento2plugin.magento.packages.Package;
 import com.magento.idea.magento2plugin.util.GetPhpClassByFQN;
 import com.magento.idea.magento2plugin.util.magento.plugin.GetTargetClassNamesByPluginClassName;
 import org.jetbrains.annotations.NotNull;
@@ -128,7 +129,7 @@ public class PluginInspection extends PhpInspection {
                     String declaredType = pluginMethodParameter.getDeclaredType().toString();
 
                     if (index == 1) {
-                        String targetClassFqn = "\\".concat(targetClassName);
+                        String targetClassFqn = Package.FQN_SEPARATOR.concat(targetClassName);
                         if (!checkTypeIncompatibility(targetClassFqn, declaredType, phpIndex)) {
                             problemsHolder.registerProblem(pluginMethodParameter, PhpBundle.message("inspection.wrong_param_type", new Object[]{declaredType, targetClassFqn}), ProblemHighlightType.ERROR);
                         }
@@ -138,7 +139,8 @@ public class PluginInspection extends PhpInspection {
                         continue;
                     }
                     if (index == 2 && pluginPrefix.equals(Plugin.PluginType.around.toString())) {
-                        if (!checkTypeIncompatibility("callable", declaredType, phpIndex)) {
+                        if (!checkTypeIncompatibility(Plugin.CALLABLE_PARAM, declaredType, phpIndex) &&
+                                !checkTypeIncompatibility(Package.FQN_SEPARATOR.concat(Plugin.CLOSURE_PARAM), declaredType, phpIndex)) {
                             problemsHolder.registerProblem(pluginMethodParameter, PhpBundle.message("inspection.wrong_param_type", new Object[]{declaredType, "callable"}), ProblemHighlightType.ERROR);
                         }
                         continue;

--- a/src/com/magento/idea/magento2plugin/magento/files/Plugin.java
+++ b/src/com/magento/idea/magento2plugin/magento/files/Plugin.java
@@ -12,6 +12,9 @@ public class Plugin implements ModuleFileInterface {
     private static final String AROUND_METHOD_TEMPLATE_NAME = "Magento Plugin Around Method";
     private static final String AFTER_METHOD_TEMPLATE_NAME = "Magento Plugin After Method";
 
+    public static final String CALLABLE_PARAM = "callable";
+    public static final String CLOSURE_PARAM = "Closure";
+
     public enum PluginType {
         before,
         after,


### PR DESCRIPTION
### Description (*)
This PR fixes the issue with \Closure in around plugin and Plugin inspection.

### Fixed Issues (if relevant)
1. magento/magento2-phpstorm-plugin#160: Plugin inspection. Closure recognized as a wrong parameter for around plugin

### \Closure ✅ 
![image](https://user-images.githubusercontent.com/20116393/79605340-6308fe80-80f8-11ea-9448-46b834b7c00f.png)

### callable ✅ 
![image](https://user-images.githubusercontent.com/20116393/79605428-93509d00-80f8-11ea-94d9-46470647aee2.png)

### wrong param ✅ 
![image](https://user-images.githubusercontent.com/20116393/79605412-892e9e80-80f8-11ea-9138-1eab2a6b515f.png)

### imported Closure ✅ 
![image](https://user-images.githubusercontent.com/20116393/79605446-9ba8d800-80f8-11ea-99ce-a6c5d3b119d9.png)


