### PR TITLE
Implemented custom file separator, utilize java.io.File breaks Windows

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAPluginDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAPluginDialog.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.*;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 import java.util.List;
 
 public class CreateAPluginDialog extends AbstractDialog {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAnObserverDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAnObserverDialog.java
@@ -5,13 +5,10 @@
 package com.magento.idea.magento2plugin.actions.generation.dialog;
 
 import com.intellij.openapi.project.Project;
-import com.jetbrains.php.lang.psi.elements.Method;
-import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.magento.idea.magento2plugin.actions.generation.CreateAPluginAction;
 import com.magento.idea.magento2plugin.actions.generation.CreateAnObserverAction;
 import com.magento.idea.magento2plugin.actions.generation.data.ObserverEventsXmlData;
 import com.magento.idea.magento2plugin.actions.generation.data.ObserverFileData;
-import com.magento.idea.magento2plugin.actions.generation.dialog.validator.CreateAPluginDialogValidator;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.CreateAnObserverDialogValidator;
 import com.magento.idea.magento2plugin.actions.generation.generator.ObserverClassGenerator;
 import com.magento.idea.magento2plugin.actions.generation.generator.ObserverEventsXmlGenerator;
@@ -19,7 +16,6 @@ import com.magento.idea.magento2plugin.indexes.ModuleIndex;
 import com.magento.idea.magento2plugin.magento.packages.Package;
 import com.magento.idea.magento2plugin.ui.FilteredComboBox;
 import org.jetbrains.annotations.NotNull;
-
 import javax.swing.*;
 import java.awt.event.*;
 import com.magento.idea.magento2plugin.magento.packages.File;

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAnObserverDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAnObserverDialog.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.event.*;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 import java.util.List;
 
 public class CreateAnObserverDialog extends AbstractDialog {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewBlockDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewBlockDialog.java
@@ -16,7 +16,7 @@ import com.magento.idea.magento2plugin.magento.packages.Package;
 import com.magento.idea.magento2plugin.util.magento.GetModuleNameByDirectory;
 import javax.swing.*;
 import java.awt.event.*;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 
 public class NewBlockDialog extends AbstractDialog {
     private final NewBlockValidator validator;

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewGraphQlResolverDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewGraphQlResolverDialog.java
@@ -16,7 +16,7 @@ import com.magento.idea.magento2plugin.magento.packages.Package;
 import com.magento.idea.magento2plugin.util.magento.GetModuleNameByDirectory;
 import javax.swing.*;
 import java.awt.event.*;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 
 public class NewGraphQlResolverDialog extends AbstractDialog {
     private final NewGraphQlResolverValidator validator;

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewViewModelDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewViewModelDialog.java
@@ -16,7 +16,7 @@ import com.magento.idea.magento2plugin.magento.packages.Package;
 import com.magento.idea.magento2plugin.util.magento.GetModuleNameByDirectory;
 import javax.swing.*;
 import java.awt.event.*;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 
 public class NewViewModelDialog extends AbstractDialog {
     private final NewViewModelValidator validator;

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideClassByAPreferenceDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideClassByAPreferenceDialog.java
@@ -21,7 +21,7 @@ import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
 import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
 import java.awt.event.*;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 import java.util.List;
 
 public class OverrideClassByAPreferenceDialog extends AbstractDialog {

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleBlockClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleBlockClassGenerator.java
@@ -20,7 +20,7 @@ import com.magento.idea.magento2plugin.util.GetPhpClassByFQN;
 import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
 import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 import java.util.Properties;
 
 public class ModuleBlockClassGenerator extends FileGenerator {

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleGraphQlResolverClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleGraphQlResolverClassGenerator.java
@@ -29,7 +29,7 @@ import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 import java.util.Properties;
 
 public class ModuleGraphQlResolverClassGenerator extends FileGenerator {

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleViewModelClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleViewModelClassGenerator.java
@@ -19,7 +19,7 @@ import com.magento.idea.magento2plugin.util.GetPhpClassByFQN;
 import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
 import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 import java.util.Properties;
 
 public class ModuleViewModelClassGenerator extends FileGenerator {

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ObserverClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ObserverClassGenerator.java
@@ -23,7 +23,7 @@ import com.magento.idea.magento2plugin.util.GetFirstClassOfFile;
 import com.magento.idea.magento2plugin.util.GetPhpClassByFQN;
 import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
 import javax.swing.*;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 import java.util.Properties;
 
 public class ObserverClassGenerator extends FileGenerator {

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/PluginClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/PluginClassGenerator.java
@@ -38,7 +38,7 @@ import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
 import gnu.trove.THashSet;
 import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/PreferenceClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/PreferenceClassGenerator.java
@@ -19,7 +19,7 @@ import com.magento.idea.magento2plugin.util.GetPhpClassByFQN;
 import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
 import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 import java.util.Properties;
 
 public class PreferenceClassGenerator extends FileGenerator {

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FileFromTemplateGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FileFromTemplateGenerator.java
@@ -23,7 +23,7 @@ import com.intellij.util.IncorrectOperationException;
 import com.magento.idea.magento2plugin.magento.files.ModuleFileInterface;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;

--- a/src/com/magento/idea/magento2plugin/generation/php/NewModuleForm.java
+++ b/src/com/magento/idea/magento2plugin/generation/php/NewModuleForm.java
@@ -25,7 +25,7 @@ import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;

--- a/src/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspection.java
@@ -23,7 +23,7 @@ import com.magento.idea.magento2plugin.magento.packages.Package;
 import com.magento.idea.magento2plugin.util.magento.GetModuleNameByDirectory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 import java.util.*;
 import com.intellij.openapi.util.Pair;
 

--- a/src/com/magento/idea/magento2plugin/magento/packages/File.java
+++ b/src/com/magento/idea/magento2plugin/magento/packages/File.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+package com.magento.idea.magento2plugin.magento.packages;
+
+public class File {
+    public static String separator = "/";
+}

--- a/src/com/magento/idea/magento2plugin/util/magento/FileBasedIndexUtil.java
+++ b/src/com/magento/idea/magento2plugin/util/magento/FileBasedIndexUtil.java
@@ -15,7 +15,7 @@ import com.magento.idea.magento2plugin.magento.packages.Package;
 import com.magento.idea.magento2plugin.stubs.indexes.ModuleNameIndex;
 import com.magento.idea.magento2plugin.util.RegExUtil;
 
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.regex.Matcher;

--- a/src/com/magento/idea/magento2plugin/util/magento/MagentoVersion.java
+++ b/src/com/magento/idea/magento2plugin/util/magento/MagentoVersion.java
@@ -16,7 +16,7 @@ import com.intellij.psi.util.PsiTreeUtil;
 import com.magento.idea.magento2plugin.magento.files.ComposerJson;
 import com.magento.idea.magento2plugin.magento.packages.ComposerPackageModel;
 import com.magento.idea.magento2plugin.magento.packages.ComposerPackageModelImpl;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 
 public class MagentoVersion {
     private static MagentoVersion INSTANCE = null;

--- a/tests/com/magento/idea/magento2plugin/BaseProjectTestCase.java
+++ b/tests/com/magento/idea/magento2plugin/BaseProjectTestCase.java
@@ -9,7 +9,7 @@ import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import com.magento.idea.magento2plugin.indexes.IndexManager;
 import com.magento.idea.magento2plugin.project.Settings;
 import com.magento.idea.magento2plugin.project.util.GetProjectBasePath;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 
 /**
  * Configure test environment with Magento 2 project

--- a/tests/com/magento/idea/magento2plugin/completion/xml/CompletionXmlFixtureTestCase.java
+++ b/tests/com/magento/idea/magento2plugin/completion/xml/CompletionXmlFixtureTestCase.java
@@ -6,7 +6,7 @@ package com.magento.idea.magento2plugin.completion.xml;
 
 import com.magento.idea.magento2plugin.BaseProjectTestCase;
 
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 import java.util.Arrays;
 import java.util.List;
 

--- a/tests/com/magento/idea/magento2plugin/inspections/php/InspectionPhpFixtureTestCase.java
+++ b/tests/com/magento/idea/magento2plugin/inspections/php/InspectionPhpFixtureTestCase.java
@@ -6,7 +6,7 @@ package com.magento.idea.magento2plugin.inspections.php;
 
 import com.intellij.codeInsight.daemon.impl.HighlightInfo;
 import com.magento.idea.magento2plugin.BaseProjectTestCase;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 import java.util.List;
 
 abstract public class InspectionPhpFixtureTestCase extends BaseProjectTestCase {

--- a/tests/com/magento/idea/magento2plugin/inspections/xml/InspectionXmlFixtureTestCase.java
+++ b/tests/com/magento/idea/magento2plugin/inspections/xml/InspectionXmlFixtureTestCase.java
@@ -2,7 +2,7 @@ package com.magento.idea.magento2plugin.inspections.xml;
 
 import com.magento.idea.magento2plugin.BaseProjectTestCase;
 
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 
 abstract public class InspectionXmlFixtureTestCase extends BaseProjectTestCase {
 

--- a/tests/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspectionTest.java
+++ b/tests/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspectionTest.java
@@ -6,7 +6,7 @@ package com.magento.idea.magento2plugin.inspections.xml;
 
 import com.magento.idea.magento2plugin.magento.files.ModuleDiXml;
 import com.magento.idea.magento2plugin.magento.packages.Package;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 
 public class PluginDeclarationInspectionTest extends InspectionXmlFixtureTestCase {
 

--- a/tests/com/magento/idea/magento2plugin/linemarker/php/LinemarkerPhpFixtureTestCase.java
+++ b/tests/com/magento/idea/magento2plugin/linemarker/php/LinemarkerPhpFixtureTestCase.java
@@ -9,7 +9,7 @@ import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl;
 import com.magento.idea.magento2plugin.BaseProjectTestCase;
 import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 import java.util.List;
 
 abstract public class LinemarkerPhpFixtureTestCase extends BaseProjectTestCase {

--- a/tests/com/magento/idea/magento2plugin/reference/php/ReferencePhpFixtureTestCase.java
+++ b/tests/com/magento/idea/magento2plugin/reference/php/ReferencePhpFixtureTestCase.java
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiReference;
 import com.intellij.psi.impl.source.xml.XmlAttributeValueImpl;
 import com.magento.idea.magento2plugin.BaseProjectTestCase;
 import com.magento.idea.magento2plugin.reference.xml.PolyVariantReferenceBase;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 
 abstract public class ReferencePhpFixtureTestCase extends BaseProjectTestCase {
 

--- a/tests/com/magento/idea/magento2plugin/reference/xml/ReferenceXmlFixtureTestCase.java
+++ b/tests/com/magento/idea/magento2plugin/reference/xml/ReferenceXmlFixtureTestCase.java
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiReference;
 import com.intellij.psi.xml.XmlAttributeValue;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.magento.idea.magento2plugin.BaseProjectTestCase;
-import java.io.File;
+import com.magento.idea.magento2plugin.magento.packages.File;
 
 abstract public class ReferenceXmlFixtureTestCase extends BaseProjectTestCase {
 


### PR DESCRIPTION
### Description (*)
Replaced `java.io.File` with the custom implementation to fix compatibility with the Windows os.

### Fixed Issues (if relevant)
Some features were broken before changes provided in the PR, for example creating a view model popup had been never shown.
![image](https://user-images.githubusercontent.com/20116393/80022451-efb51300-8490-11ea-9e1a-292caf4a3330.png)


