### PR TITLE
Managing the static phrases to use the bundle messages

### DIFF
--- a/resources/magento2/common.properties
+++ b/resources/magento2/common.properties
@@ -7,3 +7,5 @@ common.module.description=Module Description
 common.ok=OK
 common.cancel=Cancel
 common.error=Error
+common.module.target=Target Module
+common.area.target=Target Area

--- a/resources/magento2/common.properties
+++ b/resources/magento2/common.properties
@@ -6,3 +6,4 @@ common.module.dependencies=Module Dependencies
 common.module.description=Module Description
 common.ok=OK
 common.cancel=Cancel
+common.error=Error

--- a/resources/magento2/inspection.properties
+++ b/resources/magento2/inspection.properties
@@ -1,5 +1,17 @@
+inspection.class.hierarchyImplementationCheck=Class must implement {0}
+inspection.class.hierarchyExtendingCheck=Class must extend {0}
 inspection.plugin.duplicateInSameFile=The plugin name already used in this file. For more details see Inspection Description.
 inspection.plugin.duplicateInOtherPlaces=The plugin name "{0}" for targeted "{1}" class is already used in the module "{2}" ({3} scope). For more details see Inspection Description.
 inspection.graphql.resolver.mustImplement=Class must implements any of the following interfaces: \\Magento\\Framework\\GraphQl\\Query\\ResolverInterface, \\Magento\\Framework\\GraphQl\\Query\\Resolver\\BatchResolverInterface, \\Magento\\Framework\\GraphQl\\Query\\Resolver\\BatchServiceContractResolverInterface
 inspection.graphql.resolver.fix.family=Implement Resolver interface
 inspection.graphql.resolver.fix.title=Select one of the following interface
+inspection.plugin.error.nonPublicMethod=You can't declare a plugin for a not public method.
+inspection.plugin.error.finalClass=You can't declare a plugin for a final class.
+inspection.plugin.error.finalMethod=You can't declare a plugin for a final method.
+inspection.plugin.error.staticMethod=You can't declare a plugin for a static method.
+inspection.plugin.error.constructMethod=You can't declare a plugin for a __construct method.
+inspection.plugin.error.redundantParameter=Redundant parameter
+inspection.plugin.error.typeIncompatibility=Possible type incompatibility. Consider changing the parameter according to the target method.
+inspection.observer.duplicateInSameFile=The observer name already used in this file. For more details see Inspection Description.
+inspection.observer.duplicateInOtherPlaces=The observer name "{0}" for event "{1}" is already used in the module "{2}" ({3} scope). For more details see Inspection Description.
+inspection.cache.disabledCache=Cacheable false attribute on the default layout will disable cache site-wide

--- a/src/com/magento/idea/magento2plugin/actions/generation/PluginGenerateMethodHandlerBase.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/PluginGenerateMethodHandlerBase.java
@@ -34,6 +34,7 @@ import com.magento.idea.magento2plugin.actions.generation.generator.code.PluginM
 import com.magento.idea.magento2plugin.actions.generation.util.CodeStyleSettings;
 import com.magento.idea.magento2plugin.actions.generation.util.CollectInsertedMethods;
 import com.magento.idea.magento2plugin.actions.generation.util.FillTextBufferWithPluginMethods;
+import com.magento.idea.magento2plugin.bundles.CommonBundle;
 import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
 import com.magento.idea.magento2plugin.magento.files.Plugin;
 import com.magento.idea.magento2plugin.util.GetPhpClassByFQN;
