### PR TITLE
[Code Generation] Fixing overriding a template from the base area

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/OverrideInThemeGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/OverrideInThemeGenerator.java
@@ -98,7 +98,9 @@ public class OverrideInThemeGenerator {
         final List<String> pathComponents = new ArrayList<>();
         PsiDirectory parent = file.getParent();
         while (!parent.getName().equals(Areas.frontend.toString())
-                && !parent.getName().equals(Areas.adminhtml.toString())) {
+                && !parent.getName().equals(Areas.adminhtml.toString())
+                && !parent.getName().equals(Areas.base.toString())
+        ) {
             pathComponents.add(parent.getName());
             parent = parent.getParent();
         }


### PR DESCRIPTION

**Description** (*)
The following PR allows overriding the templates that are located in `base` area. This way, the developer can override a base template in any existing frontend/backend themes.

**Fixed Issues (if relevant)**

1. Fixes magento/magento2-phpstorm-plugin#441

**Questions or comments**


**Contribution checklist** (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with integration/functional tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
