### PR TITLE
Fixed plugin name validator

### DIFF
--- a/resources/magento2/validation.properties
+++ b/resources/magento2/validation.properties
@@ -10,6 +10,7 @@ validator.startWithNumberOrCapitalLetter=The {0} field must start with a number 
 validator.onlyNumbers=The {0} field must contain numbers only
 validator.mustNotBeNegative={0} must not be negative
 validator.identifier=The {0} field must contain letters, numbers, dashes, and underscores only
+validator.identifier.colon=The {0} field must contain letters, numbers, colons, dashes, and underscores only
 validator.class.isNotValid=The {0} field does not contain a valid class name
 validator.fqn.isNotValid=The {0} field does not contain a valid fully qualified class name
 validator.class.shouldBeUnique=Duplicated class {0}

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAPluginDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAPluginDialog.java
@@ -15,7 +15,7 @@ import com.magento.idea.magento2plugin.actions.generation.dialog.validator.annot
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.annotation.RuleRegistry;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.BoxNotEmptyRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.DirectoryRule;
-import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.IdentifierRule;
+import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.IdentifierWithColonRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.NotEmptyRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.NumericRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.PhpClassRule;
@@ -88,8 +88,8 @@ public class CreateAPluginDialog extends AbstractDialog {
 
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
             message = {NotEmptyRule.MESSAGE, PLUGIN_NAME})
-    @FieldValidation(rule = RuleRegistry.IDENTIFIER,
-            message = {IdentifierRule.MESSAGE, PLUGIN_NAME})
+    @FieldValidation(rule = RuleRegistry.IDENTIFIER_WITH_COLON,
+            message = {IdentifierWithColonRule.MESSAGE, PLUGIN_NAME})
     private JTextField pluginName;
 
     private JLabel pluginDirectoryName;//NOPMD

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/annotation/RuleRegistry.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/annotation/RuleRegistry.java
@@ -16,6 +16,7 @@ import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.CronScheduleRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.DirectoryRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.IdentifierRule;
+import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.IdentifierWithColonRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.Lowercase;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.NotEmptyRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.NumericRule;
@@ -39,6 +40,7 @@ public enum RuleRegistry {
     DIRECTORY(DirectoryRule.class),
     PHP_DIRECTORY(PhpDirectoryRule.class),
     IDENTIFIER(IdentifierRule.class),
+    IDENTIFIER_WITH_COLON(IdentifierWithColonRule.class),
     PHP_NAMESPACE_NAME(PhpNamespaceNameRule.class),
     START_WITH_NUMBER_OR_CAPITAL_LETTER(StartWithNumberOrCapitalLetterRule.class),
     ACL_RESOURCE_ID(AclResourceIdRule.class),

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/rule/IdentifierWithColonRule.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/validator/rule/IdentifierWithColonRule.java
@@ -1,0 +1,17 @@
+package com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule;
+
+import com.magento.idea.magento2plugin.util.RegExUtil;
+
+public class IdentifierWithColonRule implements ValidationRule {
+    public static final String MESSAGE = "validator.identifier.colon";
+    private static final ValidationRule INSTANCE = new IdentifierWithColonRule();
+
+    @Override
+    public boolean check(final String value) {
+        return value.matches(RegExUtil.IDENTIFIER_WITH_COLON);
+    }
+
+    public static ValidationRule getInstance() {
+        return INSTANCE;
+    }
+}

--- a/src/com/magento/idea/magento2plugin/util/RegExUtil.java
+++ b/src/com/magento/idea/magento2plugin/util/RegExUtil.java
@@ -28,6 +28,9 @@ public class RegExUtil {
     public static final String IDENTIFIER
             = "[a-zA-Z0-9_\\-]*";
 
+    public static final String IDENTIFIER_WITH_COLON
+            = "[a-zA-Z0-9:_\\-]*";
+
     public static final String LOWER_SNAKE_CASE
             = "[a-z][a-z0-9_]*";
 


### PR DESCRIPTION
**Description**

This PR fixes the plugin validator as described in the issue

**Fixed Issues**
1. Fixes magento/magento2-phpstorm-plugin#422: Change the validation of the Plugin Name field in the New Plugin dialog window

**Contribution checklist**
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with integration/functional tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
