### PR TITLE
Fixed MFTF selector reference contributor and completion, added tes coverage

### DIFF
--- a/src/com/magento/idea/magento2plugin/completion/xml/XmlCompletionContributor.java
+++ b/src/com/magento/idea/magento2plugin/completion/xml/XmlCompletionContributor.java
@@ -215,15 +215,6 @@ public class XmlCompletionContributor extends CompletionContributor {
             new RequireJsMappingCompletionProvider()
         );
 
-        // mftf selector completion contributor
-        extend(CompletionType.BASIC,
-            psiElement(XmlTokenType.XML_ATTRIBUTE_VALUE_TOKEN)
-            .inside(XmlPatterns.xmlAttribute()
-            .withName(MftfActionGroup.SELECTOR_ATTRIBUTE))
-            .inFile(xmlFile().withName(string().endsWith("Test.xml"))),
-            new SelectorCompletionProvider()
-        );
-
         // mftf action group completion contributor
         extend(
             CompletionType.BASIC,
@@ -231,35 +222,9 @@ public class XmlCompletionContributor extends CompletionContributor {
                 .inside(
                     XmlPatterns.xmlAttribute().withName(string().oneOf("ref", "extends"))
                         .withParent(XmlPatterns.xmlTag().withName("actionGroup")
-                )
-            ),
-            new ActionGroupCompletionProvider()
-        );
-
-        // mftf page url completion contributor
-        extend(
-            CompletionType.BASIC,
-            psiElement(XmlTokenType.XML_ATTRIBUTE_VALUE_TOKEN)
-                .inside(
-                    XmlPatterns.xmlAttribute().withName(MftfActionGroup.URL_ATTRIBUTE)
-                    .withParent(XmlPatterns.xmlTag().withParent(
-                            XmlPatterns.xmlTag().withName(
-                        string().oneOf(MftfActionGroup.ROOT_TAG, MftfTest.ROOT_TAG)
-                    )))
+                    )
                 ),
-            new PageCompletionProvider()
-        );
-        extend(
-            CompletionType.BASIC,
-            psiElement(XmlTokenType.XML_ATTRIBUTE_VALUE_TOKEN)
-                .inside(
-                    XmlPatterns.xmlAttribute().withName(MftfActionGroup.URL_ATTRIBUTE)
-                    .withParent(XmlPatterns.xmlTag().withParent(
-                        XmlPatterns.xmlTag().withParent(XmlPatterns.xmlTag().withName(
-                    string().oneOf(MftfActionGroup.ROOT_TAG, MftfTest.ROOT_TAG)
-                ))))
-            ),
-            new PageCompletionProvider()
+            new ActionGroupCompletionProvider()
         );
 
         // mftf data entity completion contributor
@@ -282,5 +247,44 @@ public class XmlCompletionContributor extends CompletionContributor {
             ),
             new DataCompletionProvider()
         );
+
+        registerCompletionsForDifferentNesting();
+    }
+
+    private void registerCompletionsForDifferentNesting() {
+        int i = 1;
+        int maxNesting = 10;
+        while( i < maxNesting) {
+
+            // mftf selector completion contributor
+            extend(CompletionType.BASIC,
+                psiElement(XmlTokenType.XML_ATTRIBUTE_VALUE_TOKEN)
+                    .inside(XmlPatterns.xmlAttribute()
+                        .withName(MftfActionGroup.SELECTOR_ATTRIBUTE).withSuperParent(
+                            i,
+                            XmlPatterns.xmlTag().withParent(
+                                XmlPatterns.xmlTag().withName(
+                                    string().oneOf(MftfActionGroup.ROOT_TAG, MftfTest.ROOT_TAG)
+                                )))
+                    ),
+                new SelectorCompletionProvider()
+            );
+
+            // mftf page url completion contributor
+            extend(
+                CompletionType.BASIC,
+                psiElement(XmlTokenType.XML_ATTRIBUTE_VALUE_TOKEN)
+                    .inside(
+                        XmlPatterns.xmlAttribute().withName(MftfActionGroup.URL_ATTRIBUTE)
+                            .withSuperParent(i ,XmlPatterns.xmlTag().withParent(
+                                XmlPatterns.xmlTag().withName(
+                                    string().oneOf(MftfActionGroup.ROOT_TAG, MftfTest.ROOT_TAG)
+                                )))
+                    ),
+                new PageCompletionProvider()
+            );
+
+            i++;
+        }
     }
 }

