### PR TITLE
Covered referenceContainer related functionality by tests

### DIFF
--- a/gradle-tasks/pmd/ruleset.xml
+++ b/gradle-tasks/pmd/ruleset.xml
@@ -13,8 +13,12 @@
     <description>
         Magento PhpStorm rules
     </description>
-    <rule ref="category/java/bestpractices.xml" />
-    <rule ref="category/java/codestyle.xml"/>
+    <rule ref="category/java/bestpractices.xml">
+        <exclude name="JUnit4TestShouldUseTestAnnotation"/>
+    </rule>
+    <rule ref="category/java/codestyle.xml">
+        <exclude name="AtLeastOneConstructor" />
+    </rule>
     <rule ref="category/java/design.xml">
         <exclude name="LawOfDemeter"/>
     </rule>

--- a/testData/completion/xml/LayoutContainerCompletionRegistrar/referenceContainerMustHaveCompletion/default.xml
+++ b/testData/completion/xml/LayoutContainerCompletionRegistrar/referenceContainerMustHaveCompletion/default.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="test_index_index<caret>"/>
+    </body>
+</page>

--- a/testData/project/magento2/vendor/magento/module-catalog/view/frontend/layout/test_index_index.xml
+++ b/testData/project/magento2/vendor/magento/module-catalog/view/frontend/layout/test_index_index.xml
@@ -2,9 +2,11 @@
 
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="after.body.start">
+        <container name="test_index_index_container">
             <block name="test_index_index_block" />
+        </container>
+        <container name="test_index_index_container2">
             <block name="test_index_index_block2" />
-        </referenceContainer>
+        </container>
     </body>
 </page>

--- a/testData/reference/xml/LayoutContainerReferenceRegistrar/referenceContainerMustHaveReference/default.xml
+++ b/testData/reference/xml/LayoutContainerReferenceRegistrar/referenceContainerMustHaveReference/default.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="test_index_index_container2<caret>">
+        </referenceContainer>
+    </body>
+</page>

--- a/tests/com/magento/idea/magento2plugin/completion/xml/LayoutContainerCompletionRegistrarTest.java
+++ b/tests/com/magento/idea/magento2plugin/completion/xml/LayoutContainerCompletionRegistrarTest.java
@@ -18,9 +18,9 @@ public class LayoutContainerCompletionRegistrarTest extends CompletionXmlFixture
         myFixture.configureByFile(filePath);
 
         assertCompletionContains(
-            filePath,
-            "test_index_index_container",
-            "test_index_index_container2"
+                filePath,
+                "test_index_index_container",
+                "test_index_index_container2"
         );
     }
 }

--- a/tests/com/magento/idea/magento2plugin/completion/xml/LayoutContainerCompletionRegistrarTest.java
+++ b/tests/com/magento/idea/magento2plugin/completion/xml/LayoutContainerCompletionRegistrarTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.completion.xml;
+
+import com.magento.idea.magento2plugin.magento.files.LayoutXml;
+
+public class LayoutContainerCompletionRegistrarTest extends CompletionXmlFixtureTestCase {
+
+    /**
+     * The `name` attribute of the `referenceContainer` tag in layout XML must
+     * have completion based on `name` attribute of `container` tags
+     */
+    public void testReferenceContainerMustHaveCompletion() {
+        final String filePath = this.getFixturePath(LayoutXml.DEFAULT_FILENAME);
+        myFixture.configureByFile(filePath);
+
+        assertCompletionContains(
+            filePath,
+            "test_index_index_container",
+            "test_index_index_container2"
+        );
+    }
+}

--- a/tests/com/magento/idea/magento2plugin/completion/xml/LayoutContainerCompletionRegistrarTest.java
+++ b/tests/com/magento/idea/magento2plugin/completion/xml/LayoutContainerCompletionRegistrarTest.java
@@ -11,7 +11,7 @@ public class LayoutContainerCompletionRegistrarTest extends CompletionXmlFixture
 
     /**
      * The `name` attribute of the `referenceContainer` tag in layout XML must
-     * have completion based on `name` attribute of `container` tags
+     * have completion based on `name` attribute of `container` tags.
      */
     public void testReferenceContainerMustHaveCompletion() {
         final String filePath = this.getFixturePath(LayoutXml.DEFAULT_FILENAME);

--- a/tests/com/magento/idea/magento2plugin/reference/xml/LayoutContainerReferenceRegistrarTest.java
+++ b/tests/com/magento/idea/magento2plugin/reference/xml/LayoutContainerReferenceRegistrarTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.reference.xml;
+
+import com.magento.idea.magento2plugin.magento.files.LayoutXml;
+
+public class LayoutContainerReferenceRegistrarTest extends ReferenceXmlFixtureTestCase {
+
+    /**
+     * The `name` attribute of the `referenceContainer` tag in layout XML must
+     * have reference to the `name` attribute of `container` tag
+     */
+    public void testReferenceContainerMustHaveReference() {
+        final String filePath = this.getFixturePath(LayoutXml.DEFAULT_FILENAME);
+        myFixture.configureByFile(filePath);
+
+        assertHasReferenceToXmlTag("container");
+    }
+}

--- a/tests/com/magento/idea/magento2plugin/reference/xml/LayoutContainerReferenceRegistrarTest.java
+++ b/tests/com/magento/idea/magento2plugin/reference/xml/LayoutContainerReferenceRegistrarTest.java
@@ -11,7 +11,7 @@ public class LayoutContainerReferenceRegistrarTest extends ReferenceXmlFixtureTe
 
     /**
      * The `name` attribute of the `referenceContainer` tag in layout XML must
-     * have reference to the `name` attribute of `container` tag
+     * have reference to the `name` attribute of `container` tag.
      */
     public void testReferenceContainerMustHaveReference() {
         final String filePath = this.getFixturePath(LayoutXml.DEFAULT_FILENAME);


### PR DESCRIPTION
**Description** (*)
This PR covers `referenceContainer` in layout XML completion and reference by tests.

Also I've disabled redundant checks:
`JUnit4TestShouldUseTestAnnotation` -  disabled because we are using JUnit3;
`AtLeastOneConstructor` - have to be suppressed in tests all the time, and I see no reason for such check. If a constructor is needed it will be declared either way, otherwise, the code won't work :)

