### PR TITLE
#169 :- Quick fix for Resolver inspection adds implement directive to the next line

### DIFF
--- a/resources/magento2/inspection.properties
+++ b/resources/magento2/inspection.properties
@@ -1,3 +1,5 @@
 inspection.plugin.duplicateInSameFile=The plugin name already used in this file. For more details see Inspection Description.
 inspection.plugin.duplicateInOtherPlaces=The plugin name "{0}" for targeted "{1}" class is already used in the module "{2}" ({3} scope). For more details see Inspection Description.
 inspection.graphql.resolver.mustImplement=Class must implements any of the following interfaces: \\Magento\\Framework\\GraphQl\\Query\\ResolverInterface, \\Magento\\Framework\\GraphQl\\Query\\Resolver\\BatchResolverInterface, \\Magento\\Framework\\GraphQl\\Query\\Resolver\\BatchServiceContractResolverInterface
+inspection.graphql.resolver.fix.family=Implement Resolver interface
+inspection.graphql.resolver.fix.title=Select one of the following interface

--- a/src/com/magento/idea/magento2plugin/inspections/php/fix/PhpImplementResolverClassQuickFix.java
+++ b/src/com/magento/idea/magento2plugin/inspections/php/fix/PhpImplementResolverClassQuickFix.java
@@ -7,24 +7,57 @@ package com.magento.idea.magento2plugin.inspections.php.fix;
 
 import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogBuilder;
 import com.intellij.psi.PsiElement;
 import com.jetbrains.php.lang.psi.PhpPsiElementFactory;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.magento.idea.magento2plugin.magento.files.GraphQlResolver;
 import org.jetbrains.annotations.NotNull;
+import javax.swing.*;
 
 public class PhpImplementResolverClassQuickFix implements LocalQuickFix {
+    public static final String FAMILY_NAME = "Implements Resolver interface";
+    public static final String DIALOG_TITLE = "Select one of the following interface";
     @NotNull
     @Override
     public String getFamilyName() {
-        return "Implements Resolver interface";
+        return FAMILY_NAME;
     }
 
     @Override
     public void applyFix(@NotNull Project project, @NotNull ProblemDescriptor descriptor) {
-        PsiElement correctInterface = PhpPsiElementFactory.createImplementsList(project, GraphQlResolver.RESOLVER_INTERFACE);
-        PhpClass graphQlResolverClass = (PhpClass) descriptor.getPsiElement().getParent();
-        graphQlResolverClass.getImplementsList().replace(correctInterface);
+        String[] expectedInterface = { GraphQlResolver.BATCH_RESOLVER_INTERFACE,
+                GraphQlResolver.BATCH_SERVICE_CONTRACT_RESOLVER_INTERFACE,
+                GraphQlResolver.RESOLVER_INTERFACE
+        };
+        final JComboBox expectedInterfaceDropdown = new JComboBox(expectedInterface);
+        DialogBuilder dialogBox = createDialogBox(expectedInterfaceDropdown, project);
+        if (dialogBox.showAndGet()) {
+            String getSelectedInterface = expectedInterfaceDropdown.getSelectedItem().toString();
+            PsiElement correctInterface = PhpPsiElementFactory.createImplementsList(project, getSelectedInterface);
+            PhpClass graphQlResolverClass = (PhpClass) descriptor.getPsiElement().getParent();
+            WriteCommandAction.writeCommandAction(project).run(() -> {
+                graphQlResolverClass.getImplementsList().replace(correctInterface);
+            });
+        }
+    }
+
+    private DialogBuilder createDialogBox(JComboBox selectedClass, Project project)
+    {
+        JPanel panel = new JPanel();
+        panel.add(selectedClass);
+        DialogBuilder builder = new DialogBuilder(project);
+        builder.setTitle(DIALOG_TITLE);
+        builder.setCenterPanel(panel);
+        builder.addOkAction();
+        builder.addCancelAction();
+        return builder;
+    }
+
+    @Override
+    public boolean startInWriteAction() {
+        return false;
     }
 }

--- a/src/com/magento/idea/magento2plugin/inspections/php/fix/PhpImplementResolverClassQuickFix.java
+++ b/src/com/magento/idea/magento2plugin/inspections/php/fix/PhpImplementResolverClassQuickFix.java
@@ -14,26 +14,29 @@ import com.intellij.psi.PsiElement;
 import com.jetbrains.php.refactoring.extract.extractInterface.PhpExtractInterfaceProcessor;
 import com.jetbrains.php.lang.psi.PhpPsiElementFactory;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
