### PR TITLE
#156: fix issue with wrong namespaces

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/code/PluginMethodsGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/code/PluginMethodsGenerator.java
@@ -221,11 +221,7 @@ public class PluginMethodsGenerator {
                 }
                 buf.append(parameterText);
             } else {
-                Boolean globalType = true;
-                if (i == 0) {
-                    globalType = false;
-                }
-
+                Boolean globalType = i != 0;
                 String typeHint = this.getTypeHint(element, globalType);
                 if (typeHint != null && !typeHint.isEmpty()) {
                     buf.append(typeHint).append(' ');
@@ -290,10 +286,9 @@ public class PluginMethodsGenerator {
         if (typeStrings.size() == 2) {
             PhpType filteredNullType = filterNullCaseInsensitive(filedType);
             if (filteredNullType.getTypes().size() == 1) {
+                typeString = this.convertTypeToString(element, filteredNullType.getTypes(), globalType);
                 if (PhpLanguageFeature.NULLABLES.isSupported(element.getProject())) {
-                    typeString = "?" + this.convertTypeToString(element, filteredNullType.getTypes(), globalType);
-                } else {
-                    typeString = this.convertTypeToString(element, filteredNullType.getTypes(), globalType);
+                    typeString = "?" + typeString;
                 }
             }
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
This PR fixed issue with wrong namespaces.

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

This PR fixed two issues with namespace:

1. A wrong namespace for the first method parameter in the plugin if the name of the plugin and class are the same. I added the full path for first method parameter
![2020-04-20_20-17-10](https://user-images.githubusercontent.com/60603281/79780028-f97d3000-8343-11ea-98b9-4efa4cadefbb.png)

1. I fixed the wrong namespace for the second method parameter in the plugin.
![2020-04-20_20-21-24](https://user-images.githubusercontent.com/60603281/79780409-8d4efc00-8344-11ea-8dd7-48c8900b37be.png)


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2-phpstorm-plugin#156: Wrong namespace for method parameters in plugin

### Steps to reproduce (*)

- **for the first issue:**
1. open file Magento\Catalog\Api\ProductRepositoryInterface
2. create a new plugin. >> Set plugin class name is like the same as the name of the file (ProductRepositoryInterface)
3. open new plugin file >> The first parameter must be with the full namespace.

- **for the second issue:**
1. open file Magento\Catalog\Api\ProductRepositoryInterface
2. create a new "before" plugin for save()
3. open new plugin file >> The second parameter must be with the right namespace.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages

