### PR TITLE
306: Added highlighting in error style to JComponent elements

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/AbstractDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/AbstractDialog.java
@@ -5,6 +5,7 @@
 
 package com.magento.idea.magento2plugin.actions.generation.dialog;
 
+import com.magento.idea.magento2plugin.actions.generation.dialog.util.HighlightDialogFieldOnErrorUtil;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.annotation.FieldValidation;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.annotation.FieldValidations;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.ValidationRule;
@@ -74,6 +75,7 @@ public abstract class AbstractDialog extends JDialog {
                     if (errorMessageFieldValidationRuleMap.containsKey(field)
                             && errorMessageFieldValidationRuleMap.get(field).containsKey(rule)) {
                         showErrorMessage(errorMessageFieldValidationRuleMap.get(field).get(rule));
+                        highlightFieldWithErrorStyle(field);
                     }
                     return false;
                 }
@@ -185,5 +187,18 @@ public abstract class AbstractDialog extends JDialog {
             return ((JComboBox) field).getSelectedItem().toString();
         }
         return null;
+    }
+
+    /**
+     * Highlight field with error style.
+     *
+     * @param field Object
+     */
+    private void highlightFieldWithErrorStyle(final Object field) {
+        if (field instanceof JTextField) {
+            HighlightDialogFieldOnErrorUtil.execute((JTextField) field);
+        } else if (field instanceof JComboBox) {
+            HighlightDialogFieldOnErrorUtil.execute((JComboBox) field);
+        }
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/util/HighlightDialogFieldOnErrorUtil.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/util/HighlightDialogFieldOnErrorUtil.java
@@ -1,0 +1,37 @@
+package com.magento.idea.magento2plugin.actions.generation.dialog.util;
+
+import java.awt.Color;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import javax.swing.BorderFactory;
+import javax.swing.JComponent;
+
+public final class HighlightDialogFieldOnErrorUtil {
+    private static final Color ERROR_BORDER_COLOR = new Color(252, 119, 83);
+    private static final Color ERROR_BACKGROUND_COLOR = new Color(252, 119, 83, 15);
+
+    private HighlightDialogFieldOnErrorUtil() {}
+
+    /**
+     * Add error highlighting for JComponent.
+     *
+     * @param field JComponent
+     */
+    public static void execute(final JComponent field) {
+        final Color defaultBackgroundColor = field.getBackground();
+
+        field.setBorder(BorderFactory.createLineBorder(ERROR_BORDER_COLOR));
+        field.setBackground(ERROR_BACKGROUND_COLOR);
+
+        field.addFocusListener(new FocusListener() {
+            @Override
+            public void focusGained(final FocusEvent event) {
+                field.setBorder(null);
+                field.setBackground(defaultBackgroundColor);
+            }
+
+            @Override
+            public void focusLost(FocusEvent e) {}//NOPMD
+        });
+    }
+}


### PR DESCRIPTION
**Description (*)**
This PR adds error highlighting to validation through annotations. Related issue: #306 

**Here is the result of errors highlighting:**
![image](https://user-images.githubusercontent.com/31848341/95655927-67e0c500-0b13-11eb-88ec-8a2a23760260.png)

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