+import com.magento.idea.magento2plugin.bundles.InspectionBundle;
 import com.magento.idea.magento2plugin.magento.files.GraphQlResolver;
 import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
 
 public class PhpImplementResolverClassQuickFix implements LocalQuickFix {
-    public static final String FAMILY_NAME = "Implements Resolver interface";
-    public static final String DIALOG_TITLE = "Select one of the following interface";
+    private InspectionBundle inspectionBundle = new InspectionBundle();
+
     @NotNull
     @Override
     public String getFamilyName() {
-        return FAMILY_NAME;
+        return inspectionBundle.message("inspection.graphql.resolver.fix.family");
     }
 
     @Override
     public void applyFix(@NotNull Project project, @NotNull ProblemDescriptor descriptor) {
-        String[] expectedInterface = { GraphQlResolver.BATCH_RESOLVER_INTERFACE,
-                GraphQlResolver.BATCH_SERVICE_CONTRACT_RESOLVER_INTERFACE,
-                GraphQlResolver.RESOLVER_INTERFACE
+        String[] expectedInterface = {
+            GraphQlResolver.BATCH_RESOLVER_INTERFACE,
+            GraphQlResolver.BATCH_SERVICE_CONTRACT_RESOLVER_INTERFACE,
+            GraphQlResolver.RESOLVER_INTERFACE
         };
         final JComboBox expectedInterfaceDropdown = new JComboBox(expectedInterface);
+        ((JLabel)expectedInterfaceDropdown.getRenderer()).setHorizontalAlignment(SwingConstants.CENTER);
         DialogBuilder dialogBox = createDialogBox(expectedInterfaceDropdown, project);
         if (dialogBox.showAndGet()) {
             String getSelectedInterface = expectedInterfaceDropdown.getSelectedItem().toString();
@@ -56,7 +59,7 @@ public class PhpImplementResolverClassQuickFix implements LocalQuickFix {
         JPanel panel = new JPanel();
         panel.add(selectedClass);
         DialogBuilder builder = new DialogBuilder(project);
-        builder.setTitle(DIALOG_TITLE);
+        builder.setTitle(inspectionBundle.message("inspection.graphql.resolver.fix.title"));
         builder.setCenterPanel(panel);
         builder.addOkAction();
         builder.addCancelAction();

--- a/src/com/magento/idea/magento2plugin/inspections/php/fix/PhpImplementResolverClassQuickFix.java
+++ b/src/com/magento/idea/magento2plugin/inspections/php/fix/PhpImplementResolverClassQuickFix.java
@@ -10,8 +10,8 @@ import com.intellij.codeInspection.ProblemDescriptor;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogBuilder;
-import com.intellij.psi.codeStyle.CodeStyleManager;
 import com.intellij.psi.PsiElement;
+import com.jetbrains.php.refactoring.extract.extractInterface.PhpExtractInterfaceProcessor;
 import com.jetbrains.php.lang.psi.PhpPsiElementFactory;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.magento.idea.magento2plugin.magento.files.GraphQlResolver;
@@ -43,7 +43,7 @@ public class PhpImplementResolverClassQuickFix implements LocalQuickFix {
             String[] implementedInterfaceNames = graphQlResolverClass.getInterfaceNames();
             WriteCommandAction.runWriteCommandAction(project, () -> {
                 if (implementedInterfaceNames.length == 0) {
-                    graphQlResolverClass.getImplementsList().addAfter(correctInterface, erroredElement);
+                    PhpExtractInterfaceProcessor.addImplementClause(project, graphQlResolverClass, getSelectedInterface);
                 } else {
                     graphQlResolverClass.getImplementsList().replace(correctInterface);
                 }

--- a/src/com/magento/idea/magento2plugin/magento/files/GraphQlResolver.java
+++ b/src/com/magento/idea/magento2plugin/magento/files/GraphQlResolver.java
@@ -6,5 +6,7 @@ package com.magento.idea.magento2plugin.magento.files;
 
 public class GraphQlResolver {
     public static final String RESOLVER_INTERFACE = "\\Magento\\Framework\\GraphQl\\Query\\ResolverInterface";
+    public static final String BATCH_RESOLVER_INTERFACE = "\\Magento\\Framework\\GraphQl\\Query\\Resolver\\BatchResolverInterface";
+    public static final String BATCH_SERVICE_CONTRACT_RESOLVER_INTERFACE = "\\Magento\\Framework\\GraphQl\\Query\\Resolver\\BatchServiceContractResolverInterface";
     public static final String CLASS_ARGUMENT = "class";
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will add following interface to implement resolver
1. `Magento\Framework\GraphQl\Query\ResolverInterface`
2. `Magento\Framework\GraphQl\Query\Resolver\BatchResolverInterface`
3. `Magento\Framework\GraphQl\Query\Resolver\BatchServiceContractResolverInterface`

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2-phpstorm-plugin#169: Quick fix for Resolver inspection adds implement directive to the next line

### Screenshot
![image](https://user-images.githubusercontent.com/39480008/79689317-9a4eeb00-8271-11ea-912c-f02021abf80f.png)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages

### Note
I'm not able to reproduce the issue with the interface applied to the next line. I will check again this issue