### PR TITLE
Backport #386 Allow theme override of non-magento composer themes

### DIFF
--- a/src/com/magento/idea/magento2plugin/indexes/ModuleIndex.java
+++ b/src/com/magento/idea/magento2plugin/indexes/ModuleIndex.java
@@ -53,7 +53,7 @@ public final class ModuleIndex {
     }
 
     public List<String> getEditableThemeNames() {
-        return getThemeNames("/" + Package.vendor + "/|/tests/|/test/", true);
+        return getThemeNames("/" + Package.vendor + "/magento/|/tests/|/test/", true);
     }
 
     public List<String> getModuleNames() {


### PR DESCRIPTION
**Description** (*)
**Backport #386**

This commit adjusts the editable theme filter to only exclued composer
themes in `vendor/magento`. All other themes installed via composer will
appear in the theme list when using the "Override this template in a
project theme" action.

**Fixed Issues (if relevant)**

1. Fixes magento/magento2-phpstorm-plugin#64

**Contribution checklist** (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with integration/functional tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
