### PR TITLE
Refactored and improved EAV attribute generators

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCategoryEavAttributeDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCategoryEavAttributeDialog.form
@@ -3,7 +3,7 @@
   <grid id="28350" binding="contentPanel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
-      <xy x="-1" y="5" width="764" height="764"/>
+      <xy x="-1" y="5" width="764" height="805"/>
     </constraints>
     <properties>
       <enabled value="true"/>
@@ -11,7 +11,7 @@
     </properties>
     <border type="none"/>
     <children>
-      <grid id="6fc7e" layout-manager="GridLayoutManager" row-count="11" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="6fc7e" layout-manager="GridLayoutManager" row-count="16" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -23,7 +23,7 @@
         <children>
           <component id="7248b" class="javax.swing.JLabel">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -33,25 +33,15 @@
           </component>
           <component id="11452" class="javax.swing.JTextField" binding="codeTextField">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="3" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
             <properties/>
           </component>
-          <component id="ced84" class="javax.swing.JLabel">
-            <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-                <preferred-size width="144" height="15"/>
-              </grid>
-            </constraints>
-            <properties>
-              <text value="Label"/>
-            </properties>
-          </component>
           <component id="eee14" class="javax.swing.JLabel">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -61,15 +51,7 @@
           </component>
           <component id="26858" class="javax.swing.JTextField" binding="groupTextField">
             <constraints>
-              <grid row="4" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-                <preferred-size width="150" height="-1"/>
-              </grid>
-            </constraints>
-            <properties/>
-          </component>
-          <component id="ec512" class="javax.swing.JTextField" binding="labelTextField">
-            <constraints>
-              <grid row="3" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="7" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -77,7 +59,7 @@
           </component>
           <component id="20b6c" class="javax.swing.JLabel">
             <constraints>
-              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -87,7 +69,7 @@
           </component>
           <component id="2c543" class="javax.swing.JLabel">
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -97,7 +79,7 @@
           </component>
           <component id="4c86b" class="javax.swing.JTextField" binding="dataPatchNameTextField">
             <constraints>
-              <grid row="2" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="5" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -105,7 +87,7 @@
           </component>
           <component id="e7353" class="javax.swing.JLabel">
             <constraints>
-              <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -115,7 +97,7 @@
           </component>
           <component id="3ac94" class="javax.swing.JComboBox" binding="typeComboBox">
             <constraints>
-              <grid row="8" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="12" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
@@ -129,7 +111,7 @@
           </component>
           <component id="8675d" class="javax.swing.JLabel">
             <constraints>
-              <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="14" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -139,7 +121,7 @@
           </component>
           <component id="3084d" class="javax.swing.JTextField" binding="sortOrderTextField">
             <constraints>
-              <grid row="10" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="14" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -159,19 +141,19 @@
           </component>
           <component id="3c7c1" class="javax.swing.JComboBox" binding="inputComboBox">
             <constraints>
-              <grid row="5" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="9" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
           <component id="d345e" class="javax.swing.JComboBox" binding="scopeComboBox">
             <constraints>
-              <grid row="9" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="13" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
           <component id="230fe" class="javax.swing.JLabel">
             <constraints>
-              <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="13" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -182,7 +164,7 @@
           <grid id="77358" binding="sourcePanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="6" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+              <grid row="10" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <focusable value="true"/>
@@ -211,10 +193,10 @@
               </component>
             </children>
           </grid>
-          <grid id="bd748" binding="customSourceModelPanel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="bd748" binding="customSourceModelPanel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="7" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+              <grid row="11" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <visible value="true"/>
@@ -224,14 +206,14 @@
               <component id="93f75" class="javax.swing.JLabel">
                 <constraints>
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-                    <preferred-size width="100" height="15"/>
+                    <preferred-size width="144" height="15"/>
                   </grid>
                 </constraints>
                 <properties>
                   <text value="Source Model Directory"/>
                 </properties>
               </component>
-              <component id="1e113" class="javax.swing.JTextField" binding="sourceModelDirectoryTexField">
+              <component id="1e113" class="javax.swing.JTextField" binding="sourceModelDirectoryTextField">
                 <constraints>
                   <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
@@ -241,9 +223,9 @@
                   <text value=""/>
                 </properties>
               </component>
-              <component id="ab01b" class="javax.swing.JTextField" binding="sourceModelNameTexField">
+              <component id="ab01b" class="javax.swing.JTextField" binding="sourceModelNameTextField">
                 <constraints>
-                  <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
                   </grid>
                 </constraints>
@@ -251,16 +233,97 @@
               </component>
               <component id="c2c06" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-                    <preferred-size width="100" height="15"/>
+                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                    <preferred-size width="144" height="15"/>
                   </grid>
                 </constraints>
                 <properties>
                   <text value="Source Model Name"/>
                 </properties>
               </component>
+              <component id="908eb" class="javax.swing.JLabel" binding="sourceModelDirectoryTextFieldErrorMessage">
+                <constraints>
+                  <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Label"/>
+                  <visible value="false"/>
+                </properties>
+              </component>
+              <component id="67939" class="javax.swing.JLabel" binding="sourceModelNameTextFieldErrorMessage">
+                <constraints>
+                  <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Label"/>
+                  <visible value="false"/>
+                </properties>
+              </component>
             </children>
           </grid>
+          <component id="ced84" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="144" height="15"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value="Label"/>
+            </properties>
+          </component>
+          <component id="ec512" class="javax.swing.JTextField" binding="labelTextField">
+            <constraints>
+              <grid row="1" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="-1"/>
+              </grid>
+            </constraints>
+            <properties/>
+          </component>
+          <component id="dcc26" class="javax.swing.JLabel" binding="labelTextFieldErrorMessage">
+            <constraints>
+              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Label"/>
+              <visible value="false"/>
+            </properties>
+          </component>
+          <component id="915dd" class="javax.swing.JLabel" binding="codeTextFieldErrorMessage">
+            <constraints>
+              <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Label"/>
+              <visible value="false"/>
+            </properties>
+          </component>
+          <component id="43170" class="javax.swing.JLabel" binding="dataPatchNameTextFieldErrorMessage">
+            <constraints>
+              <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Label"/>
+              <visible value="false"/>
+            </properties>
+          </component>
+          <component id="25a0d" class="javax.swing.JLabel" binding="groupTextFieldErrorMessage">
+            <constraints>
+              <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Label"/>
+              <visible value="false"/>
+            </properties>
+          </component>
+          <component id="d47b9" class="javax.swing.JLabel" binding="sortOrderTextFieldErrorMessage">
+            <constraints>
+              <grid row="15" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Label"/>
+              <visible value="false"/>
+            </properties>
+          </component>
         </children>
       </grid>
       <hspacer id="75d92">

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCategoryEavAttributeDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCategoryEavAttributeDialog.form
@@ -23,7 +23,7 @@
         <children>
           <component id="7248b" class="javax.swing.JLabel">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -33,7 +33,7 @@
           </component>
           <component id="11452" class="javax.swing.JTextField" binding="codeTextField">
             <constraints>
-              <grid row="3" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="2" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -41,7 +41,7 @@
           </component>
           <component id="eee14" class="javax.swing.JLabel">
             <constraints>
-              <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -51,7 +51,7 @@
           </component>
           <component id="26858" class="javax.swing.JTextField" binding="groupTextField">
             <constraints>
-              <grid row="7" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="6" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -59,7 +59,7 @@
           </component>
           <component id="20b6c" class="javax.swing.JLabel">
             <constraints>
-              <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -69,7 +69,7 @@
           </component>
           <component id="2c543" class="javax.swing.JLabel">
             <constraints>
-              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -79,7 +79,7 @@
           </component>
           <component id="4c86b" class="javax.swing.JTextField" binding="dataPatchNameTextField">
             <constraints>
-              <grid row="5" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="4" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -87,7 +87,7 @@
           </component>
           <component id="e7353" class="javax.swing.JLabel">
             <constraints>
-              <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -97,21 +97,13 @@
           </component>
           <component id="3ac94" class="javax.swing.JComboBox" binding="typeComboBox">
             <constraints>
-              <grid row="12" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="11" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
-          <component id="40617" class="javax.swing.JCheckBox" binding="requiredCheckBox" default-binding="true">
-            <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Is Required"/>
-            </properties>
-          </component>
           <component id="8675d" class="javax.swing.JLabel">
             <constraints>
-              <grid row="14" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="13" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -121,7 +113,7 @@
           </component>
           <component id="3084d" class="javax.swing.JTextField" binding="sortOrderTextField">
             <constraints>
-              <grid row="14" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="13" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -129,31 +121,21 @@
               <text value="10"/>
             </properties>
           </component>
-          <component id="2a067" class="javax.swing.JCheckBox" binding="visibleCheckBox" default-binding="true">
-            <constraints>
-              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <enabled value="true"/>
-              <selected value="true"/>
-              <text value="Visible"/>
-            </properties>
-          </component>
           <component id="3c7c1" class="javax.swing.JComboBox" binding="inputComboBox">
             <constraints>
-              <grid row="9" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="8" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
           <component id="d345e" class="javax.swing.JComboBox" binding="scopeComboBox">
             <constraints>
-              <grid row="13" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="12" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
           <component id="230fe" class="javax.swing.JLabel">
             <constraints>
-              <grid row="13" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -164,7 +146,7 @@
           <grid id="77358" binding="sourcePanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="10" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+              <grid row="9" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <focusable value="true"/>
@@ -196,7 +178,7 @@
           <grid id="bd748" binding="customSourceModelPanel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="11" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+              <grid row="10" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <visible value="true"/>
@@ -263,7 +245,7 @@
           </grid>
           <component id="ced84" class="javax.swing.JLabel">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -273,7 +255,7 @@
           </component>
           <component id="ec512" class="javax.swing.JTextField" binding="labelTextField">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="0" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -281,7 +263,7 @@
           </component>
           <component id="dcc26" class="javax.swing.JLabel" binding="labelTextFieldErrorMessage">
             <constraints>
-              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Label"/>
@@ -290,7 +272,7 @@
           </component>
           <component id="915dd" class="javax.swing.JLabel" binding="codeTextFieldErrorMessage">
             <constraints>
-              <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Label"/>
@@ -299,7 +281,7 @@
           </component>
           <component id="43170" class="javax.swing.JLabel" binding="dataPatchNameTextFieldErrorMessage">
             <constraints>
-              <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Label"/>
@@ -308,7 +290,7 @@
           </component>
           <component id="25a0d" class="javax.swing.JLabel" binding="groupTextFieldErrorMessage">
             <constraints>
-              <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Label"/>
@@ -317,11 +299,37 @@
           </component>
           <component id="d47b9" class="javax.swing.JLabel" binding="sortOrderTextFieldErrorMessage">
             <constraints>
-              <grid row="15" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="14" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Label"/>
               <visible value="false"/>
+            </properties>
+          </component>
+          <component id="184ee" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Properties"/>
+            </properties>
+          </component>
+          <component id="40617" class="javax.swing.JCheckBox" binding="requiredCheckBox" default-binding="true">
+            <constraints>
+              <grid row="15" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Is Required"/>
+            </properties>
+          </component>
+          <component id="2a067" class="javax.swing.JCheckBox" binding="visibleCheckBox" default-binding="true">
+            <constraints>
+              <grid row="15" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <enabled value="true"/>
+              <selected value="true"/>
+              <text value="Visible"/>
             </properties>
           </component>
         </children>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCategoryEavAttributeDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCategoryEavAttributeDialog.java
