### PR TITLE
Fixed incorrect duplication warning for disabled plugin in di.xml

### DIFF
--- a/src/com/magento/idea/magento2plugin/inspections/xml/ObserverDeclarationInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/xml/ObserverDeclarationInspection.java
@@ -124,22 +124,18 @@ public class ObserverDeclarationInspection extends PhpInspection {
                         if (observerDisabledAttribute != null
                                 && observerDisabledAttribute.getValue() != null
                                 && observerDisabledAttribute.getValue().equals("true")
-                                && modulesWithSameObserverName.isEmpty()
                         ) {
-                            problemsHolder.registerProblem(
-                                    observerNameAttribute.getValueElement(),
-                                    inspectionBundle.message(
-                                            "inspection.observer.disabledObserverDoesNotExist"
-                                    ),
-                                    errorSeverity
-                            );
-                        }
-
-                        if (observerDisabledAttribute != null
-                                && observerDisabledAttribute.getValue() != null
-                                && observerDisabledAttribute.getValue().equals("true")
-                        ) {
+                            if (modulesWithSameObserverName.isEmpty()) {
+                                    problemsHolder.registerProblem(
+                                            observerNameAttribute.getValueElement(),
+                                            inspectionBundle.message(
+                                                "inspection.observer.disabledObserverDoesNotExist"
+                                            ),
+                                            errorSeverity
+                                    );
+                            } else {
                                 continue;
+                            }
                         }
 
                         for (final HashMap<String, String> moduleEntry:

--- a/src/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspection.java
@@ -118,22 +118,18 @@ public class PluginDeclarationInspection extends PhpInspection {
                         if (pluginTypeDisabledAttribute != null
                                 && pluginTypeDisabledAttribute.getValue() != null
                                 && pluginTypeDisabledAttribute.getValue().equals("true")
-                                && modulesWithSamePluginName.isEmpty()
                         ) {
-                            problemsHolder.registerProblem(
-                                    pluginTypeNameAttribute.getValueElement(),
-                                    inspectionBundle.message(
+                            if (modulesWithSamePluginName.isEmpty()) {
+                                problemsHolder.registerProblem(
+                                        pluginTypeNameAttribute.getValueElement(),
+                                        inspectionBundle.message(
                                             "inspection.plugin.disabledPluginDoesNotExist"
-                                    ),
-                                    errorSeverity
-                            );
-                        }
-
-                        if (pluginTypeDisabledAttribute != null
-                                 && pluginTypeDisabledAttribute.getValue() != null
-                                 && pluginTypeDisabledAttribute.getValue().equals("true")
-                        ) {
-                            continue;
+                                        ),
+                                        errorSeverity
+                                );
+                            } else {
+                                continue;
+                            }
                         }
 
                         for (final Pair<String, String> moduleEntry: modulesWithSamePluginName) {

--- a/src/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspection.java
@@ -129,6 +129,13 @@ public class PluginDeclarationInspection extends PhpInspection {
                             );
                         }
 
+                        if (pluginTypeDisabledAttribute != null
+                                 && pluginTypeDisabledAttribute.getValue() != null
+                                 && pluginTypeDisabledAttribute.getValue().equals("true")
+                        ) {
+                            continue;
+                        }
+
                         for (final Pair<String, String> moduleEntry: modulesWithSamePluginName) {
                             final String scope = moduleEntry.getFirst();
                             final String moduleName = moduleEntry.getSecond();


### PR DESCRIPTION
**Description** (*)
The duplication plugin warning is shown when disabling a plugin via `di.xml`

<img width="754" alt="Screenshot 2021-04-09 at 11 05 08" src="https://user-images.githubusercontent.com/20116393/114150321-986bb500-9924-11eb-837b-c861f2bf2592.png">

This should be shown only for active plugins. Disabled plugins should be skipped.

<img width="773" alt="Screenshot 2021-04-09 at 11 10 16" src="https://user-images.githubusercontent.com/20116393/114150389-ac171b80-9924-11eb-874a-b9295515ca5c.png">