--- a/src/com/magento/idea/magento2plugin/reference/xml/XmlReferenceContributor.java
+++ b/src/com/magento/idea/magento2plugin/reference/xml/XmlReferenceContributor.java
@@ -170,34 +170,6 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
             )
         );
 
-        // <someXmlTag url="{{someValue}}" /> in MFTF Tests and ActionGroups
-        registrar.registerReferenceProvider(
-            XmlPatterns.xmlAttributeValue().withValue(
-                string().matches(RegExUtil.Magento.MFTF_CURLY_BRACES)
-            ).withParent(XmlPatterns.xmlAttribute().withName(
-                MftfActionGroup.URL_ATTRIBUTE
-            ).withParent(XmlPatterns.xmlTag().withParent(XmlPatterns.xmlTag().withName(
-                string().oneOf(MftfActionGroup.ROOT_TAG, MftfTest.ROOT_TAG)
-            )))),
-            new CompositeReferenceProvider(
-                new PageReferenceProvider()
-            )
-        );
-        registrar.registerReferenceProvider(
-            XmlPatterns.xmlAttributeValue().withValue(
-                string().matches(RegExUtil.Magento.MFTF_CURLY_BRACES)
-            ).withParent(XmlPatterns.xmlAttribute().withName(
-                MftfActionGroup.URL_ATTRIBUTE
-            ).withParent(XmlPatterns.xmlTag().withParent(XmlPatterns.xmlTag().withParent(
-                XmlPatterns.xmlTag().withName(
-                    string().oneOf(MftfActionGroup.ROOT_TAG, MftfTest.ROOT_TAG)
-                )
-            )))),
-            new CompositeReferenceProvider(
-                    new PageReferenceProvider()
-            )
-        );
-
         // <createData entity="SimpleProduct" />
         // <updateData entity="SimpleProduct" />
         registrar.registerReferenceProvider(
@@ -273,5 +245,44 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
                 ),
                 new RequireJsPreferenceReferenceProvider()
         );
+
+        registerReferenceForDifferentNesting(registrar);
+    }
+
+    private void registerReferenceForDifferentNesting(@NotNull PsiReferenceRegistrar registrar) {
+        int i = 1;
+        int maxNesting = 10;
+        while( i < maxNesting) {
+
+            // <someXmlTag url="{{someValue}}" /> in MFTF Tests and ActionGroups
+            registrar.registerReferenceProvider(
+                XmlPatterns.xmlAttributeValue().withValue(
+                    string().matches(RegExUtil.Magento.MFTF_CURLY_BRACES)
+                ).withParent(XmlPatterns.xmlAttribute().withName(
+                    MftfActionGroup.URL_ATTRIBUTE
+                ).withParent(XmlPatterns.xmlTag().withSuperParent(i, XmlPatterns.xmlTag().withName(
+                    string().oneOf(MftfActionGroup.ROOT_TAG, MftfTest.ROOT_TAG)
+                )))),
+                new CompositeReferenceProvider(
+                    new PageReferenceProvider()
+                )
+            );
+
+            // <someXmlTag selector="{{someValue}}" /> in MFTF Tests and ActionGroups
+            registrar.registerReferenceProvider(
+                XmlPatterns.xmlAttributeValue().withValue(
+                    string().matches(RegExUtil.Magento.MFTF_CURLY_BRACES)
+                ).withParent(XmlPatterns.xmlAttribute().withName(
+                    MftfActionGroup.SELECTOR_ATTRIBUTE
+                ).withParent(XmlPatterns.xmlTag().withSuperParent(i, XmlPatterns.xmlTag().withName(
+                    string().oneOf(MftfActionGroup.ROOT_TAG, MftfTest.ROOT_TAG)
+                )))),
+                new CompositeReferenceProvider(
+                    new SectionReferenceProvider()
+                )
+            );
+
+            i++;
+        }
     }
 }

