### PR TITLE
Added XML reference for disabled plugins

### DIFF
--- a/src/com/magento/idea/magento2plugin/reference/provider/PluginReferenceProvider.java
+++ b/src/com/magento/idea/magento2plugin/reference/provider/PluginReferenceProvider.java
@@ -12,6 +12,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.PsiReferenceProvider;
 import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.xml.XmlAttribute;
 import com.intellij.psi.xml.XmlTag;
 import com.intellij.util.ProcessingContext;
 import com.magento.idea.magento2plugin.indexes.PluginIndex;
@@ -47,9 +48,9 @@ public class PluginReferenceProvider extends PsiReferenceProvider {
             final XmlTag typeTag = (XmlTag) type.getParent().getParent();
             final XmlTag[] pluginTags = typeTag.findSubTags("plugin");
             for (final XmlTag pluginTag: pluginTags) {
-                final String pluginName = pluginTag.getAttribute("name").getValue();
-                if (pluginName.equals(originalPluginName)) {
-                    psiElements.add(pluginTag);
+                final XmlAttribute pluginNameAttribute = pluginTag.getAttribute("name");
+                if (pluginNameAttribute.getValue().equals(originalPluginName)) {
+                    psiElements.add(pluginNameAttribute.getValueElement());
                 }
             }
         }

--- a/src/com/magento/idea/magento2plugin/reference/provider/PluginReferenceProvider.java
+++ b/src/com/magento/idea/magento2plugin/reference/provider/PluginReferenceProvider.java
@@ -16,17 +16,16 @@ import com.intellij.psi.xml.XmlTag;
 import com.intellij.util.ProcessingContext;
 import com.magento.idea.magento2plugin.indexes.PluginIndex;
 import com.magento.idea.magento2plugin.reference.xml.PolyVariantReferenceBase;
-import org.jetbrains.annotations.NotNull;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import org.jetbrains.annotations.NotNull;
 
 public class PluginReferenceProvider extends PsiReferenceProvider {
     @Override
     public @NotNull PsiReference[] getReferencesByElement(
-        @NotNull final PsiElement element,
-        @NotNull final ProcessingContext context
+            @NotNull final PsiElement element,
+            @NotNull final ProcessingContext context
     ) {
         final List<PsiReference> psiReferences = new ArrayList<>();
         final Project project = element.getProject();
@@ -38,10 +37,10 @@ public class PluginReferenceProvider extends PsiReferenceProvider {
         final String originalTypeName = originalTypeTag.getAttribute("name").getValue();
 
         final Collection<PsiElement> types = PluginIndex.getInstance(project).getPluginElements(
-            originalTypeName,
-            GlobalSearchScope.getScopeRestrictedByFileTypes(
-                GlobalSearchScope.allScope(project), XmlFileType.INSTANCE
-            )
+                originalTypeName,
+                GlobalSearchScope.getScopeRestrictedByFileTypes(
+                        GlobalSearchScope.allScope(project), XmlFileType.INSTANCE
+                )
         );
 
         for (final PsiElement type: types) {

--- a/src/com/magento/idea/magento2plugin/reference/provider/PluginReferenceProvider.java
+++ b/src/com/magento/idea/magento2plugin/reference/provider/PluginReferenceProvider.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.reference.provider;
+
+import com.intellij.ide.highlighter.XmlFileType;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.PsiReferenceProvider;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.xml.XmlTag;
+import com.intellij.util.ProcessingContext;
+import com.magento.idea.magento2plugin.indexes.PluginIndex;
+import com.magento.idea.magento2plugin.reference.xml.PolyVariantReferenceBase;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class PluginReferenceProvider extends PsiReferenceProvider {
+    @Override
+    public @NotNull PsiReference[] getReferencesByElement(
+        @NotNull final PsiElement element,
+        @NotNull final ProcessingContext context
+    ) {
+        final List<PsiReference> psiReferences = new ArrayList<>();
+        final Project project = element.getProject();
+        final List<PsiElement> psiElements = new ArrayList<>();
+
+        final XmlTag originalPluginTag = (XmlTag) element.getParent().getParent();
+        final XmlTag originalTypeTag = originalPluginTag.getParentTag();
+        final String originalPluginName = originalPluginTag.getAttribute("name").getValue();
+        final String originalTypeName = originalTypeTag.getAttribute("name").getValue();
+
+        final Collection<PsiElement> types = PluginIndex.getInstance(project).getPluginElements(
+            originalTypeName,
+            GlobalSearchScope.getScopeRestrictedByFileTypes(
+                GlobalSearchScope.allScope(project), XmlFileType.INSTANCE
+            )
+        );
+
+        for (final PsiElement type: types) {
+            final XmlTag typeTag = (XmlTag) type.getParent().getParent();
+            final XmlTag[] pluginTags = typeTag.findSubTags("plugin");
+            for (final XmlTag pluginTag: pluginTags) {
+                final String pluginName = pluginTag.getAttribute("name").getValue();
+                if (pluginName.equals(originalPluginName)) {
+                    psiElements.add(pluginTag);
+                }
+            }
+        }
+
+        if (!psiElements.isEmpty()) {
+            final int startIndex = element.getText().indexOf(originalPluginName);
+            final int endIndex = startIndex + originalPluginName.length();
+            final TextRange range = new TextRange(startIndex, endIndex);
+            psiReferences.add(new PolyVariantReferenceBase(element, range, psiElements));
+        }
+
+        return psiReferences.toArray(new PsiReference[0]);
+    }
+}

--- a/src/com/magento/idea/magento2plugin/reference/xml/XmlReferenceContributor.java
+++ b/src/com/magento/idea/magento2plugin/reference/xml/XmlReferenceContributor.java
@@ -369,6 +369,18 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
             new TableColumnNamesReferenceProvider()
         );
 
+        // <plugin name="pluginName" disabled="true" /> in di.xml
+        registrar.registerReferenceProvider(
+            XmlPatterns.xmlAttributeValue().withParent(
+                XmlPatterns.xmlAttribute().withName("name").withParent(
+                    XmlPatterns.xmlTag().withName("plugin").withChild(
+                        XmlPatterns.xmlAttribute().withName("disabled")
+                    )
+                )
+            ).inFile(xmlFile().withName(string().endsWith("di.xml"))),
+            new PluginReferenceProvider()
+        );
+
         registerReferenceForDifferentNesting(registrar);
     }
 

--- a/testData/reference/xml/DisabledPluginReferenceRegistrar/disabledPluginNameMustHaveReference/di.xml
+++ b/testData/reference/xml/DisabledPluginReferenceRegistrar/disabledPluginNameMustHaveReference/di.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Theme\Block\Html\Topmenu">
+        <plugin name="catalogTopmenu<caret>" disabled="true"/>
+    </type>
+</config>

--- a/tests/com/magento/idea/magento2plugin/reference/xml/DisabledPluginReferenceRegistrarTest.java
+++ b/tests/com/magento/idea/magento2plugin/reference/xml/DisabledPluginReferenceRegistrarTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.reference.xml;
+
+import com.magento.idea.magento2plugin.magento.files.ModuleDiXml;
+
+public class DisabledPluginReferenceRegistrarTest extends ReferenceXmlFixtureTestCase {
+
+    /**
+     * Tests for disabled plugin name reference to original definition.
+     */
+    public void testDisabledPluginNameMustHaveReference() {
+        myFixture.configureByFile(this.getFixturePath(ModuleDiXml.FILE_NAME));
+
+        assertHasReferenceToXmlAttributeValue("catalogTopmenu");
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description**

Added reference for disabled plugins through the plugin name.

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#146: Reference navigation. Reference: disabled plugin declaration -> plugin declaration

**Contribution checklist**
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with integration/functional tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
