### PR TITLE
Fixed null pointer exception on ObserverDeclarationInspection

### DIFF
--- a/src/com/magento/idea/magento2plugin/inspections/xml/ObserverDeclarationInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/xml/ObserverDeclarationInspection.java
@@ -72,7 +72,7 @@ public class ObserverDeclarationInspection extends PhpInspection {
 
                     List<XmlTag> targetObservers = fetchObserverTagsFromEventTag(eventXmlTag);
                     if (targetObservers.isEmpty()) {
-                        return;
+                        continue;
                     }
 
                     for (XmlTag observerXmlTag: targetObservers) {

--- a/src/com/magento/idea/magento2plugin/inspections/xml/ObserverDeclarationInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/xml/ObserverDeclarationInspection.java
@@ -71,6 +71,9 @@ public class ObserverDeclarationInspection extends PhpInspection {
                     }
 
                     List<XmlTag> targetObservers = fetchObserverTagsFromEventTag(eventXmlTag);
+                    if (targetObservers.isEmpty()) {
+                        return;
+                    }
 
                     for (XmlTag observerXmlTag: targetObservers) {
                         XmlAttribute observerNameAttribute = observerXmlTag.getAttribute("name");


### PR DESCRIPTION
### Description (*)
This PR fixes null pointer exception when editing events.xml file

### Fixed Issues (if relevant)
1. magento/magento2-phpstorm-plugin#168: Null Pointer on Observer Declaration inspection 
