### PR TITLE
Fixed disabling plugin on a startup when Magento not in the root

### DIFF
--- a/src/com/magento/idea/magento2plugin/project/startup/CheckIfMagentoPathIsValidActivity.java
+++ b/src/com/magento/idea/magento2plugin/project/startup/CheckIfMagentoPathIsValidActivity.java
@@ -18,7 +18,7 @@ public class CheckIfMagentoPathIsValidActivity implements StartupActivity {
     public void runActivity(final @NotNull Project project) {
         final Settings settings = Settings.getInstance(project);
         final String path = settings.magentoPath;
-        if (settings.pluginEnabled || path == null || path.isEmpty()) {
+        if (settings.pluginEnabled && (path == null || path.isEmpty())) {
             if (MagentoBasePathUtil.isMagentoFolderValid(project.getBasePath())) {
                 settings.setMagentoPath(project.getBasePath());
                 return;


### PR DESCRIPTION


**Description** (*)
Fixed issue with constant disabling on startup when Magento not in the root.

**Fixed Issues (if relevant)**
1. magento/magento2-phpstorm-plugin#342: Plugin automatically disables after PhpStorm restart



**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
