### PR TITLE
Fixed null pointer exception in the PluginDeclarationInspection

### DIFF
--- a/src/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspection.java
@@ -95,6 +95,9 @@ public class PluginDeclarationInspection extends PhpInspection {
                         for (Pair<String, String> moduleEntry: modulesWithSamePluginName) {
                             String scope = moduleEntry.getFirst();
                             String moduleName = moduleEntry.getSecond();
+                            if (scope == null || moduleName == null) {
+                                continue;
+                            }
                             String problemKey = pluginTypeKey.concat(Package.VENDOR_MODULE_NAME_SEPARATOR)
                                     .concat(moduleName).concat(Package.VENDOR_MODULE_NAME_SEPARATOR).concat(scope);
                             if (!pluginProblems.containsKey(problemKey)){


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento/magento2-phpstorm-plugin#182: NullPointerException in PhpStorm 2020.1
