### PR TITLE
Added possibility to set options

### DIFF
--- a/resources/fileTemplates/internal/Magento Eav Attribute Data Patch Class.php.ft
+++ b/resources/fileTemplates/internal/Magento Eav Attribute Data Patch Class.php.ft
@@ -82,8 +82,8 @@ class ${CLASS_NAME} implements ${IMPLEMENTS} {
         '${ATTRIBUTE_CODE}',
             [
             #set ($attributeSet = ${ATTRIBUTE_SET})
-            #foreach ($attribute in $attributeSet.split(","))
-                $attribute,
+            #foreach ($attribute in $attributeSet.split("->"))
+                $attribute
             #end
 ]
         );

--- a/src/com/magento/idea/magento2plugin/actions/generation/data/ProductEntityData.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/data/ProductEntityData.java
@@ -7,6 +7,7 @@ package com.magento.idea.magento2plugin.actions.generation.data;
 
 import com.magento.idea.magento2plugin.magento.files.EavAttributeDataPatchFile;
 import com.magento.idea.magento2plugin.magento.packages.eav.EavEntity;
+import java.util.Map;
 
 @SuppressWarnings({"PMD.TooManyFields"})
 public class ProductEntityData implements EavEntityDataInterface {
@@ -25,6 +26,8 @@ public class ProductEntityData implements EavEntityDataInterface {
     private boolean htmlAllowedOnFront;
     private boolean visibleOnFront;
     private int sortOrder;
+    private Map<Integer, String> options;
+    private Map<Integer, String> optionsSortOrder;
 
     private String dataPatchName;
     private String namespace;
@@ -119,6 +122,22 @@ public class ProductEntityData implements EavEntityDataInterface {
 
     public void setModuleName(final String moduleName) {
         this.moduleName = moduleName;
+    }
+
+    public void setOptions(final Map<Integer, String> options) {
+        this.options = options;
+    }
+
+    public void setOptionsSortOrder(final Map<Integer, String> optionsSortOrder) {
+        this.optionsSortOrder = optionsSortOrder;
+    }
+
+    public Map<Integer, String> getOptions() {
+        return options;
+    }
+
+    public Map<Integer, String> getOptionsSortOrder() {
+        return optionsSortOrder;
     }
 
     @Override

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEavAttributeDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEavAttributeDialog.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.magento.idea.magento2plugin.actions.generation.dialog.NewEavAttributeDialog">
-  <grid id="28350" binding="contentPanel" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="28350" binding="contentPanel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
-      <xy x="-1" y="5" width="870" height="659"/>
+      <xy x="-1" y="5" width="870" height="790"/>
     </constraints>
     <properties>
       <enabled value="true"/>
@@ -326,13 +326,13 @@
       </grid>
       <hspacer id="75d92">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
       </hspacer>
       <grid id="181ea" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -369,6 +369,45 @@
               </component>
             </children>
           </grid>
+        </children>
+      </grid>
+      <grid id="9fd98" binding="optionsPanel" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="5" left="5" bottom="5" right="5"/>
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <visible value="false"/>
+        </properties>
+        <border type="empty" title="Options" title-justification="2" title-position="2"/>
+        <children>
+          <scrollpane id="47220">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <enabled value="true"/>
+            </properties>
+            <border type="none"/>
+            <children>
+              <component id="b0960" class="javax.swing.JTable" binding="optionTable">
+                <constraints/>
+                <properties>
+                  <intercellSpacing width="1" height="3"/>
+                  <requestFocusEnabled value="true"/>
+                  <rowHeight value="30"/>
+                </properties>
+              </component>
+            </children>
+          </scrollpane>
+          <component id="835cb" class="javax.swing.JButton" binding="addOptionButton">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Add Option"/>
+            </properties>
+          </component>
         </children>
       </grid>
     </children>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/event/AttributeSourcePanelComponentListener.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/event/AttributeSourcePanelComponentListener.java
@@ -31,15 +31,19 @@ public class AttributeSourcePanelComponentListener implements ComponentListener 
 
     @Override
     public void componentShown(final ComponentEvent componentEvent) {
+        initSetDirectoryFieldValue();
+    }
+
+    @Override
+    public void componentHidden(final ComponentEvent componentEvent) {
+        initSetDirectoryFieldValue();
+    }
+
+    private void initSetDirectoryFieldValue() {
         final String sourceDirectoryValue = sourceModelDirectoryTexField.getText().trim();
 
         if (sourceDirectoryValue.isEmpty()) {
             sourceModelDirectoryTexField.setText(SourceModelFile.DEFAULT_DIR);
         }
-    }
-
-    @Override
-    public void componentHidden(final ComponentEvent componentEvent) {
-        //
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/event/AttributeSourcePanelComponentListener.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/event/AttributeSourcePanelComponentListener.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.actions.generation.dialog.event;
+
+import com.magento.idea.magento2plugin.magento.files.SourceModelFile;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
+import javax.swing.JTextField;
+
+public class AttributeSourcePanelComponentListener implements ComponentListener {
+    private final JTextField sourceModelDirectoryTexField;
+
+    public AttributeSourcePanelComponentListener(
+            final JTextField sourceModelDirectoryTexField
+    ) {
+        this.sourceModelDirectoryTexField = sourceModelDirectoryTexField;
+    }
+
+    @Override
+    public void componentResized(final ComponentEvent componentEvent) {
+        //
+    }
+
+    @Override
+    public void componentMoved(final ComponentEvent componentEvent) {
+        //
+    }
+
+    @Override
+    public void componentShown(final ComponentEvent componentEvent) {
+        final String sourceDirectoryValue = sourceModelDirectoryTexField.getText().trim();
+
+        if (sourceDirectoryValue.isEmpty()) {
+            sourceModelDirectoryTexField.setText(SourceModelFile.DEFAULT_DIR);
+        }
+    }
+
+    @Override
+    public void componentHidden(final ComponentEvent componentEvent) {
+        //
+    }
+}

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/event/AttributeSourceRelationsItemListener.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/event/AttributeSourceRelationsItemListener.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.actions.generation.dialog.event;
+
+import com.magento.idea.magento2plugin.magento.packages.eav.AttributeSourceModel;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import javax.swing.JPanel;
+
+public class AttributeSourceRelationsItemListener implements ItemListener {
+    private final JPanel customSourcePanel;
+
+    public AttributeSourceRelationsItemListener(final JPanel customSourcePanel) {
+        this.customSourcePanel = customSourcePanel;
+    }
+
+    @Override
+    public void itemStateChanged(final ItemEvent itemEvent) {
+        final String selectedSource = itemEvent.getItem().toString();
+
+        if (selectedSource.equals(AttributeSourceModel.GENERATE_SOURCE.getSource())) {
+            customSourcePanel.setVisible(true);
+        } else {
+            customSourcePanel.setVisible(false);
+        }
+    }
+}

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/event/OptionsPanelVisibilityChangeListener.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/event/OptionsPanelVisibilityChangeListener.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.actions.generation.dialog.event;
+
+import com.magento.idea.magento2plugin.actions.generation.data.ui.ComboBoxItemData;
+import com.magento.idea.magento2plugin.magento.packages.eav.AttributeInput;
+import com.magento.idea.magento2plugin.magento.packages.eav.AttributeSourceModel;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import javax.swing.JComboBox;
+import javax.swing.JPanel;
+import org.jetbrains.annotations.NotNull;
+
+public class OptionsPanelVisibilityChangeListener implements ItemListener {
+    private final JPanel optionsPanel;
+    private final JComboBox inputComboBox;
+
+    public OptionsPanelVisibilityChangeListener(
+            @NotNull final JPanel optionsPanel,
+            @NotNull final JComboBox inputComboBox
+    ) {
+        this.optionsPanel = optionsPanel;
+        this.inputComboBox = inputComboBox;
+    }
+
+    @Override
+    public void itemStateChanged(final ItemEvent itemEvent) {
+        final String selectedSource = itemEvent.getItem().toString();
+
+        final ComboBoxItemData selectedInputItem = (ComboBoxItemData) inputComboBox.getSelectedItem();
+        final String selectedInput = selectedInputItem == null ? "" : selectedInputItem.toString();
+
+        final boolean isAttributeWithoutSource =
+                AttributeSourceModel.NULLABLE_SOURCE.getSource().equals(selectedSource);
+        final boolean isAllowedInput =
+                AttributeInput.SELECT.getInput().equals(selectedInput)
+                        || AttributeInput.MULTISELECT.getInput().equals(selectedInput);
+
+        if (isAllowedInput && isAttributeWithoutSource) {
+            optionsPanel.setVisible(true);
+        } else {
+            optionsPanel.setVisible(false);
+        }
+    }
+}

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/EavAttributeSetupPatchGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/EavAttributeSetupPatchGenerator.java
@@ -63,7 +63,7 @@ public class EavAttributeSetupPatchGenerator extends PhpFileGenerator {
                 .appendProperty("NAMESPACE", this.getFile().getNamespace())
                 .appendProperty("ENTITY_CLASS", data.getEntityClass())
                 .appendProperty("ATTRIBUTE_CODE", data.getCode())
-                .appendProperty("ATTRIBUTE_SET", String.join(",", getAttributesList(data)))
+                .appendProperty("ATTRIBUTE_SET", String.join("->", getAttributesList(data)))
                 .append(
                         "IMPLEMENTS",
                         DataPatchDependency.DATA_PATCH_INTERFACE.getClassPatch()

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/GetAttributeOptionPropertiesUtil.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/GetAttributeOptionPropertiesUtil.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.actions.generation.generator.util;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+
+public final class GetAttributeOptionPropertiesUtil {
+    public final static String OPTION_VALUE = "Value";
+    public final static String OPTION_SORT_ORDER = "Sort Order";
+
+    private GetAttributeOptionPropertiesUtil() {}
+
+    /**
+     * Returns sort orders for options.
+     *
+     * @param columnsData List
+     */
+    public static Map<Integer, String> getSortOrders(
+            @NotNull final List<Map<String, String>> columnsData
+    ) {
+        final Map<Integer, String> sortOrders = new HashMap<>();
+
+        for (int i = 0; i < columnsData.size(); i++) {
+            final String sortOrder = columnsData.get(i).get(OPTION_SORT_ORDER);
+            if (!sortOrder.isEmpty()) {
+                sortOrders.put(i, sortOrder);
+            }
+        }
+
+        return sortOrders;
+    }
+
+    /**
+     * Returns options values.
+     *
+     * @param columnsData List
+     */
+    public static Map<Integer, String> getValues(
+            @NotNull final List<Map<String, String>> columnsData
+    ) {
+        final Map<Integer, String> options = new HashMap<>();
+
+        for (int i = 0; i < columnsData.size(); i++) {
+            options.put(i, columnsData.get(i).get(OPTION_VALUE));
+        }
+
+        return options;
+    }
+}

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/eav/ProductAttributeMapper.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/eav/ProductAttributeMapper.java
@@ -31,7 +31,7 @@ public class ProductAttributeMapper implements AttributeMapperInterface {
             final String attributeValue = attributePair.getValue();
 
             attributesWithValues.add(
-                    String.join("=>", attributeKey, attributeValue)
+                    String.join("=>", attributeKey, attributeValue + ",")
             );
         }
 
@@ -41,7 +41,6 @@ public class ProductAttributeMapper implements AttributeMapperInterface {
     @SuppressWarnings({"PMD.NullAssignment"})
     private Map<String, String> getMappedAttributes(final ProductEntityData eavEntityData) {
         final Map<String, String> mappedAttributes = new HashMap<>();
-
         mappedAttributes.put(EavAttribute.GROUP.getAttribute(),
                 wrapStringValueForTemplate(eavEntityData.getGroup()));
         mappedAttributes.put(EavAttribute.TYPE.getAttribute(),
@@ -71,6 +70,16 @@ public class ProductAttributeMapper implements AttributeMapperInterface {
         mappedAttributes.put(EavAttribute.VISIBLE_ON_FRONT.getAttribute(),
                 Boolean.toString(eavEntityData.isVisibleOnFront()));
 
+        final String attributeOptions = getMappedOptions(
+                eavEntityData.getOptions(),
+                eavEntityData.getOptionsSortOrder()
+        );
+
+        if (!attributeOptions.isEmpty()) {
+            mappedAttributes.put(EavAttribute.OPTION.getAttribute(),
+                    getMappedOptions(eavEntityData.getOptions(), eavEntityData.getOptionsSortOrder()));
+        }
+
         return mappedAttributes;
     }
 
@@ -85,5 +94,63 @@ public class ProductAttributeMapper implements AttributeMapperInterface {
         return eavSource == null
                 || eavSource.equals(AttributeSourceModel.NULLABLE_SOURCE.getSource())
                 ? null : eavSource + "::class";
+    }
+
+    private String getMappedOptions(
+            final Map<Integer, String> optionValues,
+            final Map<Integer, String> optionSortOrders
+    ) {
+        if (optionValues == null || optionValues.isEmpty()) {
+            return "";
+        }
+
+        return "[" + getParsedOptions(optionValues)
+                + (optionSortOrders == null || optionSortOrders.isEmpty()
+                ? "->" : "," + getParsedOptionSortOrders(optionSortOrders)) + "]";
+    }
+
+    private String getParsedOptions(final Map<Integer, String> optionValues) {
+        final String valueNode = "->" + wrapStringValueForTemplate("value") + " => ";
+        final StringBuilder optionsContent = new StringBuilder();
+
+        for (final Integer optionKey : optionValues.keySet()) {
+            final String optionValue = optionValues.get(optionKey);
+
+            if (optionValue.isEmpty()) {
+                continue;
+            }
+
+            optionsContent
+                    .append("->")
+                    .append(wrapStringValueForTemplate("option_" + optionKey))
+                    .append(" => ")
+                    .append("[")
+                    .append(wrapStringValueForTemplate(optionValue))
+                    .append("], ");
+        }
+
+        return valueNode + "[" + optionsContent + "->]";
+    }
+
+    private String getParsedOptionSortOrders(final Map<Integer, String> optionSortOrders) {
+        final String orderNode = "->" + wrapStringValueForTemplate("order") + " => ";
+        final StringBuilder ordersContent = new StringBuilder();
+
+        for (final Integer optionKey : optionSortOrders.keySet()) {
+            final String orderValue = optionSortOrders.get(optionKey);
+
+            if (orderValue.isEmpty()) {
+                continue;
+            }
+
+            ordersContent
+                    .append("->")
+                    .append(wrapStringValueForTemplate("option_" + optionKey))
+                    .append(" => ")
+                    .append(orderValue)
+                    .append(",");
+        }
+
+        return orderNode + "[" + ordersContent + "->]->";
     }
 }

--- a/src/com/magento/idea/magento2plugin/magento/packages/eav/AttributeSourceModel.java
+++ b/src/com/magento/idea/magento2plugin/magento/packages/eav/AttributeSourceModel.java
@@ -11,7 +11,7 @@ public enum AttributeSourceModel {
     CONFIG("\\Magento\\Eav\\Model\\Entity\\Attribute\\Source\\Config"),
     STORE("\\Magento\\Eav\\Model\\Entity\\Attribute\\Source\\Store"),
     GENERATE_SOURCE("Custom Source"),
-    NULLABLE_SOURCE("Set Source Model as null");
+    NULLABLE_SOURCE("Without Source Model");
 
     private String source;
 

--- a/src/com/magento/idea/magento2plugin/magento/packages/eav/EavAttribute.java
+++ b/src/com/magento/idea/magento2plugin/magento/packages/eav/EavAttribute.java
@@ -19,7 +19,8 @@ public enum EavAttribute {
     IS_FILTERABLE_IN_GRID("is_filterable_in_grid"),
     VISIBLE("visible"),
     IS_HTML_ALLOWED_ON_FRONT("is_html_allowed_on_front"),
-    VISIBLE_ON_FRONT("visible_on_front");
+    VISIBLE_ON_FRONT("visible_on_front"),
+    OPTION("option");
 
     private String attribute;
 

--- a/testData/actions/generation/generator/EavAttributeSetupPatchGenerator/generateFileWithOptions/AddAttributeWithOptionsAttribute.php
+++ b/testData/actions/generation/generator/EavAttributeSetupPatchGenerator/generateFileWithOptions/AddAttributeWithOptionsAttribute.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Foo\Bar\Setup\Patch\Data;
+
+use Magento\Eav\Setup\EavSetup;
+use Magento\Eav\Setup\EavSetupFactory;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+
+class AddAttributeWithOptionsAttribute implements DataPatchInterface
+{
+
+    /**
+     * @var ModuleDataSetupInterface
+     */
+    private $moduleDataSetup;
+
+    /**
+     * @var EavSetupFactory
+     */
+    private $eavSetupFactory;
+
+    /**
+     * AddRecommendedAttribute constructor.
+     *
+     * @param ModuleDataSetupInterface $moduleDataSetup
+     * @param EavSetupFactory $eavSetupFactory
+     */
+    public function __construct(
+        ModuleDataSetupInterface $moduleDataSetup,
+        EavSetupFactory $eavSetupFactory
+    )
+    {
+        $this->moduleDataSetup = $moduleDataSetup;
+        $this->eavSetupFactory = $eavSetupFactory;
+    }
+
+    /**
+     * Get array of patches that have to be executed prior to this.
+     *
+     * Example of implementation:
+     *
+     * [
+     *      \Vendor_Name\Module_Name\Setup\Patch\Patch1::class,
+     *      \Vendor_Name\Module_Name\Setup\Patch\Patch2::class
+     * ]
+     *
+     * @return string[]
+     */
+    public static function getDependencies()
+    {
+        return [];
+    }
+
+    /**
+     * Get aliases (previous names) for the patch.
+     *
+     * @return string[]
+     */
+    public function getAliases()
+    {
+        return [];
+    }
+
+    /**
+     * Run code inside patch
+     * If code fails, patch must be reverted, in case when we are speaking about schema - then under revert
+     * means run PatchInterface::revert()
+     *
+     * If we speak about data, under revert means: $transaction->rollback()
+     *
+     * @return $this
+     */
+    public function apply()
+    {
+        /** @var EavSetup $eavSetup */
+        $eavSetup = $this->eavSetupFactory->create(['setup' => $this->moduleDataSetup]);
+
+        $eavSetup->addAttribute(
+            \Magento\Catalog\Model\Product::ENTITY,
+            'attribute_with_options',
+            [
+                'is_visible_in_grid' => false,
+                'is_html_allowed_on_front' => false,
+                'visible_on_front' => false,
+                'visible' => true,
+                'global' => \Magento\Eav\Model\Entity\Attribute\ScopedAttributeInterface::SCOPE_GLOBAL,
+                'label' => 'Attribute With Options',
+                'source' => null,
+                'type' => 'varchar',
+                'is_used_in_grid' => false,
+                'required' => false,
+                'input' => 'multiselect',
+                'is_filterable_in_grid' => false,
+                'sort_order' => 10,
+                'group' => 'General',
+                'option' => [
+                    'value' => [
+                        'option_0' => ['option1'],
+                        'option_1' => ['option2'],
+                        'option_2' => ['option3'],
+                    ]
+                ],
+            ]
+        );
+    }
+}

--- a/tests/com/magento/idea/magento2plugin/actions/generation/generator/EavAttributeSetupPatchGeneratorTest.java
+++ b/tests/com/magento/idea/magento2plugin/actions/generation/generator/EavAttributeSetupPatchGeneratorTest.java
@@ -9,6 +9,8 @@ import com.intellij.psi.PsiFile;
 import com.magento.idea.magento2plugin.actions.generation.data.ProductEntityData;
 import com.magento.idea.magento2plugin.magento.packages.eav.AttributeScope;
 import com.magento.idea.magento2plugin.magento.packages.eav.AttributeSourceModel;
+import java.util.HashMap;
+import java.util.Map;
 
 public class EavAttributeSetupPatchGeneratorTest extends BaseGeneratorTestCase {
     private final static String MODULE_NAME = "Foo_Bar";
@@ -109,6 +111,46 @@ public class EavAttributeSetupPatchGeneratorTest extends BaseGeneratorTestCase {
         final PsiFile dataPatchFile = setupPatchGenerator.generate("testGenerateFileWithBooleanSourceModel");
 
         final String filePatch = this.getFixturePath("AddAttributeWithCustomSourceAttribute.php");
+        final PsiFile expectedFile = myFixture.configureByFile(filePatch);
+
+        assertGeneratedFileIsCorrect(expectedFile, "src/app/code/Foo/Bar/Setup/Patch/Data", dataPatchFile);
+    }
+
+    public void testGenerateFileWithOptions() {
+        final Project project = myFixture.getProject();
+
+        final ProductEntityData productEntityData = new ProductEntityData();
+        productEntityData.setCode("attribute_with_options");
+        productEntityData.setVisibleInGrid(false);
+        productEntityData.setHtmlAllowedOnFront(false);
+        productEntityData.setVisibleOnFront(false);
+        productEntityData.setVisible(true);
+        productEntityData.setScope(AttributeScope.GLOBAL.getScope());
+        productEntityData.setLabel("Attribute With Options");
+        productEntityData.setType("varchar");
+        productEntityData.setUsedInGrid(false);
+        productEntityData.setRequired(false);
+        productEntityData.setInput("multiselect");
+        productEntityData.setSource(AttributeSourceModel.NULLABLE_SOURCE.getSource());
+        productEntityData.setFilterableInGrid(false);
+        productEntityData.setSortOrder(10);
+        productEntityData.setGroup("General");
+
+        final Map<Integer, String> options = new HashMap<>();
+        options.put(0, "option1");
+        options.put(1, "option2");
+        options.put(2, "option3");
+
+        productEntityData.setOptions(options);
+
+        productEntityData.setDataPatchName("AddAttributeWithOptionsAttribute");
+        productEntityData.setModuleName(MODULE_NAME);
+
+        final EavAttributeSetupPatchGenerator setupPatchGenerator =
+                new EavAttributeSetupPatchGenerator(productEntityData, project);
+        final PsiFile dataPatchFile = setupPatchGenerator.generate("testGenerateFileWithOptions");
+
+        final String filePatch = this.getFixturePath("AddAttributeWithOptionsAttribute.php");
         final PsiFile expectedFile = myFixture.configureByFile(filePatch);
 
         assertGeneratedFileIsCorrect(expectedFile, "src/app/code/Foo/Bar/Setup/Patch/Data", dataPatchFile);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description** (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Added possibility set options.  We can add options only if input type selected `multi-select` or `select` and didn’t set source model. 
For example  in this case we can’t  see options pane:
<img width="912" alt="Screenshot 2021-04-14 at 19 38 09" src="https://user-images.githubusercontent.com/29776509/114748164-4d093a80-9d5a-11eb-88e3-638e7391cb6d.png">

If we set source model as `Without Source Model` we can see options panel here:
<img width="912" alt="Screenshot 2021-04-14 at 19 38 31" src="https://user-images.githubusercontent.com/29776509/114748368-880b6e00-9d5a-11eb-9111-5ff089de23b0.png">

Now try to set options without sort orders: 

<img width="912" alt="Screenshot 2021-04-14 at 19 39 31" src="https://user-images.githubusercontent.com/29776509/114748501-ab361d80-9d5a-11eb-8b39-87eb6c28b344.png">

After generation we will see next data patch file:

<img width="1035" alt="Screenshot 2021-04-14 at 19 40 07" src="https://user-images.githubusercontent.com/29776509/114748589-c012b100-9d5a-11eb-83e8-ba58c6985163.png">

After `bin/magento setup:upgrade` command execution let's check the attribute in admin panel:

<img width="1655" alt="Screenshot 2021-04-14 at 19 42 24" src="https://user-images.githubusercontent.com/29776509/114748878-0405b600-9d5b-11eb-8b02-ac05a00e09c5.png">

As we can see, product options works as we expected.  On the product edit page it works as expected also:

<img width="1637" alt="Screenshot 2021-04-14 at 19 45 08" src="https://user-images.githubusercontent.com/29776509/114749010-27306580-9d5b-11eb-9e25-3ecaef94fb31.png">

Let's do the same but with sort ordered option: 

<img width="912" alt="Screenshot 2021-04-14 at 19 57 42" src="https://user-images.githubusercontent.com/29776509/114750124-4da2d080-9d5c-11eb-94ff-a3f9dd9f1548.png">

Generated file:

<img width="1002" alt="Screenshot 2021-04-14 at 19 59 16" src="https://user-images.githubusercontent.com/29776509/114750153-55627500-9d5c-11eb-8eb3-facdda7bf7a9.png">

Attribute in admin panel:

<img width="1675" alt="Screenshot 2021-04-14 at 20 00 56" src="https://user-images.githubusercontent.com/29776509/114750191-60b5a080-9d5c-11eb-96dd-03d46a7eee28.png">
<img width="1685" alt="Screenshot 2021-04-14 at 20 01 42" src="https://user-images.githubusercontent.com/29776509/114750196-6317fa80-9d5c-11eb-9771-9e99586ff9a1.png">


**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#545

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
