### PR TITLE
Added form field status to reflect plugin status

### DIFF
--- a/src/com/magento/idea/magento2plugin/project/SettingsForm.java
+++ b/src/com/magento/idea/magento2plugin/project/SettingsForm.java
@@ -77,12 +77,12 @@ public class SettingsForm implements PhpFrameworkConfigurable {
                 }
         );
 
-        buttonReindex.setEnabled(getSettings().pluginEnabled);
-        regenerateUrnMapButton.setEnabled(getSettings().pluginEnabled);
-
         regenerateUrnMapButton.addMouseListener(
                 new RegenerateUrnMapListener(project)
         );
+
+        refreshFormStatus(getSettings().pluginEnabled);
+        pluginEnabled.addActionListener(e -> refreshFormStatus(pluginEnabled.isSelected()));
 
         moduleDefaultLicenseName.setText(getSettings().defaultLicense);
         mftfSupportEnabled.setSelected(getSettings().mftfSupportEnabled);
@@ -93,6 +93,15 @@ public class SettingsForm implements PhpFrameworkConfigurable {
         addMagentoVersionListener();
 
         return (JComponent) panel;
+    }
+
+    private void refreshFormStatus(boolean isEnabled) {
+        buttonReindex.setEnabled(isEnabled);
+        regenerateUrnMapButton.setEnabled(isEnabled);
+        magentoVersion.setEnabled(isEnabled);
+        mftfSupportEnabled.setEnabled(isEnabled);
+        magentoPath.setEnabled(isEnabled);
+        moduleDefaultLicenseName.setEnabled(isEnabled);
     }
 
     protected void reindex() {

--- a/src/com/magento/idea/magento2plugin/project/SettingsForm.java
+++ b/src/com/magento/idea/magento2plugin/project/SettingsForm.java
@@ -33,8 +33,11 @@ import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+@SuppressWarnings({
+        "PMD.TooManyFields",
+        "PMD.TooManyMethods"
+})
 public class SettingsForm implements PhpFrameworkConfigurable {
-
     private final Project project;
     private JCheckBox pluginEnabled;
     private JButton buttonReindex;
@@ -95,7 +98,7 @@ public class SettingsForm implements PhpFrameworkConfigurable {
         return (JComponent) panel;
     }
 
-    private void refreshFormStatus(boolean isEnabled) {
+    private void refreshFormStatus(final boolean isEnabled) {
         buttonReindex.setEnabled(isEnabled);
         regenerateUrnMapButton.setEnabled(isEnabled);
         magentoVersion.setEnabled(isEnabled);


### PR DESCRIPTION
**Description** 

This PR fixes the inconsistency while enabling/disabling this plugin in the settings. When a plugin is disabled, all its related fields must be disabled. Having it enabled at all times confuses the user, from a UX point of view. This PR hence disables and enables all the related fields dynamically on settings page open event, and on change event of the plugin status checkbox.

**Contribution checklist**
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with integration/functional tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
