### PR TITLE
Added completion and reference for module names in config.php with tests

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -100,6 +100,7 @@
         <projectService serviceImplementation="com.magento.idea.magento2plugin.project.Settings"/>
 
         <completion.contributor language="XML" implementationClass="com.magento.idea.magento2plugin.completion.xml.XmlCompletionContributor" id="xml" />
+        <completion.contributor language="PHP" implementationClass="com.magento.idea.magento2plugin.completion.php.PhpCompletionContributor" id="php" />
 
         <psi.referenceContributor language="XML" implementation="com.magento.idea.magento2plugin.reference.xml.XmlReferenceContributor"/>
         <psi.referenceContributor language="PHP" implementation="com.magento.idea.magento2plugin.reference.php.PhpReferenceContributor"/>

--- a/src/com/magento/idea/magento2plugin/completion/php/PhpCompletionContributor.java
+++ b/src/com/magento/idea/magento2plugin/completion/php/PhpCompletionContributor.java
@@ -8,10 +8,16 @@ package com.magento.idea.magento2plugin.completion.php;
 import com.intellij.codeInsight.completion.CompletionContributor;
 import com.intellij.codeInsight.completion.CompletionType;
 import com.magento.idea.magento2plugin.completion.provider.ModuleNameCompletionProvider;
+import com.magento.idea.magento2plugin.util.php.PhpPatternsHelper;
 
-import static com.magento.idea.magento2plugin.util.php.PhpPatternsHelper.CONFIGPHP_COMPLETION;
-
+@SuppressWarnings({
+        "PMD.CallSuperInConstructor",
+})
 public class PhpCompletionContributor extends CompletionContributor {
+
+    /**
+     * Constructor.
+     */
     public PhpCompletionContributor() {
         /*
           'modules' => [
@@ -19,9 +25,9 @@ public class PhpCompletionContributor extends CompletionContributor {
           ]
          */
         extend(
-            CompletionType.BASIC,
-            CONFIGPHP_COMPLETION,
-            new ModuleNameCompletionProvider()
+                CompletionType.BASIC,
+                PhpPatternsHelper.CONFIGPHP_COMPLETION,
+                new ModuleNameCompletionProvider()
         );
     }
 }

--- a/src/com/magento/idea/magento2plugin/completion/php/PhpCompletionContributor.java
+++ b/src/com/magento/idea/magento2plugin/completion/php/PhpCompletionContributor.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.completion.php;
+
+import com.intellij.codeInsight.completion.CompletionContributor;
+import com.intellij.codeInsight.completion.CompletionType;
+import com.magento.idea.magento2plugin.completion.provider.ModuleNameCompletionProvider;
+
+import static com.magento.idea.magento2plugin.util.php.PhpPatternsHelper.CONFIGPHP_COMPLETION;
+
+public class PhpCompletionContributor extends CompletionContributor {
+    public PhpCompletionContributor() {
+        /*
+          'modules' => [
+            'Vendor_Module' => 1
+          ]
+         */
+        extend(
+            CompletionType.BASIC,
+            CONFIGPHP_COMPLETION,
+            new ModuleNameCompletionProvider()
+        );
+    }
+}

--- a/src/com/magento/idea/magento2plugin/reference/php/PhpReferenceContributor.java
+++ b/src/com/magento/idea/magento2plugin/reference/php/PhpReferenceContributor.java
@@ -2,21 +2,33 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 package com.magento.idea.magento2plugin.reference.php;
 
 import com.intellij.psi.PsiReferenceContributor;
 import com.intellij.psi.PsiReferenceRegistrar;
