### PR TITLE
Allow theme override of non-magento composer themes

### DIFF
--- a/src/com/magento/idea/magento2plugin/indexes/ModuleIndex.java
+++ b/src/com/magento/idea/magento2plugin/indexes/ModuleIndex.java
@@ -53,7 +53,7 @@ public final class ModuleIndex {
     }
 
     public List<String> getEditableThemeNames() {
-        return getThemeNames("/" + Package.vendor + "/|/tests/|/test/", true);
+        return getThemeNames("/" + Package.vendor + "/magento/|/tests/|/test/", true);
     }
 
     public List<String> getModuleNames() {


### PR DESCRIPTION
**Description** (*)

This commit adjusts the editable theme filter to only exclued composer
themes in `vendor/magento`. All other themes installed via composer will
appear in the theme list when using the "Override this template in a
project theme" action.

**Fixed Issues (if relevant)**

1. Fixes magento/magento2-phpstorm-plugin#64

**Questions or comments**

@VitaliyBoyko This resolves the feedback resulting in the reopening of #64, though I'm not sure it is a desirable feature. This change will add non-magento themes in `vendor` to the list of editable themes when using the override in theme action, but this already works for themes installed via composer locally if the local package exists within the project root directory. For example if you are installing a theme via `path` using symlinks as done in the example screenshot below prior to making this change.

![image](https://user-images.githubusercontent.com/12674247/97912649-17781400-1d1b-11eb-9c5e-478ee75a51ad.png)

The above is my personal preference for developing composer packages locally (pretty much verbatim following the Jisse's recommendation found here for anyone googling how to develop magento 2 composer packages locally https://www.yireo.com/blog/2019-05-10-local-composer-development-with-magento2) and this works with the existing implementation. I do know plenty of developers who will install a package via composer and replace the package contents when developing locally, this change would benefit developers using this workflow.

**Contribution checklist** (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with integration/functional tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
