### PR TITLE
495: Fixed the array access exception when using copy path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 ### Fixed
 
 - Reference navigation for classes under directories with underscores
+- Fixed the array access exception when using copy path action
 
 ## 3.1.1
 

--- a/src/com/magento/idea/magento2plugin/actions/CopyMagentoPath.java
+++ b/src/com/magento/idea/magento2plugin/actions/CopyMagentoPath.java
@@ -25,7 +25,8 @@ public class CopyMagentoPath extends CopyPathProvider {
     private final String[] templatePaths = {
         "view/frontend/templates/",
         "view/adminhtml/templates/",
-        "view/base/templates/"
+        "view/base/templates/",
+        "templates/"
     };
 
     @Override


### PR DESCRIPTION
**Description** (*)
The issue was reproduced on the app/design directory.
![image](https://user-images.githubusercontent.com/20116393/108687806-d55c2380-74ff-11eb-9090-45b47679c217.png)


**Fixed Issues (if relevant)**
1. Fixes magento/magento2-phpstorm-plugin#495

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
