### PR TITLE
464: fixed reference navigation for classes under directories with underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## 3.1.2
 
+### Fixed
+
+- Reference navigation for classes under directories with underscores
+
 ## 3.1.1
 
 ### Fixed

--- a/src/com/magento/idea/magento2plugin/reference/provider/PhpClassReferenceProvider.java
+++ b/src/com/magento/idea/magento2plugin/reference/provider/PhpClassReferenceProvider.java
@@ -36,7 +36,7 @@ public class PhpClassReferenceProvider extends PsiReferenceProvider {
             return PsiReference.EMPTY_ARRAY;
         }
 
-        String classFQN = matcher.group();
+        String classFQN = origValue.replaceAll("^\"|\"$", "");;
         String[] fqnParts = classFQN.split("\\\\");
 
         PhpIndex phpIndex = PhpIndex.getInstance(element.getProject());

--- a/src/com/magento/idea/magento2plugin/reference/provider/PhpClassReferenceProvider.java
+++ b/src/com/magento/idea/magento2plugin/reference/provider/PhpClassReferenceProvider.java
@@ -52,8 +52,8 @@ public class PhpClassReferenceProvider extends PsiReferenceProvider {
         for (int i = 0; i < fqnParts.length - 1; i++) {
             namespacePart = fqnParts[i];
 
-            namespace.append("\\");
-            namespace.append(namespacePart);
+            namespace.append("\\");//NOPMD
+            namespace.append(namespacePart);//NOPMD
             final Collection<PhpNamespace> references =
                     phpIndex.getNamespacesByName(namespace.toString().toLowerCase(
                             new Locale("en","EN"))

--- a/src/com/magento/idea/magento2plugin/reference/provider/PhpClassReferenceProvider.java
+++ b/src/com/magento/idea/magento2plugin/reference/provider/PhpClassReferenceProvider.java
@@ -1,7 +1,8 @@
-/**
+/*
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 package com.magento.idea.magento2plugin.reference.provider;
 
 import com.intellij.openapi.util.TextRange;
@@ -14,60 +15,69 @@ import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.jetbrains.php.lang.psi.elements.PhpNamespace;
 import com.magento.idea.magento2plugin.reference.xml.PolyVariantReferenceBase;
 import com.magento.idea.magento2plugin.util.RegExUtil;
-import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.jetbrains.annotations.NotNull;
 
+@SuppressWarnings({"PMD.AvoidInstantiatingObjectsInLoops"})
 public class PhpClassReferenceProvider extends PsiReferenceProvider {
 
     @NotNull
     @Override
-    public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
-        List<PsiReference> psiReferences = new ArrayList<>();
+    public PsiReference[] getReferencesByElement(
+            final @NotNull PsiElement element,
+            final @NotNull ProcessingContext context
+    ) {
 
-        String origValue = element.getText();
+        final String origValue = element.getText();
 
-        Pattern pattern = Pattern.compile(RegExUtil.PhpRegex.FQN);
-        Matcher matcher = pattern.matcher(origValue);
+        final Pattern pattern = Pattern.compile(RegExUtil.PhpRegex.FQN);
+        final Matcher matcher = pattern.matcher(origValue);
         if (!matcher.find()) {
             return PsiReference.EMPTY_ARRAY;
         }
 
-        String classFQN = origValue.replaceAll("^\"|\"$", "");;
-        String[] fqnParts = classFQN.split("\\\\");
+        final String classFQN = origValue.replaceAll("^\"|\"$", "");
+        final String[] fqnParts = classFQN.split("\\\\");
 
-        PhpIndex phpIndex = PhpIndex.getInstance(element.getProject());
+        final PhpIndex phpIndex = PhpIndex.getInstance(element.getProject());
 
-        StringBuilder namespace = new StringBuilder();
+        final StringBuilder namespace = new StringBuilder();
         String namespacePart;
+        final List<PsiReference> psiReferences = new ArrayList<>();
         for (int i = 0; i < fqnParts.length - 1; i++) {
             namespacePart = fqnParts[i];
 
             namespace.append("\\");
             namespace.append(namespacePart);
-            Collection<PhpNamespace> references = phpIndex.getNamespacesByName(namespace.toString().toLowerCase());
-            if (references.size() > 0) {
-                TextRange range = new TextRange(
+            final Collection<PhpNamespace> references =
+                    phpIndex.getNamespacesByName(namespace.toString().toLowerCase(
+                            new Locale("en","EN"))
+                    );
+            if (!references.isEmpty()) {
+                final TextRange range = new TextRange(
                         origValue.indexOf(classFQN) + namespace.toString().lastIndexOf(92),
-                        origValue.indexOf(classFQN) + namespace.toString().lastIndexOf(92) + namespacePart.length()
+                        origValue.indexOf(classFQN) + namespace.toString().lastIndexOf(92)
+                                + namespacePart.length()
                 );
                 psiReferences.add(new PolyVariantReferenceBase(element, range, references));
             }
         }
 
-        String className = classFQN.substring(classFQN.lastIndexOf(92) + 1);
-        Collection<PhpClass> classes = phpIndex.getAnyByFQN(classFQN);
-        if (classes.size() > 0) {
-            TextRange range = new TextRange(
+        final String className = classFQN.substring(classFQN.lastIndexOf(92) + 1);
+        final Collection<PhpClass> classes = phpIndex.getAnyByFQN(classFQN);
+        if (!classes.isEmpty()) {
+            final TextRange range = new TextRange(
                     origValue.lastIndexOf(92) + 1,
                     origValue.lastIndexOf(92) + 1 + className.length()
             );
             psiReferences.add(new PolyVariantReferenceBase(element, range, classes));
         }
 
-        return psiReferences.toArray(new PsiReference[psiReferences.size()]);
+        return psiReferences.toArray(new PsiReference[0]);
     }
 }

--- a/src/com/magento/idea/magento2plugin/util/RegExUtil.java
+++ b/src/com/magento/idea/magento2plugin/util/RegExUtil.java
@@ -79,7 +79,7 @@ public class RegExUtil {
                 = "[a-zA-Z0-9_\\x7f-\\xff]*";
 
         public static final String FQN
-                = "(\\\\" + DIR_NAME + ")*" + CLASS_NAME;
+                = CLASS_NAME + "(\\\\" + DIR_NAME + ")*" + CLASS_NAME;
     }
 
     public static class XmlRegex {

--- a/src/com/magento/idea/magento2plugin/util/RegExUtil.java
+++ b/src/com/magento/idea/magento2plugin/util/RegExUtil.java
@@ -75,8 +75,11 @@ public class RegExUtil {
         public static final String CLASS_NAME
                 = "[A-Z][a-zA-Z0-9_\\x7f-\\xff]*";
 
+        public static final String DIR_NAME
+                = "[a-zA-Z0-9_\\x7f-\\xff]*";
+
         public static final String FQN
-                = CLASS_NAME + "(\\\\" + CLASS_NAME + ")*";
+                = CLASS_NAME + "(\\\\" + DIR_NAME + ")*" + CLASS_NAME;
     }
 
     public static class XmlRegex {

--- a/src/com/magento/idea/magento2plugin/util/RegExUtil.java
+++ b/src/com/magento/idea/magento2plugin/util/RegExUtil.java
@@ -73,13 +73,10 @@ public class RegExUtil {
     public class PhpRegex {
 
         public static final String CLASS_NAME
-                = "[A-Z][a-zA-Z0-9_\\x7f-\\xff]*";
-
-        public static final String DIR_NAME
                 = "[a-zA-Z0-9_\\x7f-\\xff]*";
 
         public static final String FQN
-                = CLASS_NAME + "(\\\\" + DIR_NAME + ")*" + CLASS_NAME;
+                = CLASS_NAME + "(\\\\" + CLASS_NAME + ")*";
     }
 
     public static class XmlRegex {

--- a/src/com/magento/idea/magento2plugin/util/RegExUtil.java
+++ b/src/com/magento/idea/magento2plugin/util/RegExUtil.java
@@ -79,7 +79,7 @@ public class RegExUtil {
                 = "[a-zA-Z0-9_\\x7f-\\xff]*";
 
         public static final String FQN
-                = CLASS_NAME + "(\\\\" + DIR_NAME + ")*" + CLASS_NAME;
+                = "(\\\\" + DIR_NAME + ")*" + CLASS_NAME;
     }
 
     public static class XmlRegex {

--- a/testData/project/magento2/vendor/magento/module-catalog/test_event/TestObserver.php
+++ b/testData/project/magento2/vendor/magento/module-catalog/test_event/TestObserver.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Catalog\test_event;
+
+use Magento\Framework\Event\ObserverInterface;
+
+class TestObserver implements ObserverInterface
+{
+    public function execute()
+    {
+    }
+}

--- a/testData/reference/xml/ObserverReferenceRegistrar/observerInstanceDirectorySnakeCaseMustHaveReference/events.xml
+++ b/testData/reference/xml/ObserverReferenceRegistrar/observerInstanceDirectorySnakeCaseMustHaveReference/events.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="test_event">
+        <observer name="test_observer" instance="Magento\Catalog\test_event\TestObserver<caret>" />
+    </event>
+</config>

--- a/tests/com/magento/idea/magento2plugin/reference/xml/ObserverReferenceRegistrarTest.java
+++ b/tests/com/magento/idea/magento2plugin/reference/xml/ObserverReferenceRegistrarTest.java
@@ -19,6 +19,15 @@ public class ObserverReferenceRegistrarTest extends ReferenceXmlFixtureTestCase 
     }
 
     /**
+     * Tests for observer instance with snake case reference in events.xml.
+     */
+    public void testObserverInstanceDirectorySnakeCaseMustHaveReference() {
+        myFixture.configureByFile(this.getFixturePath(ModuleEventsXml.FILE_NAME));
+
+        assertHasReferencePhpClass("Magento\\Catalog\\test_event\\TestObserver");
+    }
+
+    /**
      * Tests for event name reference in events.xml.
      */
     public void testEventNameMustHaveReference() {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/20116393/107969086-ef55ad80-6fb7-11eb-8c72-dae01c71e373.png)


**Fixed Issues (if relevant)**
1. Fixes magento/magento2-phpstorm-plugin#464

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
