### PR TITLE
#286 Fixed StringIndexOutOfBoundsException on PluginInspection

### DIFF
--- a/src/com/magento/idea/magento2plugin/inspections/php/PluginInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/php/PluginInspection.java
@@ -323,6 +323,9 @@ public class PluginInspection extends PhpInspection {
                 final String pluginMethodName = pluginMethod.getName();
                 final String targetClassMethodName = pluginMethodName
                         .replace(pluginPrefix, "");
+                if (targetClassMethodName.isEmpty()) {
+                    return null;
+                }
                 final char firstCharOfTargetName = targetClassMethodName.charAt(0);
                 final int charType = Character.getType(firstCharOfTargetName);
                 if (charType == Character.LOWERCASE_LETTER) {


### PR DESCRIPTION
**Description** (*)
To reproduce the issue remove the original method name part from the plugin method name e.g
beforeExecute -> before

**Fixed Issues (if relevant)**

-->
1. Fixes magento/magento2-phpstorm-plugin#286

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
