### PR TITLE
Added linemarkers for test fixtures

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -143,6 +143,7 @@
         <codeInsight.lineMarkerProvider language="PHP" implementationClass="com.magento.idea.magento2plugin.linemarker.php.PluginTargetLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="PHP" implementationClass="com.magento.idea.magento2plugin.linemarker.php.ClassConfigurationLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="PHP" implementationClass="com.magento.idea.magento2plugin.linemarker.php.WebApiLineMarkerProvider"/>
+        <codeInsight.lineMarkerProvider language="PHP" implementationClass="com.magento.idea.magento2plugin.linemarker.php.TestFixtureLineMarkerProvider"/>
 
         <directoryProjectConfigurator implementation="com.magento.idea.magento2plugin.project.ProjectDetector"/>
 

--- a/src/com/magento/idea/magento2plugin/indexes/FixtureIndex.java
+++ b/src/com/magento/idea/magento2plugin/indexes/FixtureIndex.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.indexes;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.search.FilenameIndex;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.jetbrains.php.lang.psi.PhpFile;
+import com.magento.idea.magento2plugin.magento.files.TestFixture;
+import com.magento.idea.magento2plugin.magento.packages.File;
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+public final class FixtureIndex {
+    private final Project project;
+
+    public FixtureIndex(final Project project) {
+        this.project = project;
+    }
+
+    /**
+     * Getter for data fixtures.
+     */
+    public List<PhpFile> getDataFixtures(final String fixtureIdentifier) {
+        final List<PhpFile> result = new ArrayList<>();
+
+        final String[] fixturePathParts = fixtureIdentifier.split(File.separator);
+        final String fixtureName = fixturePathParts[fixturePathParts.length - 1];
+        final String exactFilePath = TestFixture.FIXTURES_LOCATION.concat(fixtureIdentifier);
+
+        @NotNull final PsiFile[] psiFiles = FilenameIndex.getFilesByName(
+                project,
+                fixtureName,
+                GlobalSearchScope.allScope(project)
+        );
+
+        for (final PsiFile psiFile: psiFiles) {
+            @NotNull final String filePath = psiFile.getVirtualFile().getPath();
+            if (!filePath.contains(TestFixture.FIXTURES_EXCLUDE_PATH)
+                    && filePath.contains(exactFilePath)) {
+                result.add((PhpFile) psiFile);
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/com/magento/idea/magento2plugin/linemarker/php/TestFixtureLineMarkerProvider.java
+++ b/src/com/magento/idea/magento2plugin/linemarker/php/TestFixtureLineMarkerProvider.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.linemarker.php;
+
+import com.intellij.codeInsight.daemon.LineMarkerInfo;
+import com.intellij.codeInsight.daemon.LineMarkerProvider;
+import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.php.PhpIcons;
+import com.jetbrains.php.lang.documentation.phpdoc.psi.tags.PhpDocTag;
+import com.jetbrains.php.lang.psi.PhpFile;
+import com.magento.idea.magento2plugin.indexes.FixtureIndex;
+import com.magento.idea.magento2plugin.magento.files.TestFixture;
+import com.magento.idea.magento2plugin.project.Settings;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class TestFixtureLineMarkerProvider implements LineMarkerProvider {
+
+    @Nullable
+    @Override
+    public LineMarkerInfo getLineMarkerInfo(final @NotNull PsiElement psiElement) {
+        return null;
+    }
+
+    @Override
+    public void collectSlowLineMarkers(
+            final @NotNull List<? extends PsiElement> elements,
+            final @NotNull Collection<? super LineMarkerInfo<?>> result
+    ) {
+        if (elements.isEmpty() || !Settings.isEnabled(elements.get(0).getProject())) {
+            return;
+        }
+        final FixtureIndex fixtureIndex = new FixtureIndex(elements.get(0).getProject());
+        final List<PhpFile> results = new ArrayList();
+        for (final PsiElement psiElement: elements) {
+            if (psiElement instanceof PhpDocTag) {
+                @NotNull final String tagName = ((PhpDocTag) psiElement).getName();
+                if (!tagName.equals(TestFixture.PHP_DOC_TAG_NAME)
+                        && !tagName.equals(TestFixture.PHP_DOC_TAG_NAME_API)) {
+                    continue;
+                }
+                @NotNull final String tagValue = ((PhpDocTag) psiElement).getTagValue();
+                if (tagValue.isEmpty()) {
+                    continue;
+                }
+
+                final List<PhpFile> dataFixtures = fixtureIndex.getDataFixtures(tagValue);
+
+                if (dataFixtures.isEmpty()) {
+                    continue;
+                }
+
+                results.addAll(dataFixtures);
+
+                final String tooltipText = "Navigate to fixtures";
+                final NavigationGutterIconBuilder<PsiElement> builder = NavigationGutterIconBuilder
+                        .create(PhpIcons.PHP_FILE)
+                        .setTargets(results)
+                        .setTooltipText(tooltipText);
+
+                result.add(builder.createLineMarkerInfo(PsiTreeUtil.getDeepestFirst(psiElement)));
+            }
+        }
+    }
+}

--- a/src/com/magento/idea/magento2plugin/magento/files/TestFixture.java
+++ b/src/com/magento/idea/magento2plugin/magento/files/TestFixture.java
@@ -5,6 +5,9 @@
 
 package com.magento.idea.magento2plugin.magento.files;
 
+@SuppressWarnings({
+        "PMD.ClassNamingConventions"
+})
 public class TestFixture {
     public static final String PHP_DOC_TAG_NAME = "@magentoDataFixture";
     public static final String PHP_DOC_TAG_NAME_API = "@magentoApiDataFixture";

--- a/src/com/magento/idea/magento2plugin/magento/files/TestFixture.java
+++ b/src/com/magento/idea/magento2plugin/magento/files/TestFixture.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.magento.files;
+
+public class TestFixture {
+    public static final String PHP_DOC_TAG_NAME = "@magentoDataFixture";
+    public static final String PHP_DOC_TAG_NAME_API = "@magentoApiDataFixture";
+    public static final String FIXTURES_LOCATION = "dev/tests/integration/testsuite/";
+    public static final String FIXTURES_EXCLUDE_PATH = "vendor";
+}

--- a/testData/linemarker/php/FixtureLinemarkerRegistrar/magentoApiDataFixtureHaveLinemarker/Test.php
+++ b/testData/linemarker/php/FixtureLinemarkerRegistrar/magentoApiDataFixtureHaveLinemarker/Test.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Catalog\Service;
+
+class Test
+{
+    /**
+     * @magentoApiDataFixture Magento/Catalog/_files/test_fixture.php
+     */
+    public function testFoo()
+    {
+    }
+}
+

--- a/testData/linemarker/php/FixtureLinemarkerRegistrar/magentoDataFixtureHaveLinemarker/Test.php
+++ b/testData/linemarker/php/FixtureLinemarkerRegistrar/magentoDataFixtureHaveLinemarker/Test.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Catalog\Service;
+
+class Test
+{
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/test_fixture.php
+     */
+    public function testFoo()
+    {
+    }
+}
+

--- a/testData/project/magento2/dev/tests/integration/testsuite/Magento/Catalog/_files/test_fixture.php
+++ b/testData/project/magento2/dev/tests/integration/testsuite/Magento/Catalog/_files/test_fixture.php
@@ -1,0 +1,2 @@
+<?php
+//test fixture

--- a/tests/com/magento/idea/magento2plugin/linemarker/php/TestFixtureLinemarkerRegistrarTest.java
+++ b/tests/com/magento/idea/magento2plugin/linemarker/php/TestFixtureLinemarkerRegistrarTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.linemarker.php;
+
+import com.magento.idea.magento2plugin.linemarker.LinemarkerFixtureTestCase;
+
+public class TestFixtureLinemarkerRegistrarTest extends LinemarkerFixtureTestCase {
+
+    /**
+     * Tests linemarkers for @magentoDataFixture tag.
+     */
+    public void testMagentoDataFixtureHaveLinemarker() {
+        myFixture.configureByFile(this.getFixturePath("Test.php", "php"));
+
+        assertHasLinemarkerWithTooltipAndIcon("Navigate to fixtures", "icons/php-icon.svg");
+    }
+
+    /**
+     * Tests linemarkers for @magentoApiDataFixture tag.
+     */
+    public void testMagentoApiDataFixtureHaveLinemarker() {
+        myFixture.configureByFile(this.getFixturePath("Test.php", "php"));
+
+        assertHasLinemarkerWithTooltipAndIcon("Navigate to fixtures", "icons/php-icon.svg");
+    }
+}


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description** (*)
Added line markers to @magentoDataFixture and @magentoApiDataFixture PHPDoc tag values for easier navigation from a test class to a fixture file.
![test-fixture-linemarker-min](https://user-images.githubusercontent.com/20116393/107271637-32ae9a00-6a55-11eb-9e16-4fac01d7d284.gif)

**Fixed Issues (if relevant)**
1. Fixes magento/magento2-phpstorm-plugin#40

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
