### PR TITLE
Fixed new module action

### DIFF
--- a/src/com/magento/idea/magento2plugin/util/magento/MagentoVersionUtil.java
+++ b/src/com/magento/idea/magento2plugin/util/magento/MagentoVersionUtil.java
@@ -80,6 +80,9 @@ public final class MagentoVersionUtil {
      *         the value {@code false} if the argument version1 is less than to version2.
      */
     public static boolean compare(final String version1, final String version2) {
+        if (version1.equals(DEFAULT_VERSION)) {
+            return true;
+        }
         if (version1.equals(version2)) {
             return true;
         }


### PR DESCRIPTION
**Description** (*)
New module action is broken with error:
```
ava.lang.NumberFormatException: For input string: "any"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.base/java.lang.Integer.parseInt(Integer.java:652)
	at java.base/java.lang.Integer.parseInt(Integer.java:770)
	at com.magento.idea.magento2plugin.util.magento.MagentoVersionUtil.compare(MagentoVersionUtil.java:90)
	at com.magento.idea.magento2plugin.actions.generation.dialog.NewModuleDial
```

It happens if the Magento version is set to `any` in configs.
This PR fixes the issue.

**Contribution checklist** (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with integration/functional tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