@@ -14,12 +14,7 @@ import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.NotEmptyRule;
 import com.magento.idea.magento2plugin.actions.generation.generator.CategoryFormXmlGenerator;
 import com.magento.idea.magento2plugin.magento.packages.eav.AttributeScope;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JPanel;
-import javax.swing.JTable;
-import javax.swing.JTextField;
+import javax.swing.*;
 
 @SuppressWarnings({
         "PMD.TooManyFields",
@@ -62,13 +57,20 @@ public class NewCategoryEavAttributeDialog extends EavAttributeDialog {
     private JPanel customSourceModelPanel;
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
             message = {NotEmptyRule.MESSAGE, "Source Model Directory"})
-    private JTextField sourceModelDirectoryTexField;
+    private JTextField sourceModelDirectoryTextField;
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
             message = {NotEmptyRule.MESSAGE, "Source Model Name"})
-    private JTextField sourceModelNameTexField;
+    private JTextField sourceModelNameTextField;
     private JTable optionsTable;
     private JButton addNewOptionButton;
     private JPanel optionsPanel;
+    private JLabel codeTextFieldErrorMessage;
+    private JLabel labelTextFieldErrorMessage;
+    private JLabel dataPatchNameTextFieldErrorMessage;
+    private JLabel groupTextFieldErrorMessage;
+    private JLabel sourceModelDirectoryTextFieldErrorMessage;
+    private JLabel sourceModelNameTextFieldErrorMessage;
+    private JLabel sortOrderTextFieldErrorMessage;
 
     /**
      * Constructor.
@@ -83,7 +85,6 @@ public class NewCategoryEavAttributeDialog extends EavAttributeDialog {
             final String actionName
     ) {
         super(project, directory, actionName);
-
     }
 
     @Override
@@ -143,12 +144,12 @@ public class NewCategoryEavAttributeDialog extends EavAttributeDialog {
 
     @Override
     protected JTextField getAttributeSourceModelNameTexField() {
-        return sourceModelNameTexField;
+        return sourceModelNameTextField;
     }
 
     @Override
-    protected JTextField getSourceModelDirectoryTexField() {
-        return sourceModelDirectoryTexField;
+    protected JTextField getSourceModelDirectoryTextField() {
+        return sourceModelDirectoryTextField;
     }
 
     @Override
@@ -172,8 +173,8 @@ public class NewCategoryEavAttributeDialog extends EavAttributeDialog {
     }
 
     @Override
-    protected JTextField getSourceModelNameTexField() {
-        return sourceModelNameTexField;
+    protected JTextField getSourceModelNameTextField() {
+        return sourceModelNameTextField;
     }
 
     @Override

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCategoryEavAttributeDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCategoryEavAttributeDialog.java
@@ -14,7 +14,13 @@ import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.NotEmptyRule;
 import com.magento.idea.magento2plugin.actions.generation.generator.CategoryFormXmlGenerator;
 import com.magento.idea.magento2plugin.magento.packages.eav.AttributeScope;
-import javax.swing.*;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTable;
+import javax.swing.JTextField;
 
 @SuppressWarnings({
         "PMD.TooManyFields",

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCategoryEavAttributeDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCategoryEavAttributeDialog.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
 package com.magento.idea.magento2plugin.actions.generation.dialog;
 
 import com.intellij.openapi.project.Project;

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewProductEavAttributeDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewProductEavAttributeDialog.form
@@ -3,7 +3,7 @@
   <grid id="28350" binding="contentPanel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
-      <xy x="-1" y="5" width="764" height="764"/>
+      <xy x="-1" y="5" width="764" height="884"/>
     </constraints>
     <properties>
       <enabled value="true"/>
@@ -11,7 +11,7 @@
     </properties>
     <border type="none"/>
     <children>
-      <grid id="6fc7e" layout-manager="GridLayoutManager" row-count="15" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="6fc7e" layout-manager="GridLayoutManager" row-count="20" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -23,7 +23,7 @@
         <children>
           <component id="7248b" class="javax.swing.JLabel">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -31,27 +31,9 @@
               <text value="Attribute Code"/>
             </properties>
           </component>
-          <component id="11452" class="javax.swing.JTextField" binding="codeTextField">
-            <constraints>
-              <grid row="4" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-                <preferred-size width="150" height="-1"/>
-              </grid>
-            </constraints>
-            <properties/>
-          </component>
-          <component id="ced84" class="javax.swing.JLabel">
-            <constraints>
-              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-                <preferred-size width="144" height="15"/>
-              </grid>
-            </constraints>
-            <properties>
-              <text value="Label"/>
-            </properties>
-          </component>
           <component id="eee14" class="javax.swing.JLabel">
             <constraints>
-              <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -61,15 +43,7 @@
           </component>
           <component id="26858" class="javax.swing.JTextField" binding="groupTextField">
             <constraints>
-              <grid row="7" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-                <preferred-size width="150" height="-1"/>
-              </grid>
-            </constraints>
-            <properties/>
-          </component>
-          <component id="ec512" class="javax.swing.JTextField" binding="labelTextField">
-            <constraints>
-              <grid row="6" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="10" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -77,7 +51,7 @@
           </component>
           <component id="20b6c" class="javax.swing.JLabel">
             <constraints>
-              <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -87,7 +61,7 @@
           </component>
           <component id="2c543" class="javax.swing.JLabel">
             <constraints>
-              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -97,7 +71,7 @@
           </component>
           <component id="4c86b" class="javax.swing.JTextField" binding="dataPatchNameTextField">
             <constraints>
-              <grid row="5" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="8" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -105,7 +79,7 @@
           </component>
           <component id="e7353" class="javax.swing.JLabel">
             <constraints>
-              <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -115,7 +89,7 @@
           </component>
           <component id="3ac94" class="javax.swing.JComboBox" binding="typeComboBox">
             <constraints>
-              <grid row="11" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="15" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
@@ -129,7 +103,7 @@
           </component>
           <component id="8675d" class="javax.swing.JLabel">
             <constraints>
-              <grid row="13" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="17" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -139,7 +113,7 @@
           </component>
           <component id="3084d" class="javax.swing.JTextField" binding="sortOrderTextField">
             <constraints>
-              <grid row="13" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="17" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -204,19 +178,19 @@
           </component>
           <component id="3c7c1" class="javax.swing.JComboBox" binding="inputComboBox">
             <constraints>
-              <grid row="8" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="12" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
           <component id="d345e" class="javax.swing.JComboBox" binding="scopeComboBox">
             <constraints>
-              <grid row="12" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="16" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
           <component id="230fe" class="javax.swing.JLabel">
             <constraints>
-              <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="16" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -227,7 +201,7 @@
           <grid id="77358" binding="sourcePanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="9" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+              <grid row="13" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <focusable value="true"/>
@@ -256,10 +230,10 @@
               </component>
             </children>
           </grid>
-          <grid id="bd748" binding="customSourceModelPanel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="bd748" binding="customSourceModelPanel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="10" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+              <grid row="14" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <visible value="true"/>
@@ -269,14 +243,14 @@
               <component id="93f75" class="javax.swing.JLabel">
                 <constraints>
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-                    <preferred-size width="100" height="15"/>
+                    <preferred-size width="144" height="15"/>
                   </grid>
                 </constraints>
                 <properties>
                   <text value="Source Model Directory"/>
                 </properties>
               </component>
-              <component id="1e113" class="javax.swing.JTextField" binding="sourceModelDirectoryTexField">
+              <component id="1e113" class="javax.swing.JTextField" binding="sourceModelDirectoryTextField">
                 <constraints>
                   <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
@@ -286,9 +260,9 @@
                   <text value=""/>
                 </properties>
               </component>
-              <component id="ab01b" class="javax.swing.JTextField" binding="sourceModelNameTexField">
+              <component id="ab01b" class="javax.swing.JTextField" binding="sourceModelNameTextField">
                 <constraints>
-                  <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
                   </grid>
                 </constraints>
@@ -296,12 +270,30 @@
               </component>
               <component id="c2c06" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
-                    <preferred-size width="100" height="15"/>
+                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                    <preferred-size width="144" height="15"/>
                   </grid>
                 </constraints>
                 <properties>
                   <text value="Source Model Name"/>
+                </properties>
+              </component>
+              <component id="7219d" class="javax.swing.JLabel" binding="sourceModelDirectoryTextFieldErrorMessage">
+                <constraints>
+                  <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Label"/>
+                  <visible value="false"/>
+                </properties>
+              </component>
+              <component id="494be" class="javax.swing.JLabel" binding="sourceModelNameTextFieldErrorMessage">
+                <constraints>
+                  <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Label"/>
+                  <visible value="false"/>
                 </properties>
               </component>
             </children>
@@ -318,7 +310,7 @@
           <grid id="27880" binding="applyToPanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="14" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+              <grid row="19" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <visible value="false"/>
@@ -353,6 +345,77 @@
               </scrollpane>
             </children>
           </grid>
+          <component id="ced84" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="144" height="15"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value="Label"/>
+            </properties>
+          </component>
+          <component id="11452" class="javax.swing.JTextField" binding="codeTextField">
+            <constraints>
+              <grid row="6" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="-1"/>
+              </grid>
+            </constraints>
+            <properties/>
+          </component>
+          <component id="ec512" class="javax.swing.JTextField" binding="labelTextField">
+            <constraints>
+              <grid row="4" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="-1"/>
+              </grid>
+            </constraints>
+            <properties/>
+          </component>
+          <component id="52fef" class="javax.swing.JLabel" binding="labelTextFieldErrorMessage">
+            <constraints>
+              <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Label"/>
+              <visible value="false"/>
+            </properties>
+          </component>
+          <component id="b0e98" class="javax.swing.JLabel" binding="codeTextFieldErrorMessage">
+            <constraints>
+              <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Label"/>
+              <visible value="false"/>
+            </properties>
+          </component>
+          <component id="ff144" class="javax.swing.JLabel" binding="groupTextFieldErrorMessage">
+            <constraints>
+              <grid row="11" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Label"/>
+              <visible value="false"/>
+            </properties>
+          </component>
+          <component id="1fb43" class="javax.swing.JLabel" binding="sortOrderTextFieldErrorMessage">
+            <constraints>
+              <grid row="18" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Label"/>
+              <visible value="false"/>
+            </properties>
+          </component>
+          <component id="1ceca" class="javax.swing.JLabel" binding="dataPatchNameTextFieldErrorMessage">
+            <constraints>
+              <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Label"/>
+              <visible value="false"/>
+            </properties>
+          </component>
         </children>
       </grid>
       <hspacer id="75d92">

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewProductEavAttributeDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewProductEavAttributeDialog.form
@@ -3,7 +3,7 @@
   <grid id="28350" binding="contentPanel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
-      <xy x="-1" y="5" width="764" height="884"/>
+      <xy x="-1" y="5" width="764" height="959"/>
     </constraints>
     <properties>
       <enabled value="true"/>
@@ -23,7 +23,7 @@
         <children>
           <component id="7248b" class="javax.swing.JLabel">
             <constraints>
-              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -33,7 +33,7 @@
           </component>
           <component id="eee14" class="javax.swing.JLabel">
             <constraints>
-              <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -43,7 +43,7 @@
           </component>
           <component id="26858" class="javax.swing.JTextField" binding="groupTextField">
             <constraints>
-              <grid row="10" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="6" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -51,7 +51,7 @@
           </component>
           <component id="20b6c" class="javax.swing.JLabel">
             <constraints>
-              <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -61,7 +61,7 @@
           </component>
           <component id="2c543" class="javax.swing.JLabel">
             <constraints>
-              <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -71,7 +71,7 @@
           </component>
           <component id="4c86b" class="javax.swing.JTextField" binding="dataPatchNameTextField">
             <constraints>
-              <grid row="8" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="4" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -79,7 +79,7 @@
           </component>
           <component id="e7353" class="javax.swing.JLabel">
             <constraints>
-              <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -89,21 +89,13 @@
           </component>
           <component id="3ac94" class="javax.swing.JComboBox" binding="typeComboBox">
             <constraints>
-              <grid row="15" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="11" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
-          <component id="40617" class="javax.swing.JCheckBox" binding="requiredCheckBox" default-binding="true">
-            <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Is Required"/>
-            </properties>
-          </component>
           <component id="8675d" class="javax.swing.JLabel">
             <constraints>
-              <grid row="17" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="13" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -113,7 +105,7 @@
           </component>
           <component id="3084d" class="javax.swing.JTextField" binding="sortOrderTextField">
             <constraints>
-              <grid row="17" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="13" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -121,76 +113,21 @@
               <text value="10"/>
             </properties>
           </component>
-          <component id="aff93" class="javax.swing.JCheckBox" binding="visibleInGridCheckBox" default-binding="true">
-            <constraints>
-              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <selected value="false"/>
-              <text value="Is visible in grid"/>
-            </properties>
-          </component>
-          <component id="fb245" class="javax.swing.JCheckBox" binding="filterableInGridCheckBox" default-binding="true">
-            <constraints>
-              <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Is filterable in grid"/>
-            </properties>
-          </component>
-          <component id="d83ba" class="javax.swing.JCheckBox" binding="usedInGridGridCheckBox">
-            <constraints>
-              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <enabled value="true"/>
-              <selected value="false"/>
-              <text value="Is used in grid"/>
-            </properties>
-          </component>
-          <component id="2a067" class="javax.swing.JCheckBox" binding="visibleCheckBox" default-binding="true">
-            <constraints>
-              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <enabled value="true"/>
-              <selected value="true"/>
-              <text value="Visible"/>
-            </properties>
-          </component>
-          <component id="51e87" class="javax.swing.JCheckBox" binding="htmlAllowedOnCheckBox" default-binding="true">
-            <constraints>
-              <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <selected value="false"/>
-              <text value="Is html allowed on front"/>
-            </properties>
-          </component>
-          <component id="80e44" class="javax.swing.JCheckBox" binding="visibleOnFrontCheckBox" default-binding="true">
-            <constraints>
-              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <selected value="false"/>
-              <text value="Visible on front"/>
-            </properties>
-          </component>
           <component id="3c7c1" class="javax.swing.JComboBox" binding="inputComboBox">
             <constraints>
-              <grid row="12" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="8" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
           <component id="d345e" class="javax.swing.JComboBox" binding="scopeComboBox">
             <constraints>
-              <grid row="16" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="12" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
           <component id="230fe" class="javax.swing.JLabel">
             <constraints>
-              <grid row="16" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -201,7 +138,7 @@
           <grid id="77358" binding="sourcePanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="13" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+              <grid row="9" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <focusable value="true"/>
@@ -233,7 +170,7 @@
           <grid id="bd748" binding="customSourceModelPanel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="14" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+              <grid row="10" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <visible value="true"/>
@@ -298,15 +235,6 @@
               </component>
             </children>
           </grid>
-          <component id="64ef9" class="javax.swing.JCheckBox" binding="applyToAllProductsCheckBox">
-            <constraints>
-              <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <selected value="true"/>
-              <text value="Apply to all products types"/>
-            </properties>
-          </component>
           <grid id="27880" binding="applyToPanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
@@ -347,7 +275,7 @@
           </grid>
           <component id="ced84" class="javax.swing.JLabel">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="144" height="15"/>
               </grid>
             </constraints>
@@ -357,7 +285,7 @@
           </component>
           <component id="11452" class="javax.swing.JTextField" binding="codeTextField">
             <constraints>
-              <grid row="6" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="2" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -365,7 +293,7 @@
           </component>
           <component id="ec512" class="javax.swing.JTextField" binding="labelTextField">
             <constraints>
-              <grid row="4" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="0" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -373,7 +301,7 @@
           </component>
           <component id="52fef" class="javax.swing.JLabel" binding="labelTextFieldErrorMessage">
             <constraints>
-              <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Label"/>
@@ -382,7 +310,7 @@
           </component>
           <component id="b0e98" class="javax.swing.JLabel" binding="codeTextFieldErrorMessage">
             <constraints>
-              <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Label"/>
@@ -391,7 +319,7 @@
           </component>
           <component id="ff144" class="javax.swing.JLabel" binding="groupTextFieldErrorMessage">
             <constraints>
-              <grid row="11" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Label"/>
@@ -400,7 +328,7 @@
           </component>
           <component id="1fb43" class="javax.swing.JLabel" binding="sortOrderTextFieldErrorMessage">
             <constraints>
-              <grid row="18" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="14" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Label"/>
@@ -409,11 +337,91 @@
           </component>
           <component id="1ceca" class="javax.swing.JLabel" binding="dataPatchNameTextFieldErrorMessage">
             <constraints>
-              <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Label"/>
               <visible value="false"/>
+            </properties>
+          </component>
+          <component id="da439" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="15" column="0" row-span="4" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Properties"/>
+            </properties>
+          </component>
+          <component id="40617" class="javax.swing.JCheckBox" binding="requiredCheckBox" default-binding="true">
+            <constraints>
+              <grid row="15" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Is Required"/>
+            </properties>
+          </component>
+          <component id="2a067" class="javax.swing.JCheckBox" binding="visibleCheckBox" default-binding="true">
+            <constraints>
+              <grid row="15" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <enabled value="true"/>
+              <selected value="true"/>
+              <text value="Visible"/>
+            </properties>
+          </component>
+          <component id="aff93" class="javax.swing.JCheckBox" binding="visibleInGridCheckBox" default-binding="true">
+            <constraints>
+              <grid row="16" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <selected value="false"/>
+              <text value="Is visible in grid"/>
+            </properties>
+          </component>
+          <component id="d83ba" class="javax.swing.JCheckBox" binding="usedInGridGridCheckBox">
+            <constraints>
+              <grid row="17" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <enabled value="true"/>
+              <selected value="false"/>
+              <text value="Is used in grid"/>
+            </properties>
+          </component>
+          <component id="80e44" class="javax.swing.JCheckBox" binding="visibleOnFrontCheckBox" default-binding="true">
+            <constraints>
+              <grid row="18" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <selected value="false"/>
+              <text value="Visible on front"/>
+            </properties>
+          </component>
+          <component id="fb245" class="javax.swing.JCheckBox" binding="filterableInGridCheckBox" default-binding="true">
+            <constraints>
+              <grid row="16" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Is filterable in grid"/>
+            </properties>
+          </component>
+          <component id="51e87" class="javax.swing.JCheckBox" binding="htmlAllowedOnCheckBox" default-binding="true">
+            <constraints>
+              <grid row="17" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <selected value="false"/>
+              <text value="Is html allowed on front"/>
+            </properties>
+          </component>
+          <component id="64ef9" class="javax.swing.JCheckBox" binding="applyToAllProductsCheckBox">
+            <constraints>
+              <grid row="18" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <selected value="true"/>
+              <text value="Apply to all products types"/>
             </properties>
           </component>
         </children>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewProductEavAttributeDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewProductEavAttributeDialog.java
@@ -21,7 +21,15 @@ import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.
 import com.magento.idea.magento2plugin.magento.packages.eav.AttributeScope;
 import com.magento.idea.magento2plugin.util.magento.GetProductTypesListUtil;
 import java.util.List;
-import javax.swing.*;
+import javax.swing.DefaultListModel;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.JTable;
+import javax.swing.JTextField;
 
 @SuppressWarnings({
         "PMD.TooManyFields",

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewProductEavAttributeDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewProductEavAttributeDialog.java
@@ -21,14 +21,7 @@ import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.
 import com.magento.idea.magento2plugin.magento.packages.eav.AttributeScope;
 import com.magento.idea.magento2plugin.util.magento.GetProductTypesListUtil;
 import java.util.List;
-import javax.swing.DefaultListModel;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JList;
-import javax.swing.JPanel;
-import javax.swing.JTable;
-import javax.swing.JTextField;
+import javax.swing.*;
 
 @SuppressWarnings({
         "PMD.TooManyFields",
@@ -76,10 +69,10 @@ public class NewProductEavAttributeDialog extends EavAttributeDialog {
     private JPanel customSourceModelPanel;
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
             message = {NotEmptyRule.MESSAGE, "Source Model Directory"})
-    private JTextField sourceModelDirectoryTexField;
+    private JTextField sourceModelDirectoryTextField;
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
             message = {NotEmptyRule.MESSAGE, "Source Model Name"})
-    private JTextField sourceModelNameTexField;
+    private JTextField sourceModelNameTextField;
     private JTable optionsTable;
     private JButton addNewOptionButton;
     private JPanel optionsPanel;
@@ -88,6 +81,13 @@ public class NewProductEavAttributeDialog extends EavAttributeDialog {
     private JCheckBox applyToAllProductsCheckBox;
     private JPanel applyToPanel;
     private JList productsTypesList;
+    private JLabel labelTextFieldErrorMessage;
+    private JLabel codeTextFieldErrorMessage;
+    private JLabel dataPatchNameTextFieldErrorMessage;
+    private JLabel groupTextFieldErrorMessage;
+    private JLabel sourceModelDirectoryTextFieldErrorMessage;
+    private JLabel sourceModelNameTextFieldErrorMessage;
+    private JLabel sortOrderTextFieldErrorMessage;
 
     /**
      * Constructor.
@@ -162,12 +162,12 @@ public class NewProductEavAttributeDialog extends EavAttributeDialog {
 
     @Override
     protected JTextField getAttributeSourceModelNameTexField() {
-        return sourceModelNameTexField;
+        return sourceModelNameTextField;
     }
 
     @Override
-    protected JTextField getSourceModelDirectoryTexField() {
-        return sourceModelDirectoryTexField;
+    protected JTextField getSourceModelDirectoryTextField() {
+        return sourceModelDirectoryTextField;
     }
 
     @Override
@@ -191,8 +191,8 @@ public class NewProductEavAttributeDialog extends EavAttributeDialog {
     }
 
     @Override
-    protected JTextField getSourceModelNameTexField() {
-        return sourceModelNameTexField;
+    protected JTextField getSourceModelNameTextField() {
+        return sourceModelNameTextField;
     }
 
     @Override

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/eavattribute/EavAttributeDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/eavattribute/EavAttributeDialog.java
@@ -11,12 +11,7 @@ import com.magento.idea.magento2plugin.actions.generation.data.EavEntityDataInte
 import com.magento.idea.magento2plugin.actions.generation.data.SourceModelData;
 import com.magento.idea.magento2plugin.actions.generation.data.ui.ComboBoxItemData;
 import com.magento.idea.magento2plugin.actions.generation.dialog.AbstractDialog;
-import com.magento.idea.magento2plugin.actions.generation.dialog.event.eavdialog.AttributeSourcePanelComponentListener;
-import com.magento.idea.magento2plugin.actions.generation.dialog.event.eavdialog.AttributeSourceRelationsItemListener;
-import com.magento.idea.magento2plugin.actions.generation.dialog.event.eavdialog.DataPatchNameAdapter;
-import com.magento.idea.magento2plugin.actions.generation.dialog.event.eavdialog.EavAttributeInputItemListener;
-import com.magento.idea.magento2plugin.actions.generation.dialog.event.eavdialog.OptionsPanelVisibilityChangeListener;
-import com.magento.idea.magento2plugin.actions.generation.dialog.event.eavdialog.SourceModelNameAdapter;
+import com.magento.idea.magento2plugin.actions.generation.dialog.event.eavdialog.*;
 import com.magento.idea.magento2plugin.actions.generation.dialog.util.eavdialog.AttributeUtil;
 import com.magento.idea.magento2plugin.actions.generation.generator.EavAttributeSetupPatchGenerator;
 import com.magento.idea.magento2plugin.actions.generation.generator.SourceModelGenerator;
@@ -42,6 +37,7 @@ import javax.swing.JPanel;
 import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
+import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings({"PMD.GodClass", "PMD.TooManyMethods"})
 public abstract class  EavAttributeDialog extends AbstractDialog {
@@ -72,7 +68,7 @@ public abstract class  EavAttributeDialog extends AbstractDialog {
 
     protected abstract JTextField getAttributeSourceModelNameTexField();
 
-    protected abstract JTextField getSourceModelDirectoryTexField();
+    protected abstract JTextField getSourceModelDirectoryTextField();
 
     protected abstract JPanel getAttributeCustomSourceModelPanel();
 
@@ -82,7 +78,7 @@ public abstract class  EavAttributeDialog extends AbstractDialog {
 
     protected abstract JTextField getDataPatchNameTextField();
 
-    protected abstract JTextField getSourceModelNameTexField();
+    protected abstract JTextField getSourceModelNameTextField();
 
     protected abstract JTextField getAttributeLabelTexField();
 
@@ -121,6 +117,7 @@ public abstract class  EavAttributeDialog extends AbstractDialog {
         this.initBaseDialogState();
         pack();
         centerDialog(this);
+        setTitle(actionName);
         setVisible(true);
     }
 
@@ -151,7 +148,7 @@ public abstract class  EavAttributeDialog extends AbstractDialog {
 
         this.setSourceModelPanelAction(
                 getAttributeCustomSourceModelPanel(),
-                getSourceModelDirectoryTexField()
+                getSourceModelDirectoryTextField()
         );
         this.addOptionPanelListener(
                 getAttributeSourceComboBox(),
@@ -159,13 +156,17 @@ public abstract class  EavAttributeDialog extends AbstractDialog {
                 getAttributeOptionsPanel()
         );
         this.setDefaultSources(getAttributeSourceComboBox());
+        this.setAutocompleteListenerForAttributeCodeField(
+                getAttributeLabelTexField(),
+                getAttributeCodeTextField()
+        );
         this.setAutocompleteListenerForDataPathNameField(
                 getAttributeCodeTextField(),
                 getDataPatchNameTextField()
         );
         this.setAutocompleteListenerForSourceModelNameField(
                 getAttributeCodeTextField(),
-                getSourceModelNameTexField()
+                getSourceModelNameTextField()
         );
     }
 
@@ -241,6 +242,8 @@ public abstract class  EavAttributeDialog extends AbstractDialog {
     }
 
     protected void onOk() {
+        stopOptionsTableEditing(getOptionsTable());
+
         if (!validateFormFields()) {
             return;
         }
@@ -267,7 +270,7 @@ public abstract class  EavAttributeDialog extends AbstractDialog {
 
         sourceModelData.setModuleName(moduleName);
         sourceModelData.setClassName(getAttributeSourceModelNameTexField().getText().trim());
-        sourceModelData.setDirectory(getSourceModelDirectoryTexField().getText().trim());
+        sourceModelData.setDirectory(getSourceModelDirectoryTextField().getText().trim());
 
         new SourceModelGenerator(sourceModelData, project, true)
                 .generate(actionName, false);
@@ -386,6 +389,14 @@ public abstract class  EavAttributeDialog extends AbstractDialog {
         sourceComboBox.setSelectedItem(defaultSourceItem);
     }
 
+    protected void setAutocompleteListenerForAttributeCodeField(
+            @NotNull final JTextField attributeLabelTextField,
+            @NotNull final JTextField attributeCodeTextField
+    ) {
+        attributeLabelTextField.getDocument()
+                .addDocumentListener(new AttributeCodeAdapter(attributeCodeTextField));
+    }
+
     @SuppressWarnings("PMD.AccessorMethodGeneration")
     protected void setAutocompleteListenerForDataPathNameField(
             final JTextField mainTextField,
@@ -492,5 +503,11 @@ public abstract class  EavAttributeDialog extends AbstractDialog {
         return GetAttributeOptionPropertiesUtil.getSortOrders(
                 entityPropertiesTableGroupWrapper.getColumnsData()
         );
+    }
+
+    private void stopOptionsTableEditing(final JTable optionsTable) {
+        if (optionsTable != null && optionsTable.isEditing()) {
+            optionsTable.getCellEditor().stopCellEditing();
+        }
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/eavattribute/EavAttributeDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/eavattribute/EavAttributeDialog.java
@@ -11,7 +11,13 @@ import com.magento.idea.magento2plugin.actions.generation.data.EavEntityDataInte
 import com.magento.idea.magento2plugin.actions.generation.data.SourceModelData;
 import com.magento.idea.magento2plugin.actions.generation.data.ui.ComboBoxItemData;
 import com.magento.idea.magento2plugin.actions.generation.dialog.AbstractDialog;
-import com.magento.idea.magento2plugin.actions.generation.dialog.event.eavdialog.*;
+import com.magento.idea.magento2plugin.actions.generation.dialog.event.eavdialog.AttributeCodeAdapter;
+import com.magento.idea.magento2plugin.actions.generation.dialog.event.eavdialog.AttributeSourcePanelComponentListener;
+import com.magento.idea.magento2plugin.actions.generation.dialog.event.eavdialog.AttributeSourceRelationsItemListener;
+import com.magento.idea.magento2plugin.actions.generation.dialog.event.eavdialog.DataPatchNameAdapter;
+import com.magento.idea.magento2plugin.actions.generation.dialog.event.eavdialog.EavAttributeInputItemListener;
+import com.magento.idea.magento2plugin.actions.generation.dialog.event.eavdialog.OptionsPanelVisibilityChangeListener;
+import com.magento.idea.magento2plugin.actions.generation.dialog.event.eavdialog.SourceModelNameAdapter;
 import com.magento.idea.magento2plugin.actions.generation.dialog.util.eavdialog.AttributeUtil;
 import com.magento.idea.magento2plugin.actions.generation.generator.EavAttributeSetupPatchGenerator;
 import com.magento.idea.magento2plugin.actions.generation.generator.SourceModelGenerator;

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/event/eavdialog/AttributeCodeAdapter.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/event/eavdialog/AttributeCodeAdapter.java
@@ -1,7 +1,6 @@
 /*
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
- *
  */
 
 package com.magento.idea.magento2plugin.actions.generation.dialog.event.eavdialog;
@@ -42,7 +41,6 @@ public class AttributeCodeAdapter extends DocumentAdapter {
     private String convertLabelToAttributeCode(final String attributeLabel) {
         final String formattedAttributeLabel = attributeLabel.trim().toLowerCase(Locale.ROOT);
 
-        //replace 2 or more spaces with underscore
         return formattedAttributeLabel.replaceAll("^ +| +$|( )+", "_");
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/event/eavdialog/AttributeCodeAdapter.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/event/eavdialog/AttributeCodeAdapter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ *
+ */
+
+package com.magento.idea.magento2plugin.actions.generation.dialog.event.eavdialog;
+
+import com.intellij.ui.DocumentAdapter;
+import java.util.Locale;
+import javax.swing.JTextField;
+import javax.swing.event.DocumentEvent;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import org.jetbrains.annotations.NotNull;
+
+public class AttributeCodeAdapter extends DocumentAdapter {
+
+    private final JTextField attributeCodeTextField;
+
+    public AttributeCodeAdapter(@NotNull final JTextField attributeCodeTextField) {
+        super();
+        this.attributeCodeTextField = attributeCodeTextField;
+    }
+
+    @Override
+    protected void textChanged(final @NotNull DocumentEvent event) {
+        final Document document = event.getDocument();
+
+        try {
+            final String attributeLabel = document.getText(
+                    0, document.getEndPosition().getOffset()
+            ).trim();
+            attributeCodeTextField.setText(
+                    convertLabelToAttributeCode(attributeLabel)
+            );
+        } catch (BadLocationException badLocationException) {
+            return;
+        }
+    }
+
+    private String convertLabelToAttributeCode(final String attributeLabel) {
+        final String formattedAttributeLabel = attributeLabel.trim().toLowerCase(Locale.ROOT);
+
+        //replace 2 or more spaces with underscore
+        return formattedAttributeLabel.replaceAll("^ +| +$|( )+", "_");
+    }
+}


### PR DESCRIPTION
Implementing change request:

> 1. Change a bit the order of fields. First field should be Label, based on which the Attribute Code should be autocompleted
> 2. Provide a fields' validation as we did for Entity Generator
> 3. Pay attention at the following PR, as it also actual in scope of Product/Category Attribute generators
> 4. We should be more strict with Group, because if we enter My Group, then Magento generates it as my-group, however the generator adds it as my_group in ui_component form file

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description** (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

1. Changed order of fields for Product and Category entity attribute generation, Attribute Code field autocompletes based on Label field:
![Screenshot 2021-04-23 at 10 08 32](https://user-images.githubusercontent.com/29776509/115832748-ee0f8980-a41b-11eb-86e3-52c8a427ad85.png)
![Screenshot 2021-04-23 at 10 08 46](https://user-images.githubusercontent.com/29776509/115832753-efd94d00-a41b-11eb-82b2-73fb983939b7.png)

2. Fixed fields validation:
![Screenshot 2021-04-23 at 10 09 33](https://user-images.githubusercontent.com/29776509/115832843-0a132b00-a41c-11eb-8f5d-4e8e54cb6e0c.png)
![Screenshot 2021-04-23 at 10 09 41](https://user-images.githubusercontent.com/29776509/115832852-0bdcee80-a41c-11eb-933c-12d880d01ac0.png)

3. Fixed tables editing bug

4. We change Group input only for ui_component (for fieldset name) but ```attribute_group_code``` installs without changes. For example: 
ui_component will looks like: 

```
<?xml version="1.0"?>
<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
    <fieldset name="my_group">
        <field name="my_group_attribute1" sortOrder="10" formElement="input"/>
    </fieldset>
</form>
```

In Db it looks like  as expected: 
![Screenshot 2021-04-23 at 10 12 41](https://user-images.githubusercontent.com/29776509/115833945-4f842800-a41d-11eb-819d-bb20724dad32.png)

In admin panel: 
![Screenshot 2021-04-23 at 10 19 55](https://user-images.githubusercontent.com/29776509/115834190-9a9e3b00-a41d-11eb-9b2a-440ba7f21e10.png)

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#<issue_number>

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
