### PR TITLE
Fixed NPTR exception in theme directory view model action

### DIFF
--- a/src/com/magento/idea/magento2plugin/util/magento/GetModuleNameByDirectoryUtil.java
+++ b/src/com/magento/idea/magento2plugin/util/magento/GetModuleNameByDirectoryUtil.java
@@ -18,6 +18,9 @@ import org.jetbrains.annotations.Nullable;
 
 public final class GetModuleNameByDirectoryUtil {
 
+    public static final int THEME_SPLIT_COUNT = 1;
+    public static final String THEME_DIRECTORY_REGEX = "app\\/design\\/(adminhtml|frontend)\\/";
+
     private GetModuleNameByDirectoryUtil() {}
 
     /**
@@ -31,6 +34,13 @@ public final class GetModuleNameByDirectoryUtil {
             final PsiDirectory psiDirectory,
             final Project project
     ) {
+        // Check if directory is theme directory and return module name from directory path if yes
+        final String[] splits = psiDirectory.getVirtualFile().getPath()
+                .split(THEME_DIRECTORY_REGEX);
+        if (splits.length > THEME_SPLIT_COUNT) {
+            return splits[1].split("\\/")[2];
+        }
+
         final PhpFile registrationPhp = getRegistrationPhpRecursively(
                 psiDirectory,
                 project


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description**

This PR fixes the null pointer exception occurring when injecting a view model in a layout file from `app/design` directory.

**Fixed Issues**

1. Fixes magento/magento2-phpstorm-plugin#433: java.lang.NullPointerException when inject view model in theme layout file

**Questions or comments**

- Currently, I check if the path of the layout file is a theme, and then extract the module name from the path (project_root/app/design/frontend/Vendor/theme/**_Magento_Catalog_**/layout). But the problem with this is that this specific module is usually a vendor module and the view model file is created in the vendor directory. Either we don't create a view model file if view model is being injected in a vendor module, and just stick to creating the layout entry for the same. Or, we ask the user for the custom module name if directory is theme.

**Contribution checklist**
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
