### PR TITLE
Fixed validator when plugin is disabled

### DIFF
--- a/src/com/magento/idea/magento2plugin/project/SettingsForm.form
+++ b/src/com/magento/idea/magento2plugin/project/SettingsForm.form
@@ -80,7 +80,7 @@
             </constraints>
             <properties>
               <horizontalAlignment value="0"/>
-              <text value="Regenerate URN mappings:"/>
+              <text value="Regenerate URN mappings"/>
             </properties>
           </component>
           <component id="aad3b" class="javax.swing.JTextField" binding="magentoVersion">

--- a/src/com/magento/idea/magento2plugin/project/validator/SettingsFormValidator.java
+++ b/src/com/magento/idea/magento2plugin/project/validator/SettingsFormValidator.java
@@ -24,7 +24,7 @@ public class SettingsFormValidator {
     }
 
     /**
-     * Validates form if plugin is enabled
+     * Validates form if plugin is enabled.
      *
      * @throws ConfigurationException Exception
      */

--- a/src/com/magento/idea/magento2plugin/project/validator/SettingsFormValidator.java
+++ b/src/com/magento/idea/magento2plugin/project/validator/SettingsFormValidator.java
@@ -24,33 +24,31 @@ public class SettingsFormValidator {
     }
 
     /**
-     * Validate form.
+     * Validates form if plugin is enabled
      *
      * @throws ConfigurationException Exception
      */
     public void validate() throws ConfigurationException {
-        if (!form.getSettings().pluginEnabled) {
-            return;
-        }
+        if (form.isBeingUsed()) {
+            if (!MagentoBasePathUtil.isMagentoFolderValid(form.getMagentoPath())) {
+                throw new ConfigurationException(
+                        validatorBundle.message("validator.package.validPath")
+                );
+            }
 
-        if (!MagentoBasePathUtil.isMagentoFolderValid(form.getMagentoPath())) {
-            throw new ConfigurationException(
-                    validatorBundle.message("validator.package.validPath")
-            );
-        }
+            final String magentoVersion = form.getMagentoVersion();
+            if (magentoVersion.length() == 0) {
+                throw new ConfigurationException(
+                        validatorBundle.message("validator.notEmpty", "Magento Version")
+                );
+            }
 
-        final String magentoVersion = form.getMagentoVersion();
-        if (magentoVersion.length() == 0) {
-            throw new ConfigurationException(
-                    validatorBundle.message("validator.notEmpty", "Magento Version")
-            );
-        }
-
-        if (!magentoVersion.matches(RegExUtil.MAGENTO_VERSION)
-                && !magentoVersion.equals(MagentoVersionUtil.DEFAULT_VERSION)) {
-            throw new ConfigurationException(
-                    validatorBundle.message("validator.magentoVersionInvalid")
-            );
+            if (!magentoVersion.matches(RegExUtil.MAGENTO_VERSION)
+                    && !magentoVersion.equals(MagentoVersionUtil.DEFAULT_VERSION)) {
+                throw new ConfigurationException(
+                        validatorBundle.message("validator.magentoVersionInvalid")
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
**Description**

This PR fixes the a bug present while saving the plugin settings. 

In, the `com.magento.idea.magento2plugin.project.validator.SettingsFormValidator#validate` method, `SettingsForm.getSettings()` method is used to check if plugin is enabled. While this works, this returns only the saved values and not the current values of the form. `SettingsForm.isBeingUsed()` on the other hand, returns the current value of the checkbox for plugin enablement. Please go through the below steps to better understand the flow. 

**Steps to reproduce bug**

1.  Open IntelliJ with plugin installed and navigate to the plugin settings
2.  Check the plugin enable checkbox and enter valid values for Magento path.
3.  Save. (this is successful)
4.  Uncheck the plugin enable checkbox and remove the value in Magento path field
5.  Save. (this is unsuccessful)

**Actual result**

Error is thrown as Magento path field is validated even though the checkbox is unchecked

**Expected result**

Able to save successfully with empty Magento path field as plugin enable checkbox is unchecked

**Additional changes**

-  Removed an extra colon introduced by previous PR
-  Added a better method description annotation
-  Refactored method with better structure to conditionals

**Contribution checklist**
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with integration/functional tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