+import com.magento.idea.magento2plugin.reference.provider.ModuleNameReferenceProvider;
 import com.magento.idea.magento2plugin.util.php.PhpPatternsHelper;
 import com.magento.idea.magento2plugin.reference.provider.EventDispatchReferenceProvider;
 import org.jetbrains.annotations.NotNull;
 
 public class PhpReferenceContributor extends PsiReferenceContributor {
     @Override
-    public void registerReferenceProviders(@NotNull PsiReferenceRegistrar registrar) {
+    public void registerReferenceProviders(@NotNull final PsiReferenceRegistrar registrar) {
         // ->dispatch("event_name")
         registrar.registerReferenceProvider(
                 PhpPatternsHelper.STRING_METHOD_ARGUMENT,
                 new EventDispatchReferenceProvider()
+        );
+
+        /*
+          'modules' => [
+            'Vendor_Module' => 1
+          ]
+         */
+        registrar.registerReferenceProvider(
+            PhpPatternsHelper.CONFIGPHP_MODULENAME,
+            new ModuleNameReferenceProvider()
         );
     }
 }

--- a/src/com/magento/idea/magento2plugin/reference/php/PhpReferenceContributor.java
+++ b/src/com/magento/idea/magento2plugin/reference/php/PhpReferenceContributor.java
@@ -7,9 +7,9 @@ package com.magento.idea.magento2plugin.reference.php;
 
 import com.intellij.psi.PsiReferenceContributor;
 import com.intellij.psi.PsiReferenceRegistrar;
+import com.magento.idea.magento2plugin.reference.provider.EventDispatchReferenceProvider;
 import com.magento.idea.magento2plugin.reference.provider.ModuleNameReferenceProvider;
 import com.magento.idea.magento2plugin.util.php.PhpPatternsHelper;
-import com.magento.idea.magento2plugin.reference.provider.EventDispatchReferenceProvider;
 import org.jetbrains.annotations.NotNull;
 
 public class PhpReferenceContributor extends PsiReferenceContributor {
@@ -27,8 +27,8 @@ public class PhpReferenceContributor extends PsiReferenceContributor {
           ]
          */
         registrar.registerReferenceProvider(
-            PhpPatternsHelper.CONFIGPHP_MODULENAME,
-            new ModuleNameReferenceProvider()
+                PhpPatternsHelper.CONFIGPHP_MODULENAME,
+                new ModuleNameReferenceProvider()
         );
     }
 }

--- a/src/com/magento/idea/magento2plugin/util/php/PhpPatternsHelper.java
+++ b/src/com/magento/idea/magento2plugin/util/php/PhpPatternsHelper.java
@@ -2,14 +2,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 package com.magento.idea.magento2plugin.util.php;
 
 import com.intellij.patterns.ElementPattern;
 import com.intellij.patterns.PlatformPatterns;
 import com.intellij.psi.PsiElement;
 import com.jetbrains.php.lang.PhpLanguage;
+import com.jetbrains.php.lang.lexer.PhpTokenTypes;
 import com.jetbrains.php.lang.patterns.PhpPatterns;
+import com.jetbrains.php.lang.psi.elements.ArrayHashElement;
 import com.jetbrains.php.lang.psi.elements.ParameterList;
+import com.jetbrains.php.lang.psi.elements.PhpPsiElement;
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+
+import static com.intellij.patterns.StandardPatterns.string;
 
 public class PhpPatternsHelper {
     public static final ElementPattern<? extends PsiElement> STRING_METHOD_ARGUMENT =
@@ -23,4 +30,24 @@ public class PhpPatternsHelper {
                             .phpFunctionReference()
                     )
             ).withLanguage(PhpLanguage.INSTANCE);
+
+    public static final ElementPattern<? extends PsiElement> CONFIGPHP_MODULENAME =
+        PlatformPatterns.psiElement(StringLiteralExpression.class)
+            .withSuperParent(5,PlatformPatterns.psiElement(ArrayHashElement.class)
+                .withChild(PlatformPatterns.psiElement(PhpPsiElement.class)
+                    .withChild(PlatformPatterns.psiElement(StringLiteralExpression.class)
+                        .withText(string().contains("modules").withLength(9))
+                    )
+                )
+            );
+
+    public static final ElementPattern<? extends PsiElement> CONFIGPHP_COMPLETION =
+        PlatformPatterns.psiElement(PhpTokenTypes.STRING_LITERAL_SINGLE_QUOTE)
+            .withSuperParent(6, PlatformPatterns.psiElement(ArrayHashElement.class)
+                .withChild(PlatformPatterns.psiElement(PhpPsiElement.class)
+                    .withChild(PlatformPatterns.psiElement(StringLiteralExpression.class)
+                        .withText(string().contains("modules").withLength(9))
+                    )
+                )
+            );
 }

--- a/src/com/magento/idea/magento2plugin/util/php/PhpPatternsHelper.java
+++ b/src/com/magento/idea/magento2plugin/util/php/PhpPatternsHelper.java
@@ -7,6 +7,7 @@ package com.magento.idea.magento2plugin.util.php;
 
 import com.intellij.patterns.ElementPattern;
 import com.intellij.patterns.PlatformPatterns;
+import com.intellij.patterns.StandardPatterns;
 import com.intellij.psi.PsiElement;
 import com.jetbrains.php.lang.PhpLanguage;
 import com.jetbrains.php.lang.lexer.PhpTokenTypes;
@@ -16,38 +17,36 @@ import com.jetbrains.php.lang.psi.elements.ParameterList;
 import com.jetbrains.php.lang.psi.elements.PhpPsiElement;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
 
