### PR TITLE
FIX: adjust Magento version validation RegExp

### DIFF
--- a/src/com/magento/idea/magento2plugin/util/RegExUtil.java
+++ b/src/com/magento/idea/magento2plugin/util/RegExUtil.java
@@ -26,7 +26,7 @@ public class RegExUtil {
             = "^(?!\\/)[a-zA-Z0-9\\/]*[^\\/]$";
 
     public static final String MAGENTO_VERSION
-            = "(\\d+)\\.(\\d+)\\.(\\d+)";
+            = "(\\d+)\\.(\\d+)\\.(\\d+)[a-zA-Z0-9_\\-]*";
 
     public static class Magento {
         public static final String MODULE_NAME


### PR DESCRIPTION
**Description** (*)
The latest releases of Magento 2 can have a version like `2.3.5-p1` This PR provides an update for the version validation RegExp.

**Fixed Issues (if relevant)**
Steps to reproduce: Set the `Magento version` to 2.3.5-p1 and try to activate the Apply button at the Magento 2 PHPStorm plugin settings. For example, click on enable/disable plugin checkbox.

Result will be 
![image](https://user-images.githubusercontent.com/5318512/81100281-f6259f00-8f14-11ea-8c5e-c38d990ec022.png)


**Questions or comments**
N/A

**Contribution checklist** (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with integration/functional tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
