### PR TITLE
Added ui components tab toggling

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEntityDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEntityDialog.form
@@ -142,8 +142,11 @@
             <constraints>
               <tabbedpane title="Admin UI Components"/>
             </constraints>
-            <properties/>
-            <border type="none" title=""/>
+            <properties>
+              <preferredSize width="483" height="230"/>
+              <requestFocusEnabled value="false"/>
+            </properties>
+            <border type="none"/>
             <children>
               <component id="3c721" class="javax.swing.JTextField" binding="route">
                 <constraints>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEntityDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEntityDialog.form
@@ -18,7 +18,10 @@
             <preferred-size width="200" height="200"/>
           </grid>
         </constraints>
-        <properties/>
+        <properties>
+          <enabled value="true"/>
+          <visible value="true"/>
+        </properties>
         <border type="none"/>
         <children>
           <grid id="6be8b" binding="generalTable" layout-manager="GridLayoutManager" row-count="7" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
@@ -26,7 +29,10 @@
             <constraints>
               <tabbedpane title="General"/>
             </constraints>
-            <properties/>
+            <properties>
+              <enabled value="true"/>
+              <visible value="false"/>
+            </properties>
             <border type="none"/>
             <children>
               <component id="210a4" class="javax.swing.JLabel" binding="entityNameLabel">
@@ -137,12 +143,19 @@
               </vspacer>
             </children>
           </grid>
-          <grid id="e3309" layout-manager="GridLayoutManager" row-count="8" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="e3309" binding="uiComponentsPanel" layout-manager="GridLayoutManager" row-count="8" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="10" left="10" bottom="0" right="10"/>
             <constraints>
               <tabbedpane title="Admin UI Components"/>
             </constraints>
-            <properties/>
+            <properties>
+              <background color="-12828863"/>
+              <enabled value="true"/>
+              <visible value="true"/>
+            </properties>
+            <clientProperties>
+              <html.disable class="java.lang.Boolean" value="false"/>
+            </clientProperties>
             <border type="none" title=""/>
             <children>
               <component id="3c721" class="javax.swing.JTextField" binding="route">

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEntityDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEntityDialog.form
@@ -18,10 +18,7 @@
             <preferred-size width="200" height="200"/>
           </grid>
         </constraints>
-        <properties>
-          <enabled value="true"/>
-          <visible value="true"/>
-        </properties>
+        <properties/>
         <border type="none"/>
         <children>
           <grid id="6be8b" binding="generalTable" layout-manager="GridLayoutManager" row-count="7" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
@@ -29,10 +26,7 @@
             <constraints>
               <tabbedpane title="General"/>
             </constraints>
-            <properties>
-              <enabled value="true"/>
-              <visible value="false"/>
-            </properties>
+            <properties/>
             <border type="none"/>
             <children>
               <component id="210a4" class="javax.swing.JLabel" binding="entityNameLabel">
@@ -148,14 +142,7 @@
             <constraints>
               <tabbedpane title="Admin UI Components"/>
             </constraints>
-            <properties>
-              <background color="-12828863"/>
-              <enabled value="true"/>
-              <visible value="true"/>
-            </properties>
-            <clientProperties>
-              <html.disable class="java.lang.Boolean" value="false"/>
-            </clientProperties>
+            <properties/>
             <border type="none" title=""/>
             <children>
               <component id="3c721" class="javax.swing.JTextField" binding="route">

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEntityDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEntityDialog.java
@@ -196,6 +196,7 @@ public class NewEntityDialog extends AbstractDialog {
     private static final String GRID_NAME = "Grit Name";
     private static final String IDENTIFIER = "Identifier";
     private static final String SORT_ORDER = "Sort Order";
+    private static final String UI_COMPONENTS_TAB_NAME = "Admin UI Components";
 
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY, message = {NotEmptyRule.MESSAGE, FORM_NAME})
     @FieldValidation(rule = RuleRegistry.IDENTIFIER, message = {IdentifierRule.MESSAGE})
@@ -221,6 +222,7 @@ public class NewEntityDialog extends AbstractDialog {
     private JTextPane exampleAclId;
     private JTextPane exampleFormName;
     private JTextPane exampleGridName;
+    private JPanel uiComponentsPanel;
     private JTextField observerName;
 
     /**
@@ -269,6 +271,10 @@ public class NewEntityDialog extends AbstractDialog {
                 autoCompleteIdentifiers();
             }
         });
+
+        toggleUiComponentsPanel();
+
+        createUiComponent.addItemListener(event -> toggleUiComponentsPanel());
     }
 
     /**
@@ -1398,5 +1404,17 @@ public class NewEntityDialog extends AbstractDialog {
         aclTitle.setText(entityNameLabel.concat(" Management"));
         menuIdentifier.setText(getModuleName().concat("::management"));
         menuTitle.setText(entityNameLabel.concat(" Management"));
+    }
+
+    /**
+     * Resolve ui components panel state.
+     */
+    private void toggleUiComponentsPanel() {
+        if (createUiComponent.isSelected()) {
+            tabbedPane1.add(uiComponentsPanel, 1);
+            tabbedPane1.setTitleAt(1, UI_COMPONENTS_TAB_NAME);
+        } else {
+            tabbedPane1.remove(1);
+        }
     }
 }


### PR DESCRIPTION
**Description** (*)
Improved UX for entity manager form. Added UI components tab toggling depending on Create Admin UI Components checkbox value.

![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/31848341/107669267-3b43e200-6c9a-11eb-9da7-7a2772f942e2.gif)

Improving was suggested by @eduard13 in the https://github.com/magento/magento2-phpstorm-plugin/pull/483

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
