### PR TITLE
Added navigation to tab with error on field

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEntityDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEntityDialog.java
@@ -251,6 +251,7 @@ public class NewEntityDialog extends AbstractDialog {
         toggleUiComponentsPanel();
 
         createUiComponent.addItemListener(event -> toggleUiComponentsPanel());
+        registerTabbedPane(tabbedPane1);
     }
 
     /**


### PR DESCRIPTION
**Description** (*)
Added navigation to the tab with an error that occurred on a field.

![NavigateToTabWithError](https://user-images.githubusercontent.com/31848341/112636193-6dbe2e80-8e45-11eb-9cce-95ac6c8ec3b6.gif)

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