@@ -49,6 +50,7 @@ import java.util.*;
 public abstract class PluginGenerateMethodHandlerBase implements LanguageCodeInsightActionHandler {
     private CollectInsertedMethods collectInsertedMethods;
     private ValidatorBundle validatorBundle;
+    private CommonBundle commonBundle;
     public String type;
     public FillTextBufferWithPluginMethods fillTextBuffer;
 
@@ -57,6 +59,7 @@ public abstract class PluginGenerateMethodHandlerBase implements LanguageCodeIns
         this.fillTextBuffer = FillTextBufferWithPluginMethods.getInstance();
         this.collectInsertedMethods = CollectInsertedMethods.getInstance();
         this.validatorBundle = new ValidatorBundle();
+        this.commonBundle = new CommonBundle();
     }
 
     public boolean isValidFor(Editor editor, PsiFile file) {
@@ -165,7 +168,7 @@ public abstract class PluginGenerateMethodHandlerBase implements LanguageCodeIns
 
             if (targetClass == null) {
                 String errorMessage = validatorBundle.message("validator.class.targetClassNotFound");
-                JOptionPane.showMessageDialog(null, errorMessage, "Error", JOptionPane.ERROR_MESSAGE);
+                JOptionPane.showMessageDialog(null, errorMessage, commonBundle.message("common.error"), JOptionPane.ERROR_MESSAGE);
                 continue;
             }
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAPluginDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAPluginDialog.form
@@ -38,7 +38,7 @@
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="OK"/>
+                  <text resource-bundle="magento2/common" key="common.ok"/>
                 </properties>
               </component>
               <component id="5723f" class="javax.swing.JButton" binding="buttonCancel">
@@ -46,7 +46,7 @@
                   <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="Cancel"/>
+                  <text resource-bundle="magento2/common" key="common.cancel"/>
                 </properties>
               </component>
             </children>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAPluginDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAPluginDialog.form
@@ -154,7 +154,7 @@
         </constraints>
         <properties>
           <labelFor value="bd654"/>
-          <text value="Target Module"/>
+          <text resource-bundle="magento2/common" key="common.module.target"/>
         </properties>
       </component>
       <component id="b0d15" class="javax.swing.JComboBox" binding="pluginType">
@@ -191,7 +191,7 @@
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="Target Area"/>
+          <text resource-bundle="magento2/common" key="common.area.target"/>
         </properties>
       </component>
     </children>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAnObserverDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAnObserverDialog.form
@@ -130,7 +130,7 @@
         </constraints>
         <properties>
           <labelFor value="bd654"/>
-          <text value="Target Module"/>
+          <text resource-bundle="magento2/common" key="common.module.target"/>
         </properties>
       </component>
       <component id="bd654" class="com.magento.idea.magento2plugin.ui.FilteredComboBox" binding="observerModule" custom-create="true">
@@ -150,7 +150,7 @@
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="Target Area"/>
+          <text resource-bundle="magento2/common" key="common.area.target"/>
         </properties>
       </component>
     </children>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAnObserverDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAnObserverDialog.form
@@ -38,7 +38,7 @@
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="OK"/>
+                  <text resource-bundle="magento2/common" key="common.ok"/>
                 </properties>
               </component>
               <component id="5723f" class="javax.swing.JButton" binding="buttonCancel">
@@ -46,7 +46,7 @@
                   <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="Cancel"/>
+                  <text resource-bundle="magento2/common" key="common.cancel"/>
                 </properties>
               </component>
             </children>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewBlockDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewBlockDialog.form
@@ -38,7 +38,7 @@
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="OK"/>
+                  <text resource-bundle="magento2/common" key="common.ok"/>
                 </properties>
               </component>
               <component id="5723f" class="javax.swing.JButton" binding="buttonCancel">
@@ -46,7 +46,7 @@
                   <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="Cancel"/>
+                  <text resource-bundle="magento2/common" key="common.cancel"/>
                 </properties>
               </component>
             </children>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCronjobDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCronjobDialog.form
@@ -34,7 +34,7 @@
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="OK"/>
+                  <text resource-bundle="magento2/common" key="common.ok"/>
                 </properties>
               </component>
               <component id="5723f" class="javax.swing.JButton" binding="buttonCancel">
@@ -42,7 +42,7 @@
                   <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="Cancel"/>
+                  <text resource-bundle="magento2/common" key="common.cancel"/>
                 </properties>
               </component>
             </children>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewGraphQlResolverDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewGraphQlResolverDialog.form
@@ -108,7 +108,7 @@
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="OK"/>
+                  <text resource-bundle="magento2/common" key="common.ok"/>
                 </properties>
               </component>
               <component id="1b860" class="javax.swing.JButton" binding="buttonCancel">
@@ -116,7 +116,7 @@
                   <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="Cancel"/>
+                  <text resource-bundle="magento2/common" key="common.cancel"/>
                 </properties>
               </component>
             </children>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewViewModelDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewViewModelDialog.form
@@ -108,7 +108,7 @@
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="OK"/>
+                  <text resource-bundle="magento2/common" key="common.ok"/>
                 </properties>
               </component>
               <component id="1b860" class="javax.swing.JButton" binding="buttonCancel">
@@ -116,7 +116,7 @@
                   <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="Cancel"/>
+                  <text resource-bundle="magento2/common" key="common.cancel"/>
                 </properties>
               </component>
             </children>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideClassByAPreferenceDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideClassByAPreferenceDialog.form
@@ -37,7 +37,7 @@
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="OK"/>
+                  <text resource-bundle="magento2/common" key="common.ok"/>
                 </properties>
               </component>
               <component id="5723f" class="javax.swing.JButton" binding="buttonCancel">
@@ -45,7 +45,7 @@
                   <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="Cancel"/>
+                  <text resource-bundle="magento2/common" key="common.cancel"/>
                 </properties>
               </component>
             </children>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideClassByAPreferenceDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideClassByAPreferenceDialog.form
@@ -127,7 +127,7 @@
         </constraints>
         <properties>
           <labelFor value="bd654"/>
-          <text value="Target Module"/>
+          <text resource-bundle="magento2/common" key="common.module.target"/>
         </properties>
       </component>
       <component id="bd654" class="com.magento.idea.magento2plugin.ui.FilteredComboBox" binding="preferenceModule" custom-create="true">
@@ -149,7 +149,7 @@
           </grid>
         </constraints>
         <properties>
-          <text value="Target Area"/>
+          <text resource-bundle="magento2/common" key="common.area.target"/>
         </properties>
       </component>
     </children>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideClassByAPreferenceDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideClassByAPreferenceDialog.java
@@ -14,6 +14,7 @@ import com.magento.idea.magento2plugin.actions.generation.data.PreferenceFileDat
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.OverrideClassByAPreferenceDialogValidator;
 import com.magento.idea.magento2plugin.actions.generation.generator.PreferenceClassGenerator;
 import com.magento.idea.magento2plugin.actions.generation.generator.PreferenceDiXmlGenerator;
+import com.magento.idea.magento2plugin.bundles.CommonBundle;
 import com.magento.idea.magento2plugin.indexes.ModuleIndex;
 import com.magento.idea.magento2plugin.magento.packages.Package;
 import com.magento.idea.magento2plugin.ui.FilteredComboBox;
@@ -44,12 +45,14 @@ public class OverrideClassByAPreferenceDialog extends AbstractDialog {
     private JLabel inheritClassLabel;
     private JLabel preferenceDirectoryLabel;
     private ValidatorBundle validatorBundle;
+    private CommonBundle commonBundle;
 
     public OverrideClassByAPreferenceDialog(@NotNull Project project, PhpClass targetClass) {
         this.project = project;
         this.targetClass = targetClass;
         this.validator = OverrideClassByAPreferenceDialogValidator.getInstance(this);
         this.validatorBundle = new ValidatorBundle();
+        this.commonBundle = new CommonBundle();
 
         setContentPane(contentPane);
         setModal(true);
@@ -127,7 +130,8 @@ public class OverrideClassByAPreferenceDialog extends AbstractDialog {
         ), project).generate(OverrideClassByAPreferenceAction.ACTION_NAME);
         if (diXml == null) {
             String errorMessage = validatorBundle.message("validator.class.alreadyDeclared", "Preference");
-            JOptionPane.showMessageDialog(null, errorMessage, "Error", JOptionPane.ERROR_MESSAGE);
+            String errorTitle = commonBundle.message("common.error");
+            JOptionPane.showMessageDialog(null, errorMessage, errorTitle, JOptionPane.ERROR_MESSAGE);
 
             return;
         }

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/CreateAPluginDialogValidator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/CreateAPluginDialogValidator.java
@@ -6,6 +6,7 @@ package com.magento.idea.magento2plugin.actions.generation.dialog.validator;
 
 import com.intellij.openapi.project.Project;
 import com.magento.idea.magento2plugin.actions.generation.dialog.CreateAPluginDialog;
+import com.magento.idea.magento2plugin.bundles.CommonBundle;
 import com.magento.idea.magento2plugin.indexes.ModuleIndex;
 import com.magento.idea.magento2plugin.util.RegExUtil;
 import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
@@ -15,6 +16,7 @@ import java.util.List;
 public class CreateAPluginDialogValidator {
     private static CreateAPluginDialogValidator INSTANCE = null;
     private ValidatorBundle validatorBundle;
+    private CommonBundle commonBundle;
     private CreateAPluginDialog dialog;
 
     public static CreateAPluginDialogValidator getInstance(CreateAPluginDialog dialog) {
@@ -28,11 +30,12 @@ public class CreateAPluginDialogValidator {
 
     public CreateAPluginDialogValidator() {
         this.validatorBundle = new ValidatorBundle();
+        this.commonBundle = new CommonBundle();
     }
 
     public boolean validate(Project project)
     {
-        String errorTitle = "Error";
+        String errorTitle = commonBundle.message("common.error");
         String pluginClassName = dialog.getPluginClassName();
 
         if (pluginClassName.length() == 0) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/CreateAnObserverDialogValidator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/CreateAnObserverDialogValidator.java
@@ -6,6 +6,7 @@ package com.magento.idea.magento2plugin.actions.generation.dialog.validator;
 
 import com.intellij.openapi.project.Project;
 import com.magento.idea.magento2plugin.actions.generation.dialog.CreateAnObserverDialog;
+import com.magento.idea.magento2plugin.bundles.CommonBundle;
 import com.magento.idea.magento2plugin.indexes.ModuleIndex;
 import com.magento.idea.magento2plugin.util.RegExUtil;
 import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
@@ -15,6 +16,7 @@ import java.util.List;
 public class CreateAnObserverDialogValidator {
     private static CreateAnObserverDialogValidator INSTANCE = null;
     private ValidatorBundle validatorBundle;
+    private CommonBundle commonBundle;
     private CreateAnObserverDialog dialog;
 
     public static CreateAnObserverDialogValidator getInstance(CreateAnObserverDialog dialog) {
@@ -27,11 +29,12 @@ public class CreateAnObserverDialogValidator {
 
     public CreateAnObserverDialogValidator() {
         this.validatorBundle = new ValidatorBundle();
+        this.commonBundle = new CommonBundle();
     }
 
     public boolean validate(Project project)
     {
-        String errorTitle = "Error";
+        String errorTitle = commonBundle.message("common.error");
         String observerClassName = dialog.getObserverClassName();
         if (observerClassName.length() == 0) {
             String errorMessage = validatorBundle.message("validator.notEmpty", "Observer Class Name");

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/NewBlockValidator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/NewBlockValidator.java
@@ -5,6 +5,7 @@
 package com.magento.idea.magento2plugin.actions.generation.dialog.validator;
 
 import com.magento.idea.magento2plugin.actions.generation.dialog.NewBlockDialog;
+import com.magento.idea.magento2plugin.bundles.CommonBundle;
 import com.magento.idea.magento2plugin.util.RegExUtil;
 import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
 import javax.swing.*;
@@ -12,6 +13,7 @@ import javax.swing.*;
 public class NewBlockValidator {
     private static NewBlockValidator INSTANCE = null;
     private ValidatorBundle validatorBundle;
+    private CommonBundle commonBundle;
     private NewBlockDialog dialog;
 
     public static NewBlockValidator getInstance(NewBlockDialog dialog) {
@@ -24,11 +26,12 @@ public class NewBlockValidator {
 
     public NewBlockValidator() {
         this.validatorBundle = new ValidatorBundle();
+        this.commonBundle = new CommonBundle();
     }
 
     public boolean validate()
     {
-        String errorTitle = "Error";
+        String errorTitle = commonBundle.message("common.error");
 
         String moduleName = dialog.getBlockName();
         if (moduleName.length() == 0) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/NewGraphQlResolverValidator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/NewGraphQlResolverValidator.java
@@ -5,6 +5,7 @@
 package com.magento.idea.magento2plugin.actions.generation.dialog.validator;
 
 import com.magento.idea.magento2plugin.actions.generation.dialog.NewGraphQlResolverDialog;
+import com.magento.idea.magento2plugin.bundles.CommonBundle;
 import com.magento.idea.magento2plugin.util.RegExUtil;
 import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
 
@@ -13,6 +14,8 @@ import javax.swing.*;
 public class NewGraphQlResolverValidator {
     private static NewGraphQlResolverValidator INSTANCE = null;
     private ValidatorBundle validatorBundle;
+    private CommonBundle commonBundle;
+
     private NewGraphQlResolverDialog dialog;
 
     public static NewGraphQlResolverValidator getInstance(NewGraphQlResolverDialog dialog) {
@@ -25,11 +28,12 @@ public class NewGraphQlResolverValidator {
 
     public NewGraphQlResolverValidator() {
         this.validatorBundle = new ValidatorBundle();
+        this.commonBundle = new CommonBundle();
     }
 
     public boolean validate()
     {
-        String errorTitle = "Error";
+        String errorTitle = commonBundle.message("common.error");
 
         String resolverClassName = dialog.getGraphQlResolverClassName();
         if (resolverClassName.length() == 0) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/NewModuleDialogValidator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/NewModuleDialogValidator.java
@@ -5,6 +5,7 @@
 package com.magento.idea.magento2plugin.actions.generation.dialog.validator;
 
 import com.magento.idea.magento2plugin.actions.generation.dialog.NewModuleDialog;
+import com.magento.idea.magento2plugin.bundles.CommonBundle;
 import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
 import com.magento.idea.magento2plugin.util.RegExUtil;
 import javax.swing.*;
@@ -12,6 +13,7 @@ import javax.swing.*;
 public class NewModuleDialogValidator {
     private static NewModuleDialogValidator INSTANCE = null;
     private ValidatorBundle validatorBundle;
+    private CommonBundle commonBundle;
     private NewModuleDialog dialog;
 
     public static NewModuleDialogValidator getInstance(NewModuleDialog dialog) {
@@ -24,11 +26,12 @@ public class NewModuleDialogValidator {
 
     public NewModuleDialogValidator() {
         this.validatorBundle = new ValidatorBundle();
+        this.commonBundle = new CommonBundle();
     }
 
     public boolean validate()
     {
-        String errorTitle = "Error";
+        String errorTitle = commonBundle.message("common.error");
         String packageName = dialog.getPackageName();
         if (packageName.length() == 0) {
             String errorMessage = validatorBundle.message("validator.notEmpty", "Package Name");

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/NewViewModelValidator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/NewViewModelValidator.java
@@ -5,6 +5,7 @@
 package com.magento.idea.magento2plugin.actions.generation.dialog.validator;
 
 import com.magento.idea.magento2plugin.actions.generation.dialog.NewViewModelDialog;
+import com.magento.idea.magento2plugin.bundles.CommonBundle;
 import com.magento.idea.magento2plugin.util.RegExUtil;
 import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
 
@@ -13,6 +14,7 @@ import javax.swing.*;
 public class NewViewModelValidator {
     private static NewViewModelValidator INSTANCE = null;
     private ValidatorBundle validatorBundle;
+    private CommonBundle commonBundle;
     private NewViewModelDialog dialog;
 
     public static NewViewModelValidator getInstance(NewViewModelDialog dialog) {
@@ -25,11 +27,12 @@ public class NewViewModelValidator {
 
     public NewViewModelValidator() {
         this.validatorBundle = new ValidatorBundle();
+        this.commonBundle = new CommonBundle();
     }
 
     public boolean validate()
     {
-        String errorTitle = "Error";
+        String errorTitle =commonBundle.message("common.error");
 
         String moduleName = dialog.getViewModelName();
         if (moduleName.length() == 0) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/NewViewModelValidator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/NewViewModelValidator.java
@@ -32,7 +32,7 @@ public class NewViewModelValidator {
 
     public boolean validate()
     {
-        String errorTitle =commonBundle.message("common.error");
+        String errorTitle = commonBundle.message("common.error");
 
         String moduleName = dialog.getViewModelName();
         if (moduleName.length() == 0) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/OverrideClassByAPreferenceDialogValidator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/OverrideClassByAPreferenceDialogValidator.java
@@ -6,6 +6,7 @@ package com.magento.idea.magento2plugin.actions.generation.dialog.validator;
 
 import com.intellij.openapi.project.Project;
 import com.magento.idea.magento2plugin.actions.generation.dialog.OverrideClassByAPreferenceDialog;
+import com.magento.idea.magento2plugin.bundles.CommonBundle;
 import com.magento.idea.magento2plugin.indexes.ModuleIndex;
 import com.magento.idea.magento2plugin.util.RegExUtil;
 import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
@@ -15,6 +16,7 @@ import java.util.List;
 public class OverrideClassByAPreferenceDialogValidator {
     private static OverrideClassByAPreferenceDialogValidator INSTANCE = null;
     private ValidatorBundle validatorBundle;
+    private CommonBundle commonBundle;
     private OverrideClassByAPreferenceDialog dialog;
 
     public static OverrideClassByAPreferenceDialogValidator getInstance(OverrideClassByAPreferenceDialog dialog) {
@@ -27,11 +29,12 @@ public class OverrideClassByAPreferenceDialogValidator {
 
     public OverrideClassByAPreferenceDialogValidator() {
         validatorBundle = new ValidatorBundle();
+        this.commonBundle = new CommonBundle();
     }
 
     public boolean validate(Project project)
     {
-        String errorTitle = "Error";
+        String errorTitle = commonBundle.message("common.error");
         String preferenceClassName = dialog.getPreferenceClassName();
         if (preferenceClassName.length() == 0) {
             String errorMessage = validatorBundle.message("validator.notEmpty", "Preference Class Name");

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleBlockClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleBlockClassGenerator.java
@@ -18,6 +18,7 @@ import com.magento.idea.magento2plugin.magento.files.PhpPreference;
 import com.magento.idea.magento2plugin.magento.packages.Package;
 import com.magento.idea.magento2plugin.util.GetPhpClassByFQN;
 import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
+import com.magento.idea.magento2plugin.bundles.CommonBundle;
 import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
 import java.util.Properties;
@@ -26,6 +27,7 @@ public class ModuleBlockClassGenerator extends FileGenerator {
     private BlockFileData blockFileData;
     private Project project;
     private ValidatorBundle validatorBundle;
+    private CommonBundle commonBundle;
     private final DirectoryGenerator directoryGenerator;
     private final FileFromTemplateGenerator fileFromTemplateGenerator;
 
@@ -36,10 +38,11 @@ public class ModuleBlockClassGenerator extends FileGenerator {
         this.blockFileData = blockFileData;
         this.project = project;
         this.validatorBundle = new ValidatorBundle();
+        this.commonBundle = new CommonBundle();
     }
 
     public PsiFile generate(String actionName) {
-        String errorTitle = "Error";
+        String errorTitle = commonBundle.message("common.error");
         PhpClass block = GetPhpClassByFQN.getInstance(project).execute(getBlockFqn());
 
         if (block != null) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleGraphQlResolverClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleGraphQlResolverClassGenerator.java
@@ -20,6 +20,7 @@ import com.magento.idea.magento2plugin.actions.generation.data.GraphQlResolverFi
 import com.magento.idea.magento2plugin.actions.generation.generator.util.DirectoryGenerator;
 import com.magento.idea.magento2plugin.actions.generation.generator.util.FileFromTemplateGenerator;
 import com.magento.idea.magento2plugin.actions.generation.util.CodeStyleSettings;
+import com.magento.idea.magento2plugin.bundles.CommonBundle;
 import com.magento.idea.magento2plugin.indexes.ModuleIndex;
 import com.magento.idea.magento2plugin.magento.files.GraphQlResolverPhp;
 import com.magento.idea.magento2plugin.magento.packages.MagentoPhpClass;
@@ -34,6 +35,7 @@ public class ModuleGraphQlResolverClassGenerator extends FileGenerator {
     private GraphQlResolverFileData graphQlResolverFileData;
     private Project project;
     private ValidatorBundle validatorBundle;
+    private CommonBundle commonBundle;
     private final DirectoryGenerator directoryGenerator;
     private final FileFromTemplateGenerator fileFromTemplateGenerator;
     private final GetFirstClassOfFile getFirstClassOfFile;
@@ -46,6 +48,7 @@ public class ModuleGraphQlResolverClassGenerator extends FileGenerator {
         this.graphQlResolverFileData = graphQlResolverFileData;
         this.project = project;
         this.validatorBundle = new ValidatorBundle();
+        this.commonBundle = new CommonBundle();
     }
 
     @Override
@@ -63,7 +66,7 @@ public class ModuleGraphQlResolverClassGenerator extends FileGenerator {
                 JOptionPane.showMessageDialog(
                         null,
                         errorMessage,
-                        "Error",
+                        commonBundle.message("common.error"),
                         JOptionPane.ERROR_MESSAGE
                 );
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleViewModelClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleViewModelClassGenerator.java
@@ -12,6 +12,7 @@ import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.magento.idea.magento2plugin.actions.generation.data.ViewModelFileData;
 import com.magento.idea.magento2plugin.actions.generation.generator.util.DirectoryGenerator;
 import com.magento.idea.magento2plugin.actions.generation.generator.util.FileFromTemplateGenerator;
+import com.magento.idea.magento2plugin.bundles.CommonBundle;
 import com.magento.idea.magento2plugin.indexes.ModuleIndex;
 import com.magento.idea.magento2plugin.magento.files.ViewModelPhp;
 import com.magento.idea.magento2plugin.magento.packages.Package;
@@ -25,6 +26,7 @@ public class ModuleViewModelClassGenerator extends FileGenerator {
     private ViewModelFileData viewModelFileData;
     private Project project;
     private ValidatorBundle validatorBundle;
+    private CommonBundle commonBundle;
     private final DirectoryGenerator directoryGenerator;
     private final FileFromTemplateGenerator fileFromTemplateGenerator;
 
@@ -35,13 +37,16 @@ public class ModuleViewModelClassGenerator extends FileGenerator {
         this.viewModelFileData = viewModelFileData;
         this.project = project;
         this.validatorBundle = new ValidatorBundle();
+        this.commonBundle = new CommonBundle();
     }
 
     public PsiFile generate(String actionName) {
         PhpClass block = GetPhpClassByFQN.getInstance(project).execute(getViewModelFqn());
+        String errorTitle = commonBundle.message("common.error");
+
         if (block != null) {
             String errorMessage = validatorBundle.message("validator.file.alreadyExists", "View Model");
-            JOptionPane.showMessageDialog(null, errorMessage, "Error", JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(null, errorMessage, errorTitle, JOptionPane.ERROR_MESSAGE);
 
             return null;
         }
@@ -49,7 +54,7 @@ public class ModuleViewModelClassGenerator extends FileGenerator {
         PhpFile viewModelFile = createViewModelClass(actionName);
         if (viewModelFile == null) {
             String errorMessage = validatorBundle.message("validator.file.cantBeCreated", "View Model");
-            JOptionPane.showMessageDialog(null, errorMessage, "Error", JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(null, errorMessage, errorTitle, JOptionPane.ERROR_MESSAGE);
 
             return null;
         }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ObserverClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ObserverClassGenerator.java
@@ -20,6 +20,7 @@ import com.magento.idea.magento2plugin.actions.generation.data.ObserverFileData;
 import com.magento.idea.magento2plugin.actions.generation.generator.util.DirectoryGenerator;
 import com.magento.idea.magento2plugin.actions.generation.generator.util.FileFromTemplateGenerator;
 import com.magento.idea.magento2plugin.actions.generation.util.CodeStyleSettings;
+import com.magento.idea.magento2plugin.bundles.CommonBundle;
 import com.magento.idea.magento2plugin.indexes.ModuleIndex;
 import com.magento.idea.magento2plugin.magento.files.Observer;
 import com.magento.idea.magento2plugin.magento.packages.MagentoPhpClass;
@@ -36,6 +37,7 @@ public class ObserverClassGenerator extends FileGenerator {
     private ObserverFileData observerFileData;
     private Project project;
     private ValidatorBundle validatorBundle;
+    private CommonBundle commonBundle;
 
     public ObserverClassGenerator(ObserverFileData observerFileData, Project project) {
         super(project);
@@ -46,6 +48,7 @@ public class ObserverClassGenerator extends FileGenerator {
         this.fileFromTemplateGenerator = FileFromTemplateGenerator.getInstance(project);
         this.getFirstClassOfFile = GetFirstClassOfFile.getInstance();
         this.validatorBundle = new ValidatorBundle();
+        this.commonBundle = new CommonBundle();
     }
 
     @Override
@@ -64,7 +67,7 @@ public class ObserverClassGenerator extends FileGenerator {
                 JOptionPane.showMessageDialog(
                         null,
                         errorMessage,
-                        "Error",
+                        commonBundle.message("common.error"),
                         JOptionPane.ERROR_MESSAGE
                 );
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/PluginClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/PluginClassGenerator.java
@@ -29,6 +29,7 @@ import com.magento.idea.magento2plugin.actions.generation.generator.util.FileFro
 import com.magento.idea.magento2plugin.actions.generation.util.CodeStyleSettings;
 import com.magento.idea.magento2plugin.actions.generation.util.CollectInsertedMethods;
 import com.magento.idea.magento2plugin.actions.generation.util.FillTextBufferWithPluginMethods;
+import com.magento.idea.magento2plugin.bundles.CommonBundle;
 import com.magento.idea.magento2plugin.indexes.ModuleIndex;
 import com.magento.idea.magento2plugin.magento.files.Plugin;
 import com.magento.idea.magento2plugin.magento.packages.MagentoPhpClass;
@@ -47,6 +48,7 @@ public class PluginClassGenerator extends FileGenerator {
     private PluginFileData pluginFileData;
     private Project project;
     private ValidatorBundle validatorBundle;
+    private CommonBundle commonBundle;
     private final FillTextBufferWithPluginMethods fillTextBuffer;
     private final CollectInsertedMethods collectInsertedMethods;
     private final DirectoryGenerator directoryGenerator;
@@ -63,6 +65,7 @@ public class PluginClassGenerator extends FileGenerator {
         this.pluginFileData = pluginFileData;
         this.project = project;
         this.validatorBundle = new ValidatorBundle();
+        this.commonBundle = new CommonBundle();
     }
 
     public PsiFile generate(String actionName)
@@ -70,12 +73,13 @@ public class PluginClassGenerator extends FileGenerator {
         final PsiFile[] pluginFile = {null};
         WriteCommandAction.runWriteCommandAction(project, () -> {
             PhpClass pluginClass = GetPhpClassByFQN.getInstance(project).execute(pluginFileData.getPluginFqn());
+            String errorTitle = commonBundle.message("common.error");
             if (pluginClass == null) {
                 pluginClass = createPluginClass(actionName);
             }
             if (pluginClass == null) {
                 String errorMessage = validatorBundle.message("validator.file.cantBeCreated", "Plugin Class");
-                JOptionPane.showMessageDialog(null, errorMessage, "Error", JOptionPane.ERROR_MESSAGE);
+                JOptionPane.showMessageDialog(null, errorMessage, errorTitle, JOptionPane.ERROR_MESSAGE);
 
                 return;
             }
@@ -88,7 +92,7 @@ public class PluginClassGenerator extends FileGenerator {
             PluginMethodData[] pluginMethodData = pluginGenerator.createPluginMethods(getPluginType());
             if (checkIfMethodExist(pluginClass, pluginMethodData)) {
                 String errorMessage = validatorBundle.message("validator.file.alreadyExists", "Plugin Class");
-                JOptionPane.showMessageDialog(null, errorMessage, "Error", JOptionPane.ERROR_MESSAGE);
+                JOptionPane.showMessageDialog(null, errorMessage, errorTitle, JOptionPane.ERROR_MESSAGE);
 
                 return;
             }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/PreferenceClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/PreferenceClassGenerator.java
@@ -12,6 +12,7 @@ import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.magento.idea.magento2plugin.actions.generation.data.PreferenceFileData;
 import com.magento.idea.magento2plugin.actions.generation.generator.util.DirectoryGenerator;
 import com.magento.idea.magento2plugin.actions.generation.generator.util.FileFromTemplateGenerator;
+import com.magento.idea.magento2plugin.bundles.CommonBundle;
 import com.magento.idea.magento2plugin.indexes.ModuleIndex;
 import com.magento.idea.magento2plugin.magento.files.PhpPreference;
 import com.magento.idea.magento2plugin.util.GetFirstClassOfFile;
@@ -25,6 +26,7 @@ public class PreferenceClassGenerator extends FileGenerator {
     private PreferenceFileData preferenceFileData;
     private Project project;
     private ValidatorBundle validatorBundle;
+    private CommonBundle commonBundle;
     private final DirectoryGenerator directoryGenerator;
     private final FileFromTemplateGenerator fileFromTemplateGenerator;
     private final GetFirstClassOfFile getFirstClassOfFile;
@@ -37,6 +39,7 @@ public class PreferenceClassGenerator extends FileGenerator {
         this.preferenceFileData = preferenceFileData;
         this.project = project;
         this.validatorBundle = new ValidatorBundle();
+        this.commonBundle = new CommonBundle();
     }
 
     public PsiFile generate(String actionName) {
@@ -48,7 +51,7 @@ public class PreferenceClassGenerator extends FileGenerator {
 
         if (pluginClass == null) {
             String errorMessage = validatorBundle.message("validator.file.cantBeCreated", "Preference Class");
-            JOptionPane.showMessageDialog(null, errorMessage, "Error", JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(null, errorMessage, commonBundle.message("common.error"), JOptionPane.ERROR_MESSAGE);
 
             return null;
         }

--- a/src/com/magento/idea/magento2plugin/bundles/CommonBundle.java
+++ b/src/com/magento/idea/magento2plugin/bundles/CommonBundle.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.bundles;
+
+public class CommonBundle extends AbstractBundle {
+    protected final String BUNDLE_NAME = "magento2.common";
+
+    public String getBundleName() {
+        return BUNDLE_NAME;
+    }
+}

--- a/src/com/magento/idea/magento2plugin/inspections/xml/CacheableFalseInDefaultLayoutInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/xml/CacheableFalseInDefaultLayoutInspection.java
@@ -10,17 +10,18 @@ import com.intellij.codeInspection.XmlSuppressableInspectionTool;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.XmlElementVisitor;
 import com.intellij.psi.xml.XmlAttribute;
+import com.magento.idea.magento2plugin.bundles.InspectionBundle;
 import com.magento.idea.magento2plugin.inspections.xml.fix.XmlRemoveCacheableAttributeQuickFix;
 import com.magento.idea.magento2plugin.magento.files.LayoutXml;
 import org.jetbrains.annotations.NotNull;
 
 public class CacheableFalseInDefaultLayoutInspection extends XmlSuppressableInspectionTool {
-    public static final String CacheDisableProblemDescription = "Cacheable false attribute on the default layout will disable cache site-wide";
-
     @NotNull
     @Override
     public PsiElementVisitor buildVisitor(final @NotNull ProblemsHolder holder, final boolean isOnTheFly) {
         return new XmlElementVisitor() {
+            private InspectionBundle inspectionBundle = new InspectionBundle();
+
             @Override
             public void visitXmlAttribute(XmlAttribute attribute) {
                 String fileName = holder.getFile().getName();
@@ -32,9 +33,12 @@ public class CacheableFalseInDefaultLayoutInspection extends XmlSuppressableInsp
                 && !attribute.getParent().getName().equals(LayoutXml.REFERENCE_BLOCK_ATTRIBUTE_TAG_NAME)) return;
                 if (text == null) return;
                 if (text.equals(LayoutXml.CACHEABLE_ATTRIBUTE_VALUE_FALSE)) {
-                    holder.registerProblem(attribute, CacheDisableProblemDescription,
-                            ProblemHighlightType.WARNING,
-                            new XmlRemoveCacheableAttributeQuickFix());
+                    holder.registerProblem(
+                        attribute,
+                        inspectionBundle.message("inspection.cache.disabledCache"),
+                        ProblemHighlightType.WARNING,
+                        new XmlRemoveCacheableAttributeQuickFix()
+                    );
                 }
             }
         };

--- a/src/com/magento/idea/magento2plugin/inspections/xml/ObserverDeclarationInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/xml/ObserverDeclarationInspection.java
@@ -17,6 +17,7 @@ import com.intellij.psi.xml.XmlAttributeValue;
 import com.intellij.psi.xml.XmlDocument;
 import com.intellij.psi.xml.XmlTag;
 import com.jetbrains.php.lang.inspections.PhpInspection;
+import com.magento.idea.magento2plugin.bundles.InspectionBundle;
 import com.magento.idea.magento2plugin.indexes.EventIndex;
 import com.magento.idea.magento2plugin.magento.files.ModuleXml;
 import com.magento.idea.magento2plugin.magento.packages.Package;
@@ -36,10 +37,8 @@ public class ObserverDeclarationInspection extends PhpInspection {
         return new XmlElementVisitor() {
             private final String moduleXmlFileName = ModuleXml.getInstance().getFileName();
             private static final String eventsXmlFileName = "events.xml";
-            private static final String duplicatedObserverNameSameFileProblemDescription = "The observer name already used in this file. For more details see Inspection Description.";
-            private static final String duplicatedObserverNameProblemDescription =
-                    "The observer name \"%s\" for event \"%s\" is already used in the module \"%s\" (%s scope). For more details see Inspection Description.";
             private HashMap<String, VirtualFile> loadedFileHash = new HashMap<>();
+            private InspectionBundle inspectionBundle = new InspectionBundle();
             private final ProblemHighlightType errorSeverity = ProblemHighlightType.WARNING;
 
             @Override
@@ -88,7 +87,7 @@ public class ObserverDeclarationInspection extends PhpInspection {
                         if (targetObserversHash.containsKey(observerKey)) {
                             problemsHolder.registerProblem(
                                 observerNameAttribute.getValueElement(),
-                                duplicatedObserverNameSameFileProblemDescription,
+                                inspectionBundle.message("inspection.observer.duplicateInSameFile"),
                                 errorSeverity
                             );
                         }
@@ -104,7 +103,7 @@ public class ObserverDeclarationInspection extends PhpInspection {
                                 problemsHolder.registerProblem(
                                     observerNameAttribute.getValueElement(),
                                     String.format(
-                                        duplicatedObserverNameProblemDescription,
+                                        inspectionBundle.message("inspection.observer.duplicateInOtherPlaces"),
                                         observerName,
                                         eventNameAttributeValue,
                                         moduleName,

--- a/src/com/magento/idea/magento2plugin/inspections/xml/ObserverDeclarationInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/xml/ObserverDeclarationInspection.java
@@ -102,8 +102,8 @@ public class ObserverDeclarationInspection extends PhpInspection {
                             if (!eventProblems.containsKey(problemKey)){
                                 problemsHolder.registerProblem(
                                     observerNameAttribute.getValueElement(),
-                                    String.format(
-                                        inspectionBundle.message("inspection.observer.duplicateInOtherPlaces"),
+                                    inspectionBundle.message(
+                                        "inspection.observer.duplicateInOtherPlaces",
                                         observerName,
                                         eventNameAttributeValue,
                                         moduleName,


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR extracts the static text to separate bundles, that will cleanup the hardcoded phrases.

 - [x] Error popup title
 - [x] Inspections
 - [x] Dialogs
### Fixed Issues (if relevant)

1. magento/magento2-phpstorm-plugin#149: Extracting the static text to separated message bundles.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Existing Problems

We aren't able to use message bundling into static methods.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages

