### PR TITLE
Inspection warning for disabling of an invalid plugin

### DIFF
--- a/resources/magento2/inspection.properties
+++ b/resources/magento2/inspection.properties
@@ -1,5 +1,6 @@
 inspection.plugin.duplicateInSameFile=The plugin name already used in this file. For more details see Inspection Description.
 inspection.plugin.duplicateInOtherPlaces=The plugin name "{0}" for targeted "{1}" class is already used in the module "{2}" ({3} scope). For more details see Inspection Description.
+inspection.plugin.disabledPluginDoesNotExist=This plugin does not exist to be disabled.
 inspection.graphql.resolver.mustImplement=Class must implements any of the following interfaces: \\Magento\\Framework\\GraphQl\\Query\\ResolverInterface, \\Magento\\Framework\\GraphQl\\Query\\Resolver\\BatchResolverInterface, \\Magento\\Framework\\GraphQl\\Query\\Resolver\\BatchServiceContractResolverInterface
 inspection.graphql.resolver.notExist=Resolver class do not exist
 inspection.graphql.resolver.fix.family=Implement Resolver interface

--- a/src/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspection.java
@@ -84,13 +84,7 @@ public class PluginDeclarationInspection extends PhpInspection {
                         final XmlAttribute pluginTypeDisabledAttribute
                                 = pluginTypeXmlTag.getAttribute(ModuleDiXml.DISABLED_ATTR_NAME);
 
-                        if (pluginTypeNameAttribute == null
-                                || (
-                                    pluginTypeDisabledAttribute != null //NOPMD
-                                    && pluginTypeDisabledAttribute.getValue() != null
-                                    && pluginTypeDisabledAttribute.getValue().equals("true")
-                                )
-                        ) {
+                        if (pluginTypeNameAttribute == null) {
                             continue;
                         }
 
@@ -116,6 +110,21 @@ public class PluginDeclarationInspection extends PhpInspection {
                                     pluginIndex,
                                     file
                         );
+
+                        if (pluginTypeDisabledAttribute != null
+                                && pluginTypeDisabledAttribute.getValue() != null
+                                && pluginTypeDisabledAttribute.getValue().equals("true")
+                                && modulesWithSamePluginName.isEmpty()
+                        ) {
+                            problemsHolder.registerProblem(
+                                    pluginTypeNameAttribute.getValueElement(),
+                                    inspectionBundle.message(
+                                            "inspection.plugin.disabledPluginDoesNotExist"
+                                    ),
+                                    errorSeverity
+                            );
+                        }
+
                         for (final Pair<String, String> moduleEntry: modulesWithSamePluginName) {
                             final String scope = moduleEntry.getFirst();
                             final String moduleName = moduleEntry.getSecond();

--- a/src/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspection.java
@@ -61,9 +61,10 @@ public class PluginDeclarationInspection extends PhpInspection {
 
                 final HashMap<String, XmlTag> targetPluginHash = new HashMap<>();
                 final PluginIndex pluginIndex = PluginIndex.getInstance(file.getProject());
+                final HashMap<String, XmlTag> pluginProblems = new HashMap<>();
 
                 for (final XmlTag pluginXmlTag: xmlTags) {
-                    final HashMap<String, XmlTag> pluginProblems = new HashMap<>();
+                    pluginProblems.clear();
                     if (!pluginXmlTag.getName().equals(ModuleDiXml.TYPE_TAG)) {
                         continue;
                     }

--- a/testData/inspections/xml/PluginDeclarationInspection/disabledNonExistingPlugin/di.xml
+++ b/testData/inspections/xml/PluginDeclarationInspection/disabledNonExistingPlugin/di.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config>
+    <type name="Magento\CatalogSearch\Helper\Data">
+        <plugin name=<warning descr="This plugin does not exist to be disabled.">"plugin_which_does_not_exist"</warning> disabled="true" />
+    </type>
+</config>

--- a/tests/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspectionTest.java
+++ b/tests/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspectionTest.java
@@ -36,7 +36,7 @@ public class PluginDeclarationInspectionTest extends InspectionXmlFixtureTestCas
     }
 
     /**
-     * Tests warning for disabling of non-existing plugin
+     * Tests warning for disabling of non-existing plugin.
      */
     public void testDisabledNonExistingPlugin() {
         myFixture.configureByFile(getFixturePath(ModuleDiXml.FILE_NAME));

--- a/tests/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspectionTest.java
+++ b/tests/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspectionTest.java
@@ -36,6 +36,14 @@ public class PluginDeclarationInspectionTest extends InspectionXmlFixtureTestCas
     }
 
     /**
+     * Tests warning for disabling of non-existing plugin
+     */
+    public void testDisabledNonExistingPlugin() {
+        myFixture.configureByFile(getFixturePath(ModuleDiXml.FILE_NAME));
+        myFixture.testHighlighting(true, false, false);
+    }
+
+    /**
      * Tests whenever the duplication warning shows when the plugin name already
      * defined in the same di.xml file
      */


### PR DESCRIPTION
**Description**

This PR adds

- inspection warning for disabling of a plugin which doesn't exist in `di.xml`
- test coverage

**Fixed Issues**

- magento/magento2-phpstorm-plugin#147: Inspection. Disabled plugin declaration

**Contribution checklist**
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with integration/functional tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
