### PR TITLE
[Backport 3.1.0] Extend .phpstorm.meta.php for more convenient autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 ### Added
 
 - Extended `.phpstorm.meta.php` for more convenient autocomplete
-86f5942
 
 ## 3.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## 3.1.0
 
+### Added
+
+- Extended `.phpstorm.meta.php` for more convenient autocomplete
+86f5942
+
 ## 3.0.4
 
 ### Fixed

--- a/resources/phpstorm.meta.php/di-autocomplete.php
+++ b/resources/phpstorm.meta.php/di-autocomplete.php
@@ -1,6 +1,123 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PHPSTORM_META {
+
     override(\Magento\Framework\ObjectManagerInterface::get(0), map(['' => '@']));
     override(\Magento\Framework\ObjectManagerInterface::create(0), map(['' => '@']));
+
+    override(\Magento\Framework\View\LayoutInterface::createBlock(0), map(['' => '@']));
+    override(\Magento\Framework\View\TemplateEngine\Php::helper(0), map(['' => '@']));
+
+    override(
+        \Magento\Framework\Controller\ResultFactory::create(0),
+        map(
+            [
+                \Magento\Framework\Controller\ResultFactory::TYPE_FORWARD => \Magento\Framework\Controller\Result\Forward::class,
+                \Magento\Framework\Controller\ResultFactory::TYPE_JSON => \Magento\Framework\Controller\Result\Json::class,
+                \Magento\Framework\Controller\ResultFactory::TYPE_LAYOUT => \Magento\Framework\View\Result\Layout::class,
+                \Magento\Framework\Controller\ResultFactory::TYPE_PAGE => \Magento\Framework\View\Result\Page::class,
+                \Magento\Framework\Controller\ResultFactory::TYPE_RAW => \Magento\Framework\Controller\Result\Raw::class,
+                \Magento\Framework\Controller\ResultFactory::TYPE_REDIRECT => \Magento\Framework\Controller\Result\Redirect::class,
+            ]
+        )
+    );
+
+    expectedArguments(
+        \Magento\Framework\Controller\ResultFactory::create(),
+        0,
+        \Magento\Framework\Controller\ResultFactory::TYPE_FORWARD,
+        \Magento\Framework\Controller\ResultFactory::TYPE_JSON,
+        \Magento\Framework\Controller\ResultFactory::TYPE_LAYOUT,
+        \Magento\Framework\Controller\ResultFactory::TYPE_PAGE,
+        \Magento\Framework\Controller\ResultFactory::TYPE_RAW,
+        \Magento\Framework\Controller\ResultFactory::TYPE_REDIRECT
+    );
+
+    registerArgumentsSet(
+        'scope_types',
+        \Magento\Framework\App\Config\ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
+        \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+        \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE
+    );
+    expectedArguments(
+        \Magento\Framework\App\Config\ScopeConfigInterface::getValue(),
+        1,
+        argumentsSet('scope_types')
+    );
+    expectedArguments(
+        \Magento\Framework\App\Config\ScopeConfigInterface::isSetFlag(),
+        1,
+        argumentsSet('scope_types')
+    );
+    expectedArguments(
+        \Magento\Framework\App\Config\MutableScopeConfigInterface::setValue(),
+        2,
+        argumentsSet('scope_types')
+    );
+
+    registerArgumentsSet(
+        'condition_types',
+        'eq',
+        'in',
+        'is',
+        'to',
+        'finset',
+        'from',
+        'gt',
+        'gteq',
+        'like',
+        'lt',
+        'lteq',
+        'moreq',
+        'neq',
+        'nin',
+        'notnull',
+        'null'
+    );
+    expectedArguments(\Magento\Framework\Api\SearchCriteriaBuilder::addFilter(), 2, argumentsSet('condition_types'));
+    expectedArguments(\Magento\Framework\Api\FilterBuilder::setConditionType(), 0, argumentsSet('condition_types'));
+
+    expectedArguments(
+        \Magento\Framework\Api\SearchCriteriaBuilder::addSortOrder(),
+        0,
+        \Magento\Framework\Api\SortOrder::SORT_ASC,
+        \Magento\Framework\Api\SortOrder::SORT_DESC
+    );
+
+    registerArgumentsSet(
+        'field_types',
+        'button',
+        'checkbox',
+        'checkboxes',
+        'column',
+        'date',
+        'editablemultiselect',
+        'editor',
+        'fieldset',
+        'file',
+        'gallery',
+        'hidden',
+        'image',
+        'imagefile',
+        'label',
+        'link',
+        'multiline',
+        'multiselect',
+        'note',
+        'obscure',
+        'password',
+        'radio',
+        'radios',
+        'reset',
+        'select',
+        'submit',
+        'text',
+        'textarea',
+        'time'
+    );
+    expectedArguments(\Magento\Framework\Data\Form\AbstractForm::addField(), 1, argumentsSet('field_types'));
+    expectedArguments(\Magento\Framework\Data\Form\Element\Fieldset::addField(), 1, argumentsSet('field_types'));
+
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description**

This PR adds extended **.phpstorm.meta.php** for more convenient autocomplete.

**Fixed Issues (if relevant)**

1. Fixes magento/magento2-phpstorm-plugin#403

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
