### PR TITLE
Focusing the entity name field after opening the Entity dialog 

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEntityDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEntityDialog.java
@@ -218,6 +218,11 @@ public class NewEntityDialog extends AbstractDialog {
             public void windowClosing(final WindowEvent event) {
                 onCancel();
             }
+
+            @Override
+            public void windowOpened(WindowEvent e) {
+                entityName.requestFocus();
+            }
         });
 
         initializeComboboxSources();


### PR DESCRIPTION

**Description** (*)
This PR aims to focus on the Entity Name field, after opening the New Entity dialog. This will speed up entering the entity data, by not being needed to make 1 extra click to the input.

![2021-03-22 16 18 37](https://user-images.githubusercontent.com/15868188/112004304-52dc7900-8b2a-11eb-99db-6cd275c45ff8.gif)

**Fixed Issues (if relevant)**
N/A

**Questions or comments**


**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
