### PR TITLE
Added templates descriptions for Magento Data Model and Magento Data Model Interface

### DIFF
--- a/resources/fileTemplates/internal/Magento Data Model Interface.php.html
+++ b/resources/fileTemplates/internal/Magento Data Model Interface.php.html
@@ -1,0 +1,66 @@
+<!--
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<html lang="en">
+<body>
+<table width="100%" border="0" cellpadding="5" cellspacing="0" style="border-collapse: collapse">
+    <tr>
+        <td><font face="verdana" size="-1">
+            The data model interface indicates all the setters and getters for the related data model.
+            This used to maintain the integrity of the data, even if there is any changes in the model you will always get consistent data.
+        </font><br>
+        </td>
+    </tr>
+</table>
+<table width="100%" border="0" cellpadding="5" cellspacing="0" style="border-collapse: collapse">
+    <tr>
+        <td colspan="3"><font face="verdana" size="-1">Predefined variables explanation:</font></td>
+    </tr>
+    <tr>
+        <td valign="top"><nobr><font face="verdana" size="-2"><b>${NAMESPACE}</b></font></nobr></td>
+        <td width="10">&nbsp;</td>
+        <td width="100%" valign="top"><font face="verdana" size="-1">A fully qualified name of the field namespace without a leading slash.
+        </font>
+        </td>
+    </tr>
+    <tr>
+        <td valign="top"><nobr><font face="verdana" size="-2"><b>${USE}</b></font></nobr></td>
+        <td width="10">&nbsp;</td>
+        <td width="100%" valign="top"><font face="verdana" size="-1">List of imports separated by comma.
+        </font>
+        </td>
+    </tr>
+    <tr>
+        <td valign="top"><nobr><font face="verdana" size="-2"><b>${NAME}</b></font></nobr></td>
+        <td width="10">&nbsp;</td>
+        <td width="100%" valign="top"><font face="verdana" size="-1">PHP Class name.
+        </font>
+        </td>
+    </tr>
+    <tr>
+        <td valign="top"><nobr><font face="verdana" size="-2"><b>${EXTENDS}</b></font></nobr></td>
+        <td width="10">&nbsp;</td>
+        <td width="100%" valign="top"><font face="verdana" size="-1">Name of PHP class that the Class extends.
+        </font>
+        </td>
+    </tr>
+    <tr>
+        <td valign="top"><nobr><font face="verdana" size="-2"><b>${IMPLEMENTS}</b></font></nobr></td>
+        <td width="10">&nbsp;</td>
+        <td width="100%" valign="top"><font face="verdana" size="-1">Name of PHP class that the Class implements.
+        </font>
+        </td>
+    </tr>
+    <tr>
+        <td valign="top"><nobr><font face="verdana" size="-2"><b>${PROPERTIES}</b></font></nobr></td>
+        <td width="10">&nbsp;</td>
+        <td width="100%" valign="top"><font face="verdana" size="-1">Class member variables.
+        </font>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/resources/fileTemplates/internal/Magento Data Model.php.html
+++ b/resources/fileTemplates/internal/Magento Data Model.php.html
@@ -1,0 +1,74 @@
+<!--
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<html lang="en">
+<body>
+<table width="100%" border="0" cellpadding="5" cellspacing="0" style="border-collapse: collapse">
+    <tr>
+        <td><font face="verdana" size="-1">
+            The data model is a stateful data transfer object (DTO) that introduces simple data PHP object that contains only getters and setters.
+            In other words, data models are interfaces that define the list of data properties other components can expect from them.
+        </font><br>
+        </td>
+    </tr>
+    <tr>
+        <td><font face="verdana" size="-1">
+            Link to documentation
+            <a href="https://www.mageplaza.com/magento-2-module-development/how-to-create-crud-model-magento-2.html">
+                DevDocs</a>.
+        </font><br>
+        </td>
+    </tr>
+</table>
+<table width="100%" border="0" cellpadding="5" cellspacing="0" style="border-collapse: collapse">
+    <tr>
+        <td colspan="3"><font face="verdana" size="-1">Predefined variables explanation:</font></td>
+    </tr>
+    <tr>
+        <td valign="top"><nobr><font face="verdana" size="-2"><b>${NAMESPACE}</b></font></nobr></td>
+        <td width="10">&nbsp;</td>
+        <td width="100%" valign="top"><font face="verdana" size="-1">A fully qualified name of the field namespace without a leading slash.
+        </font>
+        </td>
+    </tr>
+    <tr>
+        <td valign="top"><nobr><font face="verdana" size="-2"><b>${USE}</b></font></nobr></td>
+        <td width="10">&nbsp;</td>
+        <td width="100%" valign="top"><font face="verdana" size="-1">List of imports separated by comma.
+        </font>
+        </td>
+    </tr>
+    <tr>
+        <td valign="top"><nobr><font face="verdana" size="-2"><b>${NAME}</b></font></nobr></td>
+        <td width="10">&nbsp;</td>
+        <td width="100%" valign="top"><font face="verdana" size="-1">PHP Class name.
+        </font>
+        </td>
+    </tr>
+    <tr>
+        <td valign="top"><nobr><font face="verdana" size="-2"><b>${EXTENDS}</b></font></nobr></td>
+        <td width="10">&nbsp;</td>
+        <td width="100%" valign="top"><font face="verdana" size="-1">Name of PHP class that the Class extends.
+        </font>
+        </td>
+    </tr>
+    <tr>
+        <td valign="top"><nobr><font face="verdana" size="-2"><b>${IMPLEMENTS}</b></font></nobr></td>
+        <td width="10">&nbsp;</td>
+        <td width="100%" valign="top"><font face="verdana" size="-1">Name of PHP class that the Class implements.
+        </font>
+        </td>
+    </tr>
+    <tr>
+        <td valign="top"><nobr><font face="verdana" size="-2"><b>${PROPERTIES}</b></font></nobr></td>
+        <td width="10">&nbsp;</td>
+        <td width="100%" valign="top"><font face="verdana" size="-1">Class member variables.
+        </font>
+        </td>
+    </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
**Description** (*)
In this PR I've added descriptions for the internal file templates **Magento Data Model** and **Magento Data Model Interface**.

**Testing was performed on the version IDE 2020.1**

![image](https://user-images.githubusercontent.com/30952336/105517887-467da080-5ce0-11eb-84dd-010059de4d75.png)

![image](https://user-images.githubusercontent.com/30952336/105517947-55fce980-5ce0-11eb-9d03-9bbeb6f19e34.png)



**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