--- a/testData/completion/xml/MftfSelectorCompletionRegistrar/selectorInActionGroupMustBeEmpty/TestActionGroup.xml
+++ b/testData/completion/xml/MftfSelectorCompletionRegistrar/selectorInActionGroupMustBeEmpty/TestActionGroup.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="Test">
+        <click selector="{{AttributeSet<caret>}}" stepKey="saveCategoryWithProducts1"/>
+    </actionGroup>
+</actionGroups>

--- a/testData/completion/xml/MftfSelectorCompletionRegistrar/selectorInActionGroupMustProvideCompletion/TestActionGroup.xml
+++ b/testData/completion/xml/MftfSelectorCompletionRegistrar/selectorInActionGroupMustProvideCompletion/TestActionGroup.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="Test">
+        <click selector="{{Section<caret>}}" stepKey="saveCategoryWithProducts1"/>
+    </actionGroup>
+</actionGroups>

--- a/testData/completion/xml/MftfSelectorCompletionRegistrar/selectorInTestMustBeEmpty/TestMftfTest.xml
+++ b/testData/completion/xml/MftfSelectorCompletionRegistrar/selectorInTestMustBeEmpty/TestMftfTest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="TestAddOutOfStockProductToCompareListTest">
+        <before>
+            <click selector="{{AttributeSet<caret>}}" stepKey="saveCategoryWithProducts1"/>
+        </before>
+    </test>
+</tests>

--- a/testData/completion/xml/MftfSelectorCompletionRegistrar/selectorInTestMustProvideCompletion/TestMftfTest.xml
+++ b/testData/completion/xml/MftfSelectorCompletionRegistrar/selectorInTestMustProvideCompletion/TestMftfTest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="TestAddOutOfStockProductToCompareListTest">
+        <before>
+            <click selector="{{Section<caret>}}" stepKey="saveCategoryWithProducts1"/>
+        </before>
+    </test>
+</tests>

--- a/testData/reference/xml/MftfSelectorReferenceRegistrar/selectorInActionGroupMustBeEmpty/TestActionGroup.xml
+++ b/testData/reference/xml/MftfSelectorReferenceRegistrar/selectorInActionGroupMustBeEmpty/TestActionGroup.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="Test">
+        <click selector="{{TestAdminMenuCatalog<caret>}}" stepKey="saveCategoryWithProducts1"/>
+    </actionGroup>
+</actionGroups>

--- a/testData/reference/xml/MftfSelectorReferenceRegistrar/selectorInActionGroupMustHaveReference/TestActionGroup.xml
+++ b/testData/reference/xml/MftfSelectorReferenceRegistrar/selectorInActionGroupMustHaveReference/TestActionGroup.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="Test">
+        <click selector="{{TestAdminAddProductsToOptionPanelSection.testaddSelectedProducts<caret>}}" stepKey="saveCategoryWithProducts1"/>
+    </actionGroup>
+</actionGroups>

--- a/testData/reference/xml/MftfSelectorReferenceRegistrar/selectorInTestMustBeEmpty/TestMftfTest.xml
+++ b/testData/reference/xml/MftfSelectorReferenceRegistrar/selectorInTestMustBeEmpty/TestMftfTest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="TestAddOutOfStockProductToCompareListTest">
+        <before>
+            <click selector="{{TestAdminMenuCatalog<caret>}}" stepKey="saveCategoryWithProducts1"/>
+        </before>
+    </test>
+</tests>

--- a/testData/reference/xml/MftfSelectorReferenceRegistrar/selectorInTestMustHaveReference/TestMftfTest.xml
+++ b/testData/reference/xml/MftfSelectorReferenceRegistrar/selectorInTestMustHaveReference/TestMftfTest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="TestAddOutOfStockProductToCompareListTest">
+        <before>
+            <click selector="{{TestAdminAddProductsToOptionPanelSection.testaddSelectedProducts<caret>}}" stepKey="saveCategoryWithProducts1"/>
+        </before>
+    </test>
+</tests>