-import static com.intellij.patterns.StandardPatterns.string;
-
 public class PhpPatternsHelper {
     public static final ElementPattern<? extends PsiElement> STRING_METHOD_ARGUMENT =
-        PhpPatterns
-            .phpLiteralExpression()
-            .withParent(
-                PlatformPatterns
-                    .psiElement(ParameterList.class)
-                    .withParent(
-                        PhpPatterns
-                            .phpFunctionReference()
-                    )
-            ).withLanguage(PhpLanguage.INSTANCE);
+            PhpPatterns
+                .phpLiteralExpression()
+                .withParent(
+                    PlatformPatterns
+                        .psiElement(ParameterList.class)
+                        .withParent(
+                            PhpPatterns
+                                .phpFunctionReference()
+                        )
+                ).withLanguage(PhpLanguage.INSTANCE);
 
     public static final ElementPattern<? extends PsiElement> CONFIGPHP_MODULENAME =
-        PlatformPatterns.psiElement(StringLiteralExpression.class)
-            .withSuperParent(5,PlatformPatterns.psiElement(ArrayHashElement.class)
-                .withChild(PlatformPatterns.psiElement(PhpPsiElement.class)
-                    .withChild(PlatformPatterns.psiElement(StringLiteralExpression.class)
-                        .withText(string().contains("modules").withLength(9))
+            PlatformPatterns.psiElement(StringLiteralExpression.class)
+                .withSuperParent(5,PlatformPatterns.psiElement(ArrayHashElement.class)
+                    .withChild(PlatformPatterns.psiElement(PhpPsiElement.class)
+                        .withChild(PlatformPatterns.psiElement(StringLiteralExpression.class)
+                            .withText(StandardPatterns.string().contains("modules").withLength(9))
+                        )
                     )
-                )
-            );
+                );
 
     public static final ElementPattern<? extends PsiElement> CONFIGPHP_COMPLETION =
-        PlatformPatterns.psiElement(PhpTokenTypes.STRING_LITERAL_SINGLE_QUOTE)
-            .withSuperParent(6, PlatformPatterns.psiElement(ArrayHashElement.class)
-                .withChild(PlatformPatterns.psiElement(PhpPsiElement.class)
-                    .withChild(PlatformPatterns.psiElement(StringLiteralExpression.class)
-                        .withText(string().contains("modules").withLength(9))
+            PlatformPatterns.psiElement(PhpTokenTypes.STRING_LITERAL_SINGLE_QUOTE)
+                .withSuperParent(6, PlatformPatterns.psiElement(ArrayHashElement.class)
+                    .withChild(PlatformPatterns.psiElement(PhpPsiElement.class)
+                        .withChild(PlatformPatterns.psiElement(StringLiteralExpression.class)
+                            .withText(StandardPatterns.string().contains("modules").withLength(9))
+                        )
                     )
-                )
-            );
+                );
 }

--- a/testData/completion/php/ConfigPhpModuleCompletionRegistrar/moduleNameMustHaveCompletion/config.php
+++ b/testData/completion/php/ConfigPhpModuleCompletionRegistrar/moduleNameMustHaveCompletion/config.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+return [
+    'modules' => [
+        'Magento_C<caret>' => 1
+    ]
+];

--- a/testData/completion/php/ConfigPhpModuleCompletionRegistrar/moduleNameMustNotHaveCompletion/config.php
+++ b/testData/completion/php/ConfigPhpModuleCompletionRegistrar/moduleNameMustNotHaveCompletion/config.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+return [
+    'moduless' => [
+        'Magento_C<caret>' => 1
+    ]
+];

--- a/testData/reference/php/ConfigPhpModuleReferenceRegistrar/moduleNameMustHaveReference/config.php
+++ b/testData/reference/php/ConfigPhpModuleReferenceRegistrar/moduleNameMustHaveReference/config.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+return [
+    'modules' => [
+        'Magento_Catalog<caret>' => 1
+    ]
+];

--- a/testData/reference/php/ConfigPhpModuleReferenceRegistrar/moduleNameMustNotHaveReference/config.php
+++ b/testData/reference/php/ConfigPhpModuleReferenceRegistrar/moduleNameMustNotHaveReference/config.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+return [
+    'moduless' => [
+        'Magento_Catalog<caret>' => 1
+    ]
+];

--- a/tests/com/magento/idea/magento2plugin/completion/BaseCompletionTestCase.java
+++ b/tests/com/magento/idea/magento2plugin/completion/BaseCompletionTestCase.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.completion;
+
+import com.magento.idea.magento2plugin.BaseProjectTestCase;
+import com.magento.idea.magento2plugin.magento.packages.File;
+import java.util.Arrays;
+import java.util.List;
+
+abstract public class BaseCompletionTestCase extends BaseProjectTestCase {
+    private static final String MESSAGE_NO_LOOKUP = "No lookup element was provided";
+    private final String testDataFolderPath
+            = "testData" + File.separator + "completion" + File.separator;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        myFixture.setTestDataPath(testDataFolderPath);
+    }
+
+    private void configureFixture(final String filePath) {
+        myFixture.configureByFile(filePath);
+        myFixture.completeBasic();
+    }
+
+    public void assertCompletionContains(final String filePath, final String... lookupStrings) {
+        configureFixture(filePath);
+
+        final String messageEmptyLookup = "Failed that completion contains `%s`";
+        final String messageComplationContains = "Failed that completion contains `%s` in `%s`";
+
+        checkContainsCompletion(lookupStrings, messageEmptyLookup, messageComplationContains);
+    }
+
+    protected void assertFileContainsCompletions(
+            final String filePath,
+            final String... lookupStrings
+    ) {
+        configureFixture(filePath);
+
+        final String messageEmptyLookup
+                = "Failed that completion contains `%s` for file " + filePath;
+        final String messageCompletionContains
+                = "Failed that completion contains `%s` in `%s` for file " + filePath;
+
+        checkContainsCompletion(lookupStrings, messageEmptyLookup, messageCompletionContains);
+    }
+
+    protected void assertFileNotContainsCompletions(
+            final String filePath,
+            final String... lookupStrings
+    ) {
+        configureFixture(filePath);
+
+        final String messageEmptyLookup
+                = "Failed that completion does not contain `%s` for file " + filePath;
+        final String messageCompletionNotContains
+                = "Failed that completion does not contain `%s` in `%s` for file " + filePath;
+
+        checkDoesNotContainCompletion(
+                lookupStrings, messageEmptyLookup, messageCompletionNotContains
+        );
+    }
+
+    protected void assertCompletionNotShowing(final String filePath) {
+        configureFixture(filePath);
+
+        final List<String> lookupElements = myFixture.getLookupElementStrings();
+
+        if (lookupElements != null && !lookupElements.isEmpty()) {
+            final String messageCompletionDoesNotShow
+                    = "Failed asserting that completion does not show up";
+
+            fail(messageCompletionDoesNotShow);
+        }
+    }
+
+    protected void checkContainsCompletion(
+            final String[] lookupStrings,
+            final String emptyLookupError,
+            final String completionContainsError
+    ) {
+        if (lookupStrings.length == 0) {
+            fail(MESSAGE_NO_LOOKUP);
+        }
+
+        final List<String> lookupElements = myFixture.getLookupElementStrings();
+
+        if (lookupElements == null || lookupElements.isEmpty()) {
+            fail(String.format(emptyLookupError, Arrays.toString(lookupStrings)));
+        }
+
+        for (final String lookupString : lookupStrings) {
+            if (!lookupElements.contains(lookupString)) {
+                fail(String.format(
+                        completionContainsError, lookupString, lookupElements.toString())
+                );
+            }
+        }
+    }
+
+    protected void checkDoesNotContainCompletion(
+            final String[] lookupStrings,
+            final String emptyLookupError,
+            final String completionDoesNotContainError
+    ) {
+        if (lookupStrings.length == 0) {
+            fail(MESSAGE_NO_LOOKUP);
+        }
+
+        final List<String> lookupElements = myFixture.getLookupElementStrings();
+
+        if (lookupElements == null || lookupElements.isEmpty()) {
+            fail(String.format(emptyLookupError, Arrays.toString(lookupStrings)));
+        }
+
+        for (final String lookupString : lookupStrings) {
+            if (lookupElements.contains(lookupString)) {
+                fail(String.format(
+                        completionDoesNotContainError, lookupString, lookupElements.toString())
+                );
+            }
+        }
+    }
+
+    protected abstract String getFixturePath(String fileName);
+}

--- a/tests/com/magento/idea/magento2plugin/completion/BaseCompletionTestCase.java
+++ b/tests/com/magento/idea/magento2plugin/completion/BaseCompletionTestCase.java
@@ -10,7 +10,7 @@ import com.magento.idea.magento2plugin.magento.packages.File;
 import java.util.Arrays;
 import java.util.List;
 
-abstract public class BaseCompletionTestCase extends BaseProjectTestCase {
+public abstract class BaseCompletionTestCase extends BaseProjectTestCase {
     private static final String MESSAGE_NO_LOOKUP = "No lookup element was provided";
     private final String testDataFolderPath
             = "testData" + File.separator + "completion" + File.separator;
@@ -26,6 +26,9 @@ abstract public class BaseCompletionTestCase extends BaseProjectTestCase {
         myFixture.completeBasic();
     }
 
+    /**
+     * Assert that completion suggestions contains the given lookup strings.
+     */
     public void assertCompletionContains(final String filePath, final String... lookupStrings) {
         configureFixture(filePath);
 
@@ -55,13 +58,11 @@ abstract public class BaseCompletionTestCase extends BaseProjectTestCase {
     ) {
         configureFixture(filePath);
 
-        final String messageEmptyLookup
-                = "Failed that completion does not contain `%s` for file " + filePath;
         final String messageCompletionNotContains
                 = "Failed that completion does not contain `%s` in `%s` for file " + filePath;
 
         checkDoesNotContainCompletion(
-                lookupStrings, messageEmptyLookup, messageCompletionNotContains
+                lookupStrings, messageCompletionNotContains
         );
     }
 
@@ -104,7 +105,6 @@ abstract public class BaseCompletionTestCase extends BaseProjectTestCase {
 
     protected void checkDoesNotContainCompletion(
             final String[] lookupStrings,
-            final String emptyLookupError,
             final String completionDoesNotContainError
     ) {
         if (lookupStrings.length == 0) {
@@ -113,15 +113,13 @@ abstract public class BaseCompletionTestCase extends BaseProjectTestCase {
 
         final List<String> lookupElements = myFixture.getLookupElementStrings();
 
-        if (lookupElements == null || lookupElements.isEmpty()) {
-            fail(String.format(emptyLookupError, Arrays.toString(lookupStrings)));
-        }
-
-        for (final String lookupString : lookupStrings) {
-            if (lookupElements.contains(lookupString)) {
-                fail(String.format(
-                        completionDoesNotContainError, lookupString, lookupElements.toString())
-                );
+        if (lookupElements != null) {
+            for (final String lookupString : lookupStrings) {
+                if (lookupElements.contains(lookupString)) {
+                    fail(String.format(
+                            completionDoesNotContainError, lookupString, lookupElements.toString())
+                    );
+                }
             }
         }
     }

--- a/tests/com/magento/idea/magento2plugin/completion/php/CompletionPhpFixtureTestCase.java
+++ b/tests/com/magento/idea/magento2plugin/completion/php/CompletionPhpFixtureTestCase.java
@@ -3,13 +3,13 @@
  * See COPYING.txt for license details.
  */
 
-package com.magento.idea.magento2plugin.completion.xml;
+package com.magento.idea.magento2plugin.completion.php;
 
 import com.magento.idea.magento2plugin.completion.BaseCompletionTestCase;
 import com.magento.idea.magento2plugin.magento.packages.File;
 
-abstract public class CompletionXmlFixtureTestCase extends BaseCompletionTestCase {
-    private static final String FIXTURES_FOLDER_PATH = "xml" + File.separator;
+abstract public class CompletionPhpFixtureTestCase extends BaseCompletionTestCase {
+    private static final String FIXTURES_FOLDER_PATH = "php" + File.separator;
 
     @Override
     protected String getFixturePath(final String fileName) {

--- a/tests/com/magento/idea/magento2plugin/completion/php/CompletionPhpFixtureTestCase.java
+++ b/tests/com/magento/idea/magento2plugin/completion/php/CompletionPhpFixtureTestCase.java
@@ -8,7 +8,7 @@ package com.magento.idea.magento2plugin.completion.php;
 import com.magento.idea.magento2plugin.completion.BaseCompletionTestCase;
 import com.magento.idea.magento2plugin.magento.packages.File;
 
-abstract public class CompletionPhpFixtureTestCase extends BaseCompletionTestCase {
+public abstract class CompletionPhpFixtureTestCase extends BaseCompletionTestCase {
     private static final String FIXTURES_FOLDER_PATH = "php" + File.separator;
 
     @Override

--- a/tests/com/magento/idea/magento2plugin/completion/php/ConfigPhpModuleCompletionRegistrarTest.java
+++ b/tests/com/magento/idea/magento2plugin/completion/php/ConfigPhpModuleCompletionRegistrarTest.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.completion.php;
+
+public class ConfigPhpModuleCompletionRegistrarTest extends CompletionPhpFixtureTestCase {
+    private static final String[] LOOKUP_MODULE_NAMES = {
+            "Magento_Catalog",
+            "Magento_Config"
+    };
+
+    /**
+     * Tests for module name completion under array key 'modules' in config.php
+     */
+    public void testModuleNameMustHaveCompletion() {
+        final String filePath = this.getFixturePath("config.php");
+        myFixture.copyFileToProject(filePath);
+
+        assertFileContainsCompletions(filePath, LOOKUP_MODULE_NAMES);
+    }
+
+    /**
+     * Tests for no module name completion under a different array key in config.php
+     */
+    public void testModuleNameMustNotHaveCompletion() {
+        final String filePath = this.getFixturePath("config.php");
+        myFixture.copyFileToProject(filePath);
+
+        assertCompletionNotShowing(filePath);
+    }
+}

--- a/tests/com/magento/idea/magento2plugin/completion/xml/CompletionXmlFixtureTestCase.java
+++ b/tests/com/magento/idea/magento2plugin/completion/xml/CompletionXmlFixtureTestCase.java
@@ -8,7 +8,7 @@ package com.magento.idea.magento2plugin.completion.xml;
 import com.magento.idea.magento2plugin.completion.BaseCompletionTestCase;
 import com.magento.idea.magento2plugin.magento.packages.File;
 
-abstract public class CompletionXmlFixtureTestCase extends BaseCompletionTestCase {
+public abstract class CompletionXmlFixtureTestCase extends BaseCompletionTestCase {
     private static final String FIXTURES_FOLDER_PATH = "xml" + File.separator;
 
     @Override

--- a/tests/com/magento/idea/magento2plugin/reference/BaseReferenceTestCase.java
+++ b/tests/com/magento/idea/magento2plugin/reference/BaseReferenceTestCase.java
@@ -128,6 +128,18 @@ public abstract class BaseReferenceTestCase extends BaseInspectionsTestCase {
         fail(String.format(referenceNotFound, directoryName));
     }
 
+    protected void assertHasNoReferenceToDirectory(final String directoryName) {
+        for (final PsiReference psiReference : getElementFromCaret().getReferences()) {
+            final PsiElement resolvedElement = psiReference.resolve();
+            if (resolvedElement instanceof PsiDirectoryImpl
+                    && ((PsiDirectoryImpl) resolvedElement).getName().equals(directoryName)) {
+                final String referenceNotFound
+                        = "Failed that element does not contain reference to the directory `%s`";
+                fail(String.format(referenceNotFound, directoryName));
+            }
+        }
+    }
+
     @SuppressWarnings("PMD")
     protected void assertHasReferencePhpClass(final String phpClassFqn) {
         final PsiElement element = getElementFromCaret();

--- a/tests/com/magento/idea/magento2plugin/reference/php/ConfigPhpModuleReferenceRegistrarTest.java
+++ b/tests/com/magento/idea/magento2plugin/reference/php/ConfigPhpModuleReferenceRegistrarTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.reference.php;
+
+public class ConfigPhpModuleReferenceRegistrarTest extends ReferencePhpFixtureTestCase {
+
+    /**
+     * Tests for module name reference under array key 'modules' in config.php
+     */
+    public void testModuleNameMustHaveReference() {
+        myFixture.configureByFile(this.getFixturePath("config.php"));
+
+        assertHasReferenceToDirectory("module-catalog");
+    }
+
+    /**
+     * Tests for no module name reference under a different array key in config.php
+     */
+    public void testModuleNameMustNotHaveReference() {
+        myFixture.configureByFile(this.getFixturePath("config.php"));
+
+        assertHasNoReferenceToDirectory("module-catalog");
+    }
+}


### PR DESCRIPTION
**Description** 

- Added completion and reference to modules names under the `modules` array in `config.php`
- Added postive/negatives tests for the above
- Added new test assertion `assertHasNoReferenceToDirectory`
- Moved common logic from `completion/xml/CompletionXmlFixtureTestCase.java` to `completion/BaseCompletionTestCase.java` to make it extensible and cleaned up code wherever possible

**Fixed Issues**

- Fixes magento/magento2-phpstorm-plugin#321: Add module names completion and reference in config.php

**Questions**

- The same `ElementPattern` does not work for both completion and reference. Reference seems to work only when using `psiElement(StringLiteralExpression.class)` and completion seems to work only when using the child of the previously mentioned element, `psiElement(PhpTokenTypes.STRING_LITERAL_SINGLE_QUOTE)`. Is there a better way to make this common? 

**Contribution checklist**
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with integration/functional tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
