### PR TITLE
Improving the plugin's arguments inspection

### DIFF
--- a/src/com/magento/idea/magento2plugin/inspections/php/PluginInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/php/PluginInspection.java
@@ -175,7 +175,11 @@ public class PluginInspection extends PhpInspection {
                 int index = 0;
                 for (final Parameter pluginMethodParameter : pluginMethodParameters) {
                     index++;
-                    final String declaredType = pluginMethodParameter.getDeclaredType().toString();
+                    String declaredType = pluginMethodParameter.getDeclaredType().toString();
+
+                    if (declaredType.isEmpty()) {
+                        declaredType = pluginMethodParameter.getDocType().toString();
+                    }
 
                     if (index == 1) { //NOPMD
                         final String targetClassFqn = Package.fqnSeparator.concat(targetClassName);
@@ -283,9 +287,8 @@ public class PluginInspection extends PhpInspection {
                     final String targetMethodParameterDeclaredType =
                             targetMethodParameter.getDeclaredType().toString();
 
-                    if (!checkTypeIncompatibility(
-                            targetMethodParameterDeclaredType,
-                            declaredType)
+                    if (!checkTypeIncompatibility(targetMethodParameterDeclaredType, declaredType)
+                            && !pluginMethodParameter.getText().contains("...$")
                     ) {
                         problemsHolder.registerProblem(
                                 pluginMethodParameter,


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description** (*)

This PR improves the inspection for plugin's arguments, which gives the possibility to use variadic (...) arguments. It also improves the inspection by additionally checking the argument's doctype if none is declared.

```php
/**
 * @param Model $subject
 * @param callable $proceed
 * @param int $param
 */
public function aroundExecute(Model $subject, callable $proceed, $param)
{
    return $proceed();
}
```

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2-phpstorm-plugin#271: Plugin declaration inspection is not supporting variadic arguments.

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with integration/functional tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