--- a/tests/com/magento/idea/magento2plugin/completion/xml/MftfSelectorCompletionRegistrarTest.java
+++ b/tests/com/magento/idea/magento2plugin/completion/xml/MftfSelectorCompletionRegistrarTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+package com.magento.idea.magento2plugin.completion.xml;
+
+public class MftfSelectorCompletionRegistrarTest extends CompletionXmlFixtureTestCase {
+
+    private static final String[] lookupStringsEntities = new String[] {
+        "TestAdminAddProductsToOptionPanelSection",
+        "TestAdminProductsPanelSection",
+        "TestAdminProductsSection",
+        "TestAdminAddProductsToOptionPanelSection.testaddSelectedProducts",
+        "TestAdminAddProductsToOptionPanelSection.testapplyFilters",
+        "TestAdminAddProductsToOptionPanelSection.testfilters",
+        "TestAdminAddProductsToOptionPanelSection.testfirstCheckbox",
+        "TestAdminAddProductsToOptionPanelSection.testnameFilter",
+        "TestAdminAddProductsToOptionPanelSection.testnthCheckbox",
+        "TestAdminProductsPanelSection.testaddSelectedProducts",
+        "TestAdminProductsSection.testaddSelectedProducts",
+        "TestAdminProductsSection.testapplyFilters",
+        "TestAdminProductsSection.testfilters"
+      };
+
+    public void testSelectorInActionGroupMustProvideCompletion() {
+        String filePath = this.getFixturePath("TestActionGroup.xml");
+        myFixture.copyFileToProject(filePath);
+
+        assertFileContainsCompletions(filePath, lookupStringsEntities);
+    }
+
+    public void testSelectorInTestMustProvideCompletion() {
+        String filePath = this.getFixturePath("TestMftfTest.xml");
+        myFixture.copyFileToProject(filePath);
+
+        assertFileContainsCompletions(filePath, lookupStringsEntities);
+    }
+
+    public void testSelectorInActionGroupMustBeEmpty() {
+        String filePath = this.getFixturePath("TestActionGroup.xml");
+        myFixture.copyFileToProject(filePath);
+
+        assertCompletionNotShowing(filePath);
+    }
+
+    public void testSelectorInTestMustBeEmpty() {
+        String filePath = this.getFixturePath("TestMftfTest.xml");
+        myFixture.copyFileToProject(filePath);
+
+        assertCompletionNotShowing(filePath);
+    }
+}

--- a/tests/com/magento/idea/magento2plugin/reference/xml/MftfSelectorReferenceRegistrarTest.java
+++ b/tests/com/magento/idea/magento2plugin/reference/xml/MftfSelectorReferenceRegistrarTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+package com.magento.idea.magento2plugin.reference.xml;
+
+public class MftfSelectorReferenceRegistrarTest extends ReferenceXmlFixtureTestCase {
+
+    public void testSelectorInActionGroupMustHaveReference() {
+        String filePath = this.getFixturePath("TestActionGroup.xml");
+        myFixture.configureByFile(filePath);
+
+        assertHasReferenceToXmlAttributeValue("testaddSelectedProducts");
+    }
+
+    public void testSelectorInTestMustHaveReference() {
+        String filePath = this.getFixturePath("TestMftfTest.xml");
+        myFixture.configureByFile(filePath);
+
+        assertHasReferenceToXmlAttributeValue("testaddSelectedProducts");
+    }
+
+    public void testSelectorInActionGroupMustBeEmpty() {
+        String filePath = this.getFixturePath("TestActionGroup.xml");
+        myFixture.configureByFile(filePath);
+
+        assertEmptyReference();
+    }
+
+    public void testSelectorInTestMustBeEmpty() {
+        String filePath = this.getFixturePath("TestMftfTest.xml");
+        myFixture.configureByFile(filePath);
+
+        assertEmptyReference();
+    }
+}


### PR DESCRIPTION
### Description (*)
This PR fixes sections autocomplete and reference for XML tag "selector"
![image](https://user-images.githubusercontent.com/20116393/79614112-83d95000-8108-11ea-9a24-12de3389899f.png)
![image](https://user-images.githubusercontent.com/20116393/79614117-876cd700-8108-11ea-9b8c-7c27f27df96e.png)

### Fixed Issues (if relevant)
1. magento/magento2-phpstorm-plugin#106: MFTF: Section name and elements autocomplete and reference
