### PR TITLE
Added QuickFix for missing GraphQL resolver

### DIFF
--- a/resources/magento2/inspection.properties
+++ b/resources/magento2/inspection.properties
@@ -5,6 +5,7 @@ inspection.graphql.resolver.mustImplement=Class must implements any of the follo
 inspection.graphql.resolver.notExist=Resolver class do not exist
 inspection.graphql.resolver.fix.family=Implement Resolver interface
 inspection.graphql.resolver.fix.title=Select one of the following interface
+inspection.graphql.schema.resolver.fix.family=Create GraphQL Resolver
 inspection.plugin.error.nonPublicMethod=You can't declare a plugin for a not public method.
 inspection.plugin.error.finalClass=You can't declare a plugin for a final class.
 inspection.plugin.error.finalMethod=You can't declare a plugin for a final method.

--- a/src/com/magento/idea/magento2plugin/inspections/graphqls/SchemaResolverInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/graphqls/SchemaResolverInspection.java
@@ -48,14 +48,14 @@ public class SchemaResolverInspection extends LocalInspectionTool {
                             ),
                             ProblemHighlightType.ERROR,
                             new CreateResolverClassQuickFix());
-                    return;
-                }
-                if (!GraphQlUtil.isResolver(resolverClass)) {
-                    holder.registerProblem(element,
-                        inspectionBundle.message(
-                            "inspection.graphql.resolver.mustImplement"
-                        ),
-                        ProblemHighlightType.ERROR);
+                } else if (!GraphQlUtil.isResolver(resolverClass)) {
+                    holder.registerProblem(
+                            element,
+                            inspectionBundle.message(
+                                    "inspection.graphql.resolver.mustImplement"
+                            ),
+                            ProblemHighlightType.ERROR
+                    );
                 }
             }
         };

--- a/src/com/magento/idea/magento2plugin/inspections/graphqls/SchemaResolverInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/graphqls/SchemaResolverInspection.java
@@ -12,6 +12,7 @@ import com.intellij.lang.jsgraphql.psi.GraphQLValue;
 import com.intellij.lang.jsgraphql.psi.GraphQLVisitor;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.magento.idea.magento2plugin.bundles.InspectionBundle;
+import com.magento.idea.magento2plugin.inspections.graphqls.fix.CreateResolverClassQuickFix;
 import com.magento.idea.magento2plugin.util.GetPhpClassByFQN;
 import com.magento.idea.magento2plugin.util.magento.graphql.GraphQlUtil;
 import org.jetbrains.annotations.NotNull;
@@ -22,24 +23,31 @@ public class SchemaResolverInspection extends LocalInspectionTool {
 
     @NotNull
     @Override
-    public GraphQLVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
+    public GraphQLVisitor buildVisitor(
+            @NotNull final ProblemsHolder holder,
+            final boolean isOnTheFly
+    ) {
         return new GraphQLVisitor() {
             @Override
-            public void visitValue(@NotNull GraphQLValue element) {
-                String getVisitedElementValue = element.getText();
+            public void visitValue(@NotNull final GraphQLValue element) {
+                final String getVisitedElementValue = element.getText();
                 if (getVisitedElementValue == null) {
                     return;
                 }
 
-                String resolverFQN = GraphQlUtil.resolverStringToPhpFQN(getVisitedElementValue);
-                GetPhpClassByFQN getPhpClassByFQN = GetPhpClassByFQN.getInstance(holder.getProject());
-                PhpClass resolverClass = getPhpClassByFQN.execute(resolverFQN);
+                final String resolverFQN
+                        = GraphQlUtil.resolverStringToPhpFQN(getVisitedElementValue);
+                final GetPhpClassByFQN getPhpClassByFQN
+                        = GetPhpClassByFQN.getInstance(holder.getProject());
+                final PhpClass resolverClass = getPhpClassByFQN.execute(resolverFQN);
                 if (resolverClass == null) {
-                    holder.registerProblem(element,
-                        inspectionBundle.message(
-                            "inspection.graphql.resolver.notExist"
-                        ),
-                        ProblemHighlightType.ERROR);
+                    holder.registerProblem(
+                            element,
+                            inspectionBundle.message(
+                                "inspection.graphql.resolver.notExist"
+                            ),
+                            ProblemHighlightType.ERROR,
+                            new CreateResolverClassQuickFix());
                     return;
                 }
                 if (!GraphQlUtil.isResolver(resolverClass)) {

--- a/src/com/magento/idea/magento2plugin/inspections/graphqls/fix/CreateResolverClassQuickFix.java
+++ b/src/com/magento/idea/magento2plugin/inspections/graphqls/fix/CreateResolverClassQuickFix.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.inspections.graphqls.fix;
+
+import com.google.common.base.Strings;
+import com.intellij.codeInspection.LocalQuickFix;
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
+import com.magento.idea.magento2plugin.actions.generation.NewGraphQlResolverAction;
+import com.magento.idea.magento2plugin.actions.generation.data.GraphQlResolverFileData;
+import com.magento.idea.magento2plugin.actions.generation.generator.ModuleGraphQlResolverClassGenerator;
+import com.magento.idea.magento2plugin.bundles.InspectionBundle;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+
+public class CreateResolverClassQuickFix implements LocalQuickFix {
+    @Override
+    public @Nls(capitalization = Nls.Capitalization.Sentence) @NotNull String getFamilyName() {
+        return new InspectionBundle().message(
+                "inspection.graphql.schema.resolver.fix.family"
+        );
+    }
+
+    @Override
+    public void applyFix(
+            @NotNull final Project project,
+            @NotNull final ProblemDescriptor descriptor
+    ) {
+        final String resolverFqn = StringUtil.unquoteString(descriptor.getPsiElement().getText())
+                .replace("\\\\", "\\");
+        final List<String> fqnPartsList
+                = new ArrayList<>(Arrays.asList(resolverFqn.split("\\\\")));
+
+        fqnPartsList.removeIf(Strings::isNullOrEmpty);
+
+        final int endIndex = fqnPartsList.size() - 1;
+        final String moduleName = String.join("_", fqnPartsList.subList(0, 2));
+        final String resolverName = fqnPartsList.get(endIndex);
+        final String directory = fqnPartsList.get(2);
+        final String namespace = String.join("\\", fqnPartsList.subList(0, endIndex));
+
+        final GraphQlResolverFileData graphQlResolverFileData = new GraphQlResolverFileData(
+                directory,
+                resolverName,
+                moduleName,
+                resolverFqn,
+                namespace
+        );
+
+        final ModuleGraphQlResolverClassGenerator generator
+                = new ModuleGraphQlResolverClassGenerator(graphQlResolverFileData, project);
+
+        generator.generate(NewGraphQlResolverAction.ACTION_NAME, true);
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description**

Added QuickFix for mising GraphQL resolver in schema.graphqls file.

**Fixed Issues**

1. Fixes magento/magento2-phpstorm-plugin#217: Add a QuickFix for GraphQL schema inspection

**Contribution checklist**
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with integration/functional tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
