### PR TITLE
Fixed wrong new entity layout name and edit entity layout name inside it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## 3.2.2
 
+### Fixed
+
+- New entity layout name and edit entity layout name inside it
+
 ## 3.2.1
 
 ### Fixed

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEntityDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEntityDialog.java
@@ -50,7 +50,6 @@ import com.magento.idea.magento2plugin.stubs.indexes.xml.MenuIndex;
 import com.magento.idea.magento2plugin.ui.FilteredComboBox;
 import com.magento.idea.magento2plugin.ui.table.TableGroupWrapper;
 import com.magento.idea.magento2plugin.util.CamelCaseToSnakeCase;
-import com.magento.idea.magento2plugin.util.FirstLetterToLowercaseUtil;
 import com.magento.idea.magento2plugin.util.magento.GetAclResourcesListUtil;
 import com.magento.idea.magento2plugin.util.magento.GetModuleNameByDirectoryUtil;
 import java.awt.Cursor;
@@ -445,7 +444,7 @@ public class NewEntityDialog extends AbstractDialog {
         final String dtoInterfaceClassName = entityName.concat(DTO_INTERFACE_SUFFIX);
 
         final String actionsPathPrefix = dialogData.getRoute() + File.separator
-                + FirstLetterToLowercaseUtil.convert(entityName) + File.separator;
+                + entityName.toLowerCase(Locale.getDefault()) + File.separator;
         final NamespaceBuilder dtoModelNamespace =
                 new DataModelFile(moduleName, dtoClassName).getNamespaceBuilder();
         final NamespaceBuilder dtoInterfaceNamespace =


### PR DESCRIPTION
**Description** (*)
There is an issue detected in the entity creator feature. If you want to create entity with "double" name like TestEntity, new entity layout and edit entity layout inside it have wrong names:

<img width="508" alt="Screenshot 2021-04-26 at 15 19 13" src="https://user-images.githubusercontent.com/31848341/116083219-0e9e4480-a6a5-11eb-9263-11ca7ce8894f.png">
<img width="508" alt="Screenshot 2021-04-26 at 15 19 32" src="https://user-images.githubusercontent.com/31848341/116083216-0e05ae00-a6a5-11eb-8f2b-f5b64bcae801.png">
<img width="526" alt="Screenshot 2021-04-26 at 15 19 58" src="https://user-images.githubusercontent.com/31848341/116083214-0d6d1780-a6a5-11eb-9c54-b0c91086578d.png">

This PR created to fix this issue. The result:

<img width="526" alt="Screenshot 2021-04-26 at 15 31 58" src="https://user-images.githubusercontent.com/31848341/116083206-0ba35400-a6a5-11eb-9bdf-bc16a8d21b27.png">
<img width="526" alt="Screenshot 2021-04-26 at 15 31 50" src="https://user-images.githubusercontent.com/31848341/116083213-0d6d1780-a6a5-11eb-9cd3-e5a9e62a6677.png">


**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
