### PR TITLE
Fixing the positioning of all Dialogs on the center screen

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/AbstractDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/AbstractDialog.java
@@ -11,9 +11,11 @@ import java.awt.*;
  * All code generate dialog should extend this class
  */
 public abstract class AbstractDialog extends JDialog {
-    protected void pushToMiddle() {
-        Dimension dim = Toolkit.getDefaultToolkit().getScreenSize();
-        this.setLocation(dim.width / 2  -this.getSize().width / 2, dim.height / 2 - this.getSize().height / 2);
+    protected void centerDialog(AbstractDialog dialog) {
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        int x = screenSize.width / 2  - dialog.getSize().width / 2;
+        int y = screenSize.height / 2 - dialog.getSize().height / 2;
+        dialog.setLocation(x, y);
     }
 
     protected void onCancel() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAPluginDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAPluginDialog.java
@@ -58,7 +58,6 @@ public class CreateAPluginDialog extends AbstractDialog {
         setContentPane(contentPane);
         setModal(true);
         getRootPane().setDefaultButton(buttonOK);
-        pushToMiddle();
         fillPluginTypeOptions();
         fillTargetAreaOptions();
 
@@ -158,6 +157,7 @@ public class CreateAPluginDialog extends AbstractDialog {
     public static void open(@NotNull Project project, Method targetMethod, PhpClass targetClass) {
         CreateAPluginDialog dialog = new CreateAPluginDialog(project, targetMethod, targetClass);
         dialog.pack();
+        dialog.centerDialog(dialog);
         dialog.setVisible(true);
     }
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAnObserverDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAnObserverDialog.java
@@ -49,7 +49,6 @@ public class CreateAnObserverDialog extends AbstractDialog {
         setContentPane(contentPane);
         setModal(true);
         getRootPane().setDefaultButton(buttonOK);
-        pushToMiddle();
         fillTargetAreaOptions();
 
         buttonOK.addActionListener(new ActionListener() {
@@ -131,6 +130,7 @@ public class CreateAnObserverDialog extends AbstractDialog {
     public static void open(@NotNull Project project, String targetEvent) {
         CreateAnObserverDialog dialog = new CreateAnObserverDialog(project, targetEvent);
         dialog.pack();
+        dialog.centerDialog(dialog);
         dialog.setVisible(true);
     }
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewBlockDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewBlockDialog.java
@@ -43,7 +43,6 @@ public class NewBlockDialog extends AbstractDialog {
         setModal(true);
         setTitle("Create a new Magento 2 block..");
         getRootPane().setDefaultButton(buttonOK);
-        pushToMiddle();
         suggestBlockDirectory();
 
         buttonOK.addActionListener(new ActionListener() {
@@ -77,6 +76,7 @@ public class NewBlockDialog extends AbstractDialog {
     public static void open(Project project, PsiDirectory directory) {
         NewBlockDialog dialog = new NewBlockDialog(project, directory);
         dialog.pack();
+        dialog.centerDialog(dialog);
         dialog.setVisible(true);
     }
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCronjobDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCronjobDialog.java
@@ -55,7 +55,6 @@ public class NewCronjobDialog extends AbstractDialog {
         setModal(true);
         getRootPane().setDefaultButton(buttonOK);
         setTitle("Create a new Magento 2 cronjob..");
-        pushToMiddle();
 
         buttonOK.addActionListener(e -> onOK());
         buttonCancel.addActionListener(e -> onCancel());
@@ -119,8 +118,8 @@ public class NewCronjobDialog extends AbstractDialog {
 
     public static void open(Project project, PsiDirectory directory) {
         NewCronjobDialog dialog = new NewCronjobDialog(project, directory);
-
         dialog.pack();
+        dialog.centerDialog(dialog);
         dialog.setVisible(true);
     }
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewGraphQlResolverDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewGraphQlResolverDialog.java
@@ -41,7 +41,6 @@ public class NewGraphQlResolverDialog extends AbstractDialog {
         setModal(true);
         setTitle("Create a new Magento 2 GraphQL Resolver.");
         getRootPane().setDefaultButton(buttonOK);
-        pushToMiddle();
         suggestGraphQlResolverDirectory();
 
         buttonOK.addActionListener(new ActionListener() {
@@ -75,6 +74,7 @@ public class NewGraphQlResolverDialog extends AbstractDialog {
     public static void open(Project project, PsiDirectory directory) {
         NewGraphQlResolverDialog dialog = new NewGraphQlResolverDialog(project, directory);
         dialog.pack();
+        dialog.centerDialog(dialog);
         dialog.setVisible(true);
     }
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModuleDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModuleDialog.java
@@ -96,7 +96,6 @@ public class NewModuleDialog extends AbstractDialog implements ListSelectionList
         setContentPane(contentPane);
         setModal(true);
         getRootPane().setDefaultButton(buttonOK);
-        pushToMiddle();
         setLicenses();
         setModuleDependencies();
 
@@ -233,6 +232,7 @@ public class NewModuleDialog extends AbstractDialog implements ListSelectionList
     public static void open(@NotNull Project project, @NotNull PsiDirectory initialBaseDir, @Nullable PsiFile file, @Nullable IdeView view, @Nullable Editor editor) {
         NewModuleDialog dialog = new NewModuleDialog(project, initialBaseDir, file, view, editor);
         dialog.pack();
+        dialog.centerDialog(dialog);
         dialog.setVisible(true);
     }
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewViewModelDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewViewModelDialog.java
@@ -41,7 +41,6 @@ public class NewViewModelDialog extends AbstractDialog {
         setModal(true);
         setTitle("Create a new Magento 2 View Model.");
         getRootPane().setDefaultButton(buttonOK);
-        pushToMiddle();
         suggestViewModelDirectory();
 
         buttonOK.addActionListener(new ActionListener() {
@@ -75,6 +74,7 @@ public class NewViewModelDialog extends AbstractDialog {
     public static void open(Project project, PsiDirectory directory) {
         NewViewModelDialog dialog = new NewViewModelDialog(project, directory);
         dialog.pack();
+        dialog.centerDialog(dialog);
         dialog.setVisible(true);
     }
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideClassByAPreferenceDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideClassByAPreferenceDialog.java
@@ -57,7 +57,6 @@ public class OverrideClassByAPreferenceDialog extends AbstractDialog {
         setContentPane(contentPane);
         setModal(true);
         getRootPane().setDefaultButton(buttonOK);
-        pushToMiddle();
         fillTargetAreaOptions();
         if (targetClass.isFinal()) {
             inheritClass.setVisible(false);
@@ -173,6 +172,7 @@ public class OverrideClassByAPreferenceDialog extends AbstractDialog {
     public static void open(@NotNull Project project, PhpClass targetClass) {
         OverrideClassByAPreferenceDialog dialog = new OverrideClassByAPreferenceDialog(project, targetClass);
         dialog.pack();
+        dialog.centerDialog(dialog);
         dialog.setVisible(true);
     }
 


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description** (*)
This PR fixes the positioning for all the dialogs on the center screen. Currently, all the Dialogs are wrong positioned, because of the wrong calculated position based on width/height of the Dialog.

**Fixed Issues (if relevant)**
N/A

1. Open any dialog (Create a New Module/New Plugin/Observer/etc)
2. The Dialog should be perfectly positioned on the center of the screen

**Questions or comments**
And again we have to find a workaround to work with `static` methods.

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
