### PR TITLE
Fix for CreateAPluginAction accessible from the wrong context

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/CreateAPluginAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/CreateAPluginAction.java
@@ -44,15 +44,15 @@ public class CreateAPluginAction extends DumbAwareAction {
             Pair<PsiFile, PhpClass> pair = this.findPhpClass(event);
             PsiFile psiFile = pair.getFirst();
             PhpClass phpClass = pair.getSecond();
-            if (phpClass == null || psiFile == null) {
+         if ((phpClass == null || psiFile == null)
+            || !(psiFile instanceof PhpFile) 
+            || phpClass.isFinal() 
+            || this.targetMethod == null
+            ) {
                 this.setStatus(event, false);
                 return;
             }
             targetClass = phpClass;
-            if (!(psiFile instanceof PhpFile) || phpClass.isFinal() || this.targetMethod == null) {
-                this.setStatus(event, false);
-                return;
-            }
             this.setStatus(event, true);
             return;
         }

--- a/src/com/magento/idea/magento2plugin/actions/generation/CreateAPluginAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/CreateAPluginAction.java
@@ -45,6 +45,7 @@ public class CreateAPluginAction extends DumbAwareAction {
             PsiFile psiFile = pair.getFirst();
             PhpClass phpClass = pair.getSecond();
             if (phpClass == null || psiFile == null) {
+                this.setStatus(event, false);
                 return;
             }
             targetClass = phpClass;
@@ -52,11 +53,11 @@ public class CreateAPluginAction extends DumbAwareAction {
                 this.setStatus(event, false);
                 return;
             }
-        } else {
-            this.setStatus(event, false);
+            this.setStatus(event, true);
             return;
         }
-        this.setStatus(event, true);
+
+        this.setStatus(event, false);
     }
 
     private void setStatus(AnActionEvent event, boolean status) {


### PR DESCRIPTION
**Description** (*)
This PR fixes issue CreateAPluginAction accessible from the wrong context. 

*For example*, it was accessible from right-clicking on the js file ⛔:
![image](https://user-images.githubusercontent.com/20116393/80487753-f991b700-8965-11ea-8b9b-405de6c167da.png)

*Now* it is accessible only for right-clicking on class public method ✅:
![image](https://user-images.githubusercontent.com/20116393/80487813-13cb9500-8966-11ea-820e-957c99c60238.png)

**Contribution checklist** (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
