### PR TITLE
Added BoxNotEmptyRule to validators

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAPluginDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAPluginDialog.java
@@ -13,6 +13,7 @@ import com.magento.idea.magento2plugin.actions.generation.data.PluginDiXmlData;
 import com.magento.idea.magento2plugin.actions.generation.data.PluginFileData;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.annotation.FieldValidation;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.annotation.RuleRegistry;
+import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.BoxNotEmptyRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.DirectoryRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.IdentifierRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.NotEmptyRule;
@@ -65,6 +66,8 @@ public class CreateAPluginDialog extends AbstractDialog {
 
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
             message = {NotEmptyRule.MESSAGE, TARGET_MODULE})
+    @FieldValidation(rule = RuleRegistry.BOX_NOT_EMPTY,
+            message = {BoxNotEmptyRule.MESSAGE, TARGET_MODULE})
     private FilteredComboBox pluginModule;
 
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAnObserverDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAnObserverDialog.java
@@ -13,6 +13,7 @@ import com.magento.idea.magento2plugin.actions.generation.data.ObserverFileData;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.annotation.FieldValidation;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.annotation.RuleRegistry;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.AlphanumericWithUnderscoreRule;
+import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.BoxNotEmptyRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.DirectoryRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.NotEmptyRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.PhpClassRule;
@@ -63,6 +64,8 @@ public class CreateAnObserverDialog extends AbstractDialog {
 
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
             message = {NotEmptyRule.MESSAGE, OBSERVER_MODULE})
+    @FieldValidation(rule = RuleRegistry.BOX_NOT_EMPTY,
+            message = {BoxNotEmptyRule.MESSAGE, OBSERVER_MODULE})
     private FilteredComboBox observerModule;
 
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideClassByAPreferenceDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideClassByAPreferenceDialog.java
@@ -14,6 +14,7 @@ import com.magento.idea.magento2plugin.actions.generation.data.PreferenceDiXmFil
 import com.magento.idea.magento2plugin.actions.generation.data.PreferenceFileData;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.annotation.FieldValidation;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.annotation.RuleRegistry;
+import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.BoxNotEmptyRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.DirectoryRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.NotEmptyRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.PhpClassRule;
@@ -65,6 +66,8 @@ public class OverrideClassByAPreferenceDialog extends AbstractDialog { //NOPMD
 
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
             message = {NotEmptyRule.MESSAGE, MODULE})
+    @FieldValidation(rule = RuleRegistry.BOX_NOT_EMPTY,
+            message = {BoxNotEmptyRule.MESSAGE, MODULE})
     private FilteredComboBox preferenceModule;
 
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,


### PR DESCRIPTION
**Description** 

Added BoxNotEmptyRule to validators where original verbose validations were removed

**Fixed Issues (if relevant)**

1. Fixes magento/magento2-phpstorm-plugin#322: Implement module name validation in 'Create a plugin' and 'New module' dialog

**Questions**

How do we handle the issue raised at https://github.com/magento/magento2-phpstorm-plugin/pull/318#discussion_r508719248?

**Contribution checklist**
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with integration/functional tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
