### PR TITLE
Completely removed unknown property for pmd extension

### DIFF
--- a/gradle-tasks/staticChecks.gradle
+++ b/gradle-tasks/staticChecks.gradle
@@ -19,7 +19,6 @@ checkstyle {
 pmd {
     toolVersion = "6.21.0"
     consoleOutput = true
-    rulesMinimumPriority = 5
     ruleSets = [
             rootProject.file("gradle-tasks/pmd/ruleset.xml")
     ]


### PR DESCRIPTION
**Description** (*)
This PR https://github.com/magento/magento2-phpstorm-plugin/pull/553 fixed the CI building but caused a new problem for the local environment. The rulesMinimumPriority setting property doesn’t work for the runIde Gradle task:
<img width="1559" alt="Screenshot 2021-04-15 at 22 59 24" src="https://user-images.githubusercontent.com/31848341/114931391-dc881980-9e3e-11eb-8f55-404603a27f04.png">

This is not a required setting. It is better to remove it at all.

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
