### PR TITLE
Enhanced UX with generation process, generation in the separate thread (non-blocking UI), fixed multiple action listener firing

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/util/ProcessWorker.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/util/ProcessWorker.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.actions.generation.dialog.util;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import javax.swing.SwingWorker;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This worker is used to allow button on click action to be performed in the separate thread.
+ * It releases UI to not be blocked.
+ */
+public final class ProcessWorker extends SwingWorker<Boolean, String> {
+
+    private final Runnable processExecutorService;
+    private final Runnable processReleaserService;
+    private final InProgressFlag inProgressFlag;
+
+    /**
+     * Process worker constructor.
+     *
+     * @param processExecutorService Runnable
+     * @param processReleaserService Runnable
+     * @param inProgressFlag InProgressFlag
+     */
+    public ProcessWorker(
+            final @NotNull Runnable processExecutorService,
+            final @NotNull Runnable processReleaserService,
+            final InProgressFlag inProgressFlag
+    ) {
+        super();
+        this.processExecutorService = processExecutorService;
+        this.processReleaserService = processReleaserService;
+        this.inProgressFlag = inProgressFlag;
+    }
+
+    @Override
+    protected Boolean doInBackground() {
+        if (!inProgressFlag.isInProgress()) {
+            inProgressFlag.setInProgress(true);
+            // Run action event process
+            ApplicationManager.getApplication().invokeAndWait(
+                    processExecutorService,
+                    ModalityState.defaultModalityState()
+            );
+            // Run release dialog action process
+            ApplicationManager.getApplication().invokeAndWait(
+                    processReleaserService,
+                    ModalityState.defaultModalityState()
+            );
+        }
+        return null;
+    }
+
+    /**
+     * Inner class used only to stop actionPerformed method executing.
+     */
+    public static final class InProgressFlag {
+
+        /**
+         * Is action in progress flag.
+         */
+        private boolean inProgress;
+
+        /**
+         * Is action finished flag.
+         */
+        private boolean isFinished;
+
+        /**
+         * In progress flag constructor.
+         *
+         * @param inProgress boolean
+         */
+        public InProgressFlag(final boolean inProgress) {
+            this.inProgress = inProgress;
+            isFinished = false;
+        }
+
+        /**
+         * Get is in progress value.
+         *
+         * @return boolean
+         */
+        public boolean isInProgress() {
+            return inProgress;
+        }
+
+        /**
+         * Set is in progress flag value.
+         *
+         * @param inProgress boolean
+         */
+        public void setInProgress(final boolean inProgress) {
+            this.inProgress = inProgress;
+        }
+
+        /**
+         * Get is progress finished flag value.
+         */
+        public boolean isFinished() {
+            return isFinished;
+        }
+
+        /**
+         * Set is progress finished flag value.
+         *
+         * @param finished boolean
+         */
+        public void setFinished(boolean finished) {
+            isFinished = finished;
+        }
+    }
+}


### PR DESCRIPTION
**Description** (*)

**What was done:**
1. fixed multiple firing of generation action if the user clicks the OK button a few times
2. disabled the OK and Cancel buttons until a process is finished
3. run generation process in the separate thread (before: UI interface was blocked until the generation is finished)
4. added beautiful cursor that shows that process is running

The main problem:
![EntityManagerMultipleClickOnOk](https://user-images.githubusercontent.com/31848341/111153921-3923ba80-859b-11eb-9778-601de6cf5f6a.gif)

After the enhancement:
![EntityCreatorUXEnhanced](https://user-images.githubusercontent.com/31848341/111153986-4e004e00-859b-11eb-8182-de417531f636.gif)

There is on the GIF image an ugly cursor because it is rotating and cannot be captured by the screencasting app:
<img width="153" alt="Screenshot 2021-03-15 at 12 54 23" src="https://user-images.githubusercontent.com/31848341/111154120-7e47ec80-859b-11eb-8bde-ab44c13544a7.png">

In the reality it has a pretty nice look:
![20210315_130552](https://user-images.githubusercontent.com/31848341/111154258-b2231200-859b-11eb-9e2f-5eee7edd3f7d.jpg)

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
