### PR TITLE
Simplified file properties definition for the php file generation

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/DataModelGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/DataModelGenerator.java
@@ -7,8 +7,6 @@ package com.magento.idea.magento2plugin.actions.generation.generator;
 
 import com.intellij.openapi.project.Project;
 import com.magento.idea.magento2plugin.actions.generation.data.DataModelData;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassTypesBuilder;
 import com.magento.idea.magento2plugin.magento.files.AbstractPhpFile;
 import com.magento.idea.magento2plugin.magento.files.DataModelFile;
 import com.magento.idea.magento2plugin.magento.files.DataModelInterfaceFile;
@@ -60,29 +58,20 @@ public class DataModelGenerator extends PhpFileGenerator {
      */
     @Override
     protected void fillAttributes(final @NotNull Properties attributes) {
-        final PhpClassTypesBuilder phpClassTypesBuilder = new PhpClassTypesBuilder();
-
-        phpClassTypesBuilder
-                .appendProperty("NAMESPACE", file.getNamespace())
-                .appendProperty("NAME", data.getName())
-                .appendProperty("PROPERTIES", data.getProperties())
-                .appendProperty("HASINTERFACE", Boolean.toString(data.hasInterface()))
+        typesBuilder
+                .append("NAMESPACE", file.getNamespace(), false)
+                .append("NAME", data.getName(), false)
+                .append("PROPERTIES", data.getProperties(), false)
+                .append("HASINTERFACE", Boolean.toString(data.hasInterface()), false)
                 .append("EXTENDS", DataModelFile.DATA_OBJECT);
 
         if (data.hasInterface()) {
-            phpClassTypesBuilder.append(
+            typesBuilder.append(
                     "IMPLEMENTS",
                     new DataModelInterfaceFile(
                             data.getModuleName(),
                             data.getInterfaceName()
                     ).getClassFqn());
         }
-
-        phpClassTypesBuilder.mergeProperties(attributes);
-
-        attributes.setProperty(
-                "USES",
-                PhpClassGeneratorUtil.formatUses(phpClassTypesBuilder.getUses())
-        );
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/DeleteEntityByIdCommandGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/DeleteEntityByIdCommandGenerator.java
@@ -7,8 +7,6 @@ package com.magento.idea.magento2plugin.actions.generation.generator;
 
 import com.intellij.openapi.project.Project;
 import com.magento.idea.magento2plugin.actions.generation.data.DeleteEntityByIdCommandData;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassTypesBuilder;
 import com.magento.idea.magento2plugin.magento.files.AbstractPhpFile;
 import com.magento.idea.magento2plugin.magento.files.ModelFile;
 import com.magento.idea.magento2plugin.magento.files.ResourceModelFile;
@@ -63,18 +61,17 @@ public class DeleteEntityByIdCommandGenerator extends PhpFileGenerator {
      */
     @Override
     protected void fillAttributes(final @NotNull Properties attributes) {
-        final PhpClassTypesBuilder phpClassTypesBuilder = new PhpClassTypesBuilder();
         final ModelFile modelFile = new ModelFile(data.getModuleName(), data.getModelName());
         final String modelType = modelFile.getClassFqn();
         final String modelFactoryType = modelType.concat("Factory");
         final ResourceModelFile resourceFile =
                 new ResourceModelFile(data.getModuleName(), data.getResourceModelName());
 
-        phpClassTypesBuilder
-                .appendProperty("ENTITY_NAME", data.getEntityName())
-                .appendProperty("NAMESPACE", file.getNamespace())
-                .appendProperty("CLASS_NAME", DeleteEntityByIdCommandFile.CLASS_NAME)
-                .appendProperty("ENTITY_ID", data.getEntityId())
+        typesBuilder
+                .append("ENTITY_NAME", data.getEntityName(), false)
+                .append("NAMESPACE", file.getNamespace(), false)
+                .append("CLASS_NAME", DeleteEntityByIdCommandFile.CLASS_NAME, false)
+                .append("ENTITY_ID", data.getEntityId(), false)
                 .append("Exception", "Exception")
                 .append("COULD_NOT_DELETE", ExceptionType.COULD_NOT_DELETE.getType())
                 .append("NO_SUCH_ENTITY_EXCEPTION",
@@ -82,10 +79,6 @@ public class DeleteEntityByIdCommandGenerator extends PhpFileGenerator {
                 .append("LOGGER", FrameworkLibraryType.LOGGER.getType())
                 .append("MODEL", modelType)
                 .append("MODEL_FACTORY", modelFactoryType)
-                .append("RESOURCE", resourceFile.getClassFqn())
-                .mergeProperties(attributes);
-
-        attributes.setProperty("USES",
-                PhpClassGeneratorUtil.formatUses(phpClassTypesBuilder.getUses()));
+                .append("RESOURCE", resourceFile.getClassFqn());
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/DeleteEntityControllerFileGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/DeleteEntityControllerFileGenerator.java
@@ -7,8 +7,6 @@ package com.magento.idea.magento2plugin.actions.generation.generator;
 
 import com.intellij.openapi.project.Project;
 import com.magento.idea.magento2plugin.actions.generation.data.DeleteEntityControllerFileData;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassTypesBuilder;
 import com.magento.idea.magento2plugin.magento.files.AbstractPhpFile;
 import com.magento.idea.magento2plugin.magento.files.actions.DeleteActionFile;
 import com.magento.idea.magento2plugin.magento.files.commands.DeleteEntityByIdCommandFile;
@@ -64,14 +62,12 @@ public class DeleteEntityControllerFileGenerator extends PhpFileGenerator {
      */
     @Override
     protected void fillAttributes(final @NotNull Properties attributes) {
-        final PhpClassTypesBuilder phpClassTypesBuilder = new PhpClassTypesBuilder();
-
-        phpClassTypesBuilder
-                .appendProperty("NAMESPACE", file.getNamespace())
-                .appendProperty("ENTITY_NAME", data.getEntityName())
-                .appendProperty("CLASS_NAME", DeleteActionFile.CLASS_NAME)
-                .appendProperty("ADMIN_RESOURCE", data.getAcl())
-                .appendProperty("ENTITY_ID", data.getEntityId())
+        typesBuilder
+                .append("NAMESPACE", file.getNamespace(), false)
+                .append("ENTITY_NAME", data.getEntityName(), false)
+                .append("CLASS_NAME", DeleteActionFile.CLASS_NAME, false)
+                .append("ADMIN_RESOURCE", data.getAcl(), false)
+                .append("ENTITY_ID", data.getEntityId(), false)
                 .append("DELETE_COMMAND",
                         new DeleteEntityByIdCommandFile(
                                 data.getModuleName(),
@@ -86,10 +82,6 @@ public class DeleteEntityControllerFileGenerator extends PhpFileGenerator {
                 .append("IMPLEMENTS_GET", HttpMethod.GET.getInterfaceFqn())
                 .append("NO_SUCH_ENTITY_EXCEPTION",
                         ExceptionType.NO_SUCH_ENTITY_EXCEPTION.getType())
-                .append("COULD_NOT_DELETE", ExceptionType.COULD_NOT_DELETE.getType())
-                .mergeProperties(attributes);
-
-        attributes.setProperty("USES",
-                PhpClassGeneratorUtil.formatUses(phpClassTypesBuilder.getUses()));
+                .append("COULD_NOT_DELETE", ExceptionType.COULD_NOT_DELETE.getType());
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/EditEntityActionGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/EditEntityActionGenerator.java
@@ -7,8 +7,6 @@ package com.magento.idea.magento2plugin.actions.generation.generator;
 
 import com.intellij.openapi.project.Project;
 import com.magento.idea.magento2plugin.actions.generation.data.EditEntityActionData;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassTypesBuilder;
 import com.magento.idea.magento2plugin.magento.files.AbstractPhpFile;
 import com.magento.idea.magento2plugin.magento.files.actions.EditActionFile;
 import com.magento.idea.magento2plugin.magento.packages.HttpMethod;
@@ -62,22 +60,16 @@ public class EditEntityActionGenerator extends PhpFileGenerator {
      */
     @Override
     protected void fillAttributes(final @NotNull Properties attributes) {
-        final PhpClassTypesBuilder phpClassTypesBuilder = new PhpClassTypesBuilder();
-
-        phpClassTypesBuilder
-                .appendProperty("NAMESPACE", file.getNamespace())
-                .appendProperty("ENTITY_NAME", data.getEntityName())
-                .appendProperty("CLASS_NAME", file.getClassName())
-                .appendProperty("ADMIN_RESOURCE", data.getAcl())
-                .appendProperty("MENU_IDENTIFIER", data.getMenu())
+        typesBuilder
+                .append("NAMESPACE", file.getNamespace(), false)
+                .append("ENTITY_NAME", data.getEntityName(), false)
+                .append("CLASS_NAME", file.getClassName(), false)
+                .append("ADMIN_RESOURCE", data.getAcl(), false)
+                .append("MENU_IDENTIFIER", data.getMenu(), false)
                 .append("EXTENDS", BackendModuleType.EXTENDS.getType())
                 .append("IMPLEMENTS", HttpMethod.GET.getInterfaceFqn())
                 .append("RESULT_INTERFACE", FrameworkLibraryType.RESULT_INTERFACE.getType())
                 .append("RESULT_FACTORY", FrameworkLibraryType.RESULT_FACTORY.getType())
-                .append("RESULT_PAGE", BackendModuleType.RESULT_PAGE.getType())
-                .mergeProperties(attributes);
-
-        attributes.setProperty("USES",
-                PhpClassGeneratorUtil.formatUses(phpClassTypesBuilder.getUses()));
+                .append("RESULT_PAGE", BackendModuleType.RESULT_PAGE.getType());
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/EntityDataMapperGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/EntityDataMapperGenerator.java
@@ -7,8 +7,6 @@ package com.magento.idea.magento2plugin.actions.generation.generator;
 
 import com.intellij.openapi.project.Project;
 import com.magento.idea.magento2plugin.actions.generation.data.EntityDataMapperData;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassTypesBuilder;
 import com.magento.idea.magento2plugin.magento.files.AbstractPhpFile;
 import com.magento.idea.magento2plugin.magento.files.DataModelFile;
 import com.magento.idea.magento2plugin.magento.files.DataModelInterfaceFile;
@@ -63,8 +61,6 @@ public class EntityDataMapperGenerator extends PhpFileGenerator {
      */
     @Override
     protected void fillAttributes(final @NotNull Properties attributes) {
-        final PhpClassTypesBuilder phpClassTypesBuilder = new PhpClassTypesBuilder();
-
         final ModelFile modelFile = new ModelFile(data.getModuleName(), data.getModelName());
         final DataModelFile dtoFile = new DataModelFile(data.getDtoName(), data.getModuleName());
         final DataModelInterfaceFile dtoInterfaceFile =
@@ -77,20 +73,14 @@ public class EntityDataMapperGenerator extends PhpFileGenerator {
             dtoType = dtoFile.getClassFqn();
         }
 
-        phpClassTypesBuilder
-                .appendProperty("NAMESPACE", file.getNamespace())
-                .appendProperty("ENTITY_NAME", data.getEntityName())
-                .appendProperty("CLASS_NAME", file.getClassName())
+        typesBuilder
+                .append("NAMESPACE", file.getNamespace(), false)
+                .append("ENTITY_NAME", data.getEntityName(), false)
+                .append("CLASS_NAME", file.getClassName(), false)
                 .append("DATA_OBJECT", FrameworkLibraryType.DATA_OBJECT.getType())
                 .append("DTO_TYPE", dtoType)
                 .append("MAGENTO_MODEL_TYPE", modelFile.getClassFqn())
                 .append("DTO_FACTORY", dtoType.concat("Factory"))
-                .append("ABSTRACT_COLLECTION", FrameworkLibraryType.ABSTRACT_COLLECTION.getType())
-                .mergeProperties(attributes);
-
-        attributes.setProperty(
-                "USES",
-                PhpClassGeneratorUtil.formatUses(phpClassTypesBuilder.getUses())
-        );
+                .append("ABSTRACT_COLLECTION", FrameworkLibraryType.ABSTRACT_COLLECTION.getType());
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/FormGenericButtonBlockGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/FormGenericButtonBlockGenerator.java
@@ -7,8 +7,6 @@ package com.magento.idea.magento2plugin.actions.generation.generator;
 
 import com.intellij.openapi.project.Project;
 import com.magento.idea.magento2plugin.actions.generation.data.FormGenericButtonBlockData;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassTypesBuilder;
 import com.magento.idea.magento2plugin.magento.files.AbstractPhpFile;
 import com.magento.idea.magento2plugin.magento.files.FormGenericButtonBlockFile;
 import com.magento.idea.magento2plugin.magento.packages.code.FrameworkLibraryType;
@@ -63,22 +61,17 @@ public class FormGenericButtonBlockGenerator extends PhpFileGenerator {
      */
     @Override
     protected void fillAttributes(final @NotNull Properties attributes) {
-        final PhpClassTypesBuilder phpClassTypesBuilder = new PhpClassTypesBuilder();
         final String entityIdGetter = "get" + Arrays.stream(data.getEntityId().split("_"))
                 .map(s -> s.substring(0, 1).toUpperCase(Locale.getDefault()) + s.substring(1))
                 .collect(Collectors.joining());
 
-        phpClassTypesBuilder
-                .appendProperty("NAMESPACE", file.getNamespace())
-                .appendProperty("ENTITY_NAME", data.getEntityName())
-                .appendProperty("CLASS_NAME", FormGenericButtonBlockFile.CLASS_NAME)
-                .appendProperty("ENTITY_ID", data.getEntityId())
-                .appendProperty("ENTITY_ID_GETTER", entityIdGetter)
+        typesBuilder
+                .append("NAMESPACE", file.getNamespace(), false)
+                .append("ENTITY_NAME", data.getEntityName(), false)
+                .append("CLASS_NAME", FormGenericButtonBlockFile.CLASS_NAME, false)
+                .append("ENTITY_ID", data.getEntityId(), false)
+                .append("ENTITY_ID_GETTER", entityIdGetter, false)
                 .append("CONTEXT", FormGenericButtonBlockFile.CONTEXT)
-                .append("URL", FrameworkLibraryType.URL.getType())
-                .mergeProperties(attributes);
-
-        attributes.setProperty("USES",
-                PhpClassGeneratorUtil.formatUses(phpClassTypesBuilder.getUses()));
+                .append("URL", FrameworkLibraryType.URL.getType());
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/GetListQueryModelGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/GetListQueryModelGenerator.java
@@ -8,8 +8,6 @@ package com.magento.idea.magento2plugin.actions.generation.generator;
 import com.intellij.openapi.project.Project;
 import com.magento.idea.magento2plugin.actions.generation.data.GetListQueryModelData;
 import com.magento.idea.magento2plugin.actions.generation.generator.util.NamespaceBuilder;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassTypesBuilder;
 import com.magento.idea.magento2plugin.magento.files.AbstractPhpFile;
 import com.magento.idea.magento2plugin.magento.files.CollectionModelFile;
 import com.magento.idea.magento2plugin.magento.files.EntityDataMapperFile;
@@ -63,7 +61,6 @@ public class GetListQueryModelGenerator extends PhpFileGenerator {
      */
     @Override
     protected void fillAttributes(final @NotNull Properties attributes) {
-        final PhpClassTypesBuilder phpClassTypesBuilder = new PhpClassTypesBuilder();
         final CollectionModelFile collectionModelFile =
                 new CollectionModelFile(
                         data.getModuleName(),
@@ -73,10 +70,10 @@ public class GetListQueryModelGenerator extends PhpFileGenerator {
         final NamespaceBuilder collectionNamespace =
                 collectionModelFile.getNamespaceBuilder();
 
-        phpClassTypesBuilder
-                .appendProperty("ENTITY_NAME", data.getEntityName())
-                .appendProperty("NAMESPACE", file.getNamespace())
-                .appendProperty("CLASS_NAME", GetListQueryFile.CLASS_NAME)
+        typesBuilder
+                .append("ENTITY_NAME", data.getEntityName(), false)
+                .append("NAMESPACE", file.getNamespace(), false)
+                .append("CLASS_NAME", GetListQueryFile.CLASS_NAME, false)
                 .append(
                         "ENTITY_COLLECTION_TYPE",
                         collectionNamespace.getClassFqn()
@@ -111,12 +108,6 @@ public class GetListQueryModelGenerator extends PhpFileGenerator {
                 .append(
                         "SEARCH_RESULT_FACTORY_TYPE",
                         FrameworkLibraryType.SEARCH_RESULT.getFactory()
-                )
-                .mergeProperties(attributes);
-
-        attributes.setProperty(
-                "USES",
-                PhpClassGeneratorUtil.formatUses(phpClassTypesBuilder.getUses())
-        );
+                );
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/GridActionColumnFileGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/GridActionColumnFileGenerator.java
@@ -7,8 +7,6 @@ package com.magento.idea.magento2plugin.actions.generation.generator;
 
 import com.intellij.openapi.project.Project;
 import com.magento.idea.magento2plugin.actions.generation.data.GridActionColumnData;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassTypesBuilder;
 import com.magento.idea.magento2plugin.magento.files.AbstractPhpFile;
 import com.magento.idea.magento2plugin.magento.files.GridActionColumnFile;
 import com.magento.idea.magento2plugin.magento.packages.code.FrameworkLibraryType;
@@ -60,22 +58,16 @@ public class GridActionColumnFileGenerator extends PhpFileGenerator {
      */
     @Override
     protected void fillAttributes(final @NotNull Properties attributes) {
-        final PhpClassTypesBuilder phpClassTypesBuilder = new PhpClassTypesBuilder();
-
-        phpClassTypesBuilder
-                .appendProperty("ENTITY_NAME", data.getEntityName())
-                .appendProperty("ENTITY_ID", data.getEntityIdColumn())
-                .appendProperty("NAMESPACE", file.getNamespace())
-                .appendProperty("CLASS_NAME", file.getClassName())
-                .appendProperty("EDIT_URL_PATH", data.getEditUrlPath())
-                .appendProperty("DELETE_URL_PATH", data.getDeleteUrlPath())
+        typesBuilder
+                .append("ENTITY_NAME", data.getEntityName(), false)
+                .append("ENTITY_ID", data.getEntityIdColumn(), false)
+                .append("NAMESPACE", file.getNamespace(), false)
+                .append("CLASS_NAME", file.getClassName(), false)
+                .append("EDIT_URL_PATH", data.getEditUrlPath(), false)
+                .append("DELETE_URL_PATH", data.getDeleteUrlPath(), false)
                 .append("PARENT_CLASS", GridActionColumnFile.PARENT_CLASS)
                 .append("URL", FrameworkLibraryType.URL.getType())
                 .append("CONTEXT", GridActionColumnFile.CONTEXT)
-                .append("UI_COMPONENT_FACTORY", GridActionColumnFile.UI_COMPONENT_FACTORY)
-                .mergeProperties(attributes);
-
-        attributes.setProperty("USES",
-                PhpClassGeneratorUtil.formatUses(phpClassTypesBuilder.getUses()));
+                .append("UI_COMPONENT_FACTORY", GridActionColumnFile.UI_COMPONENT_FACTORY);
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/IndexActionGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/IndexActionGenerator.java
@@ -7,8 +7,6 @@ package com.magento.idea.magento2plugin.actions.generation.generator;
 
 import com.intellij.openapi.project.Project;
 import com.magento.idea.magento2plugin.actions.generation.data.IndexActionData;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassTypesBuilder;
 import com.magento.idea.magento2plugin.magento.files.AbstractPhpFile;
 import com.magento.idea.magento2plugin.magento.files.actions.IndexActionFile;
 import com.magento.idea.magento2plugin.magento.packages.HttpMethod;
@@ -62,24 +60,16 @@ public class IndexActionGenerator extends PhpFileGenerator {
      */
     @Override
     protected void fillAttributes(final @NotNull Properties attributes) {
-        final PhpClassTypesBuilder phpClassTypesBuilder = new PhpClassTypesBuilder();
-
-        phpClassTypesBuilder
-                .appendProperty("ENTITY_NAME", data.getEntityName())
-                .appendProperty("CLASS_NAME", IndexActionFile.CLASS_NAME)
-                .appendProperty("ACL", data.getAcl())
-                .appendProperty("MENU", data.getMenu())
-                .appendProperty("NAMESPACE", file.getNamespace())
+        typesBuilder
+                .append("ENTITY_NAME", data.getEntityName(), false)
+                .append("CLASS_NAME", IndexActionFile.CLASS_NAME, false)
+                .append("ACL", data.getAcl(), false)
+                .append("MENU", data.getMenu(), false)
+                .append("NAMESPACE", file.getNamespace(), false)
                 .append("PARENT_CLASS_NAME", BackendModuleType.EXTENDS.getType())
                 .append("HTTP_GET_METHOD", HttpMethod.GET.getInterfaceFqn())
                 .append("RESULT", FrameworkLibraryType.RESULT_INTERFACE.getType())
                 .append("RESPONSE", FrameworkLibraryType.RESPONSE_INTERFACE.getType())
-                .append("RESULT_FACTORY", FrameworkLibraryType.RESULT_FACTORY.getType())
-                .mergeProperties(attributes);
-
-        attributes.setProperty(
-                "USES",
-                PhpClassGeneratorUtil.formatUses(phpClassTypesBuilder.getUses())
-        );
+                .append("RESULT_FACTORY", FrameworkLibraryType.RESULT_FACTORY.getType());
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleCollectionGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleCollectionGenerator.java
@@ -7,8 +7,6 @@ package com.magento.idea.magento2plugin.actions.generation.generator;
 
 import com.intellij.openapi.project.Project;
 import com.magento.idea.magento2plugin.actions.generation.data.CollectionData;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassTypesBuilder;
 import com.magento.idea.magento2plugin.magento.files.AbstractPhpFile;
 import com.magento.idea.magento2plugin.magento.files.CollectionModelFile;
 import com.magento.idea.magento2plugin.magento.files.ModelFile;
@@ -65,17 +63,16 @@ public class ModuleCollectionGenerator extends PhpFileGenerator {
      */
     @Override
     protected void fillAttributes(final @NotNull Properties attributes) {
-        final PhpClassTypesBuilder phpClassTypesBuilder = new PhpClassTypesBuilder();
-
         final ResourceModelFile resourceModelFile =
                 new ResourceModelFile(data.getModuleName(), data.getResourceModelName());
         final ModelFile modelFile = new ModelFile(data.getModuleName(), data.getModelName());
 
-        phpClassTypesBuilder.appendProperty("NAME", data.getCollectionName())
-                .appendProperty("NAMESPACE", file.getNamespaceBuilder().getNamespace())
-                .appendProperty("DB_NAME", data.getDbTableName())
-                .appendProperty("MODEL", data.getModelName())
-                .appendProperty("RESOURCE_MODEL", data.getResourceModelName())
+        typesBuilder
+                .append("NAME", data.getCollectionName(), false)
+                .append("NAMESPACE", file.getNamespaceBuilder().getNamespace(), false)
+                .append("DB_NAME", data.getDbTableName(), false)
+                .append("MODEL", data.getModelName(), false)
+                .append("RESOURCE_MODEL", data.getResourceModelName(), false)
                 .append("EXTENDS", CollectionModelFile.ABSTRACT_COLLECTION)
                 .append(
                         "RESOURCE_MODEL",
@@ -86,14 +83,6 @@ public class ModuleCollectionGenerator extends PhpFileGenerator {
                         "MODEL",
                         modelFile.getClassFqn(),
                         ModelFile.ALIAS
-                )
-                .mergeProperties(attributes);
-
-        attributes.setProperty(
-                "USES",
-                PhpClassGeneratorUtil.formatUses(
-                        phpClassTypesBuilder.getUses()
-                )
-        );
+                );
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleModelGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleModelGenerator.java
@@ -8,7 +8,6 @@ package com.magento.idea.magento2plugin.actions.generation.generator;
 import com.intellij.openapi.project.Project;
 import com.magento.idea.magento2plugin.actions.generation.data.ModelData;
 import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassTypesBuilder;
 import com.magento.idea.magento2plugin.magento.files.AbstractPhpFile;
 import com.magento.idea.magento2plugin.magento.files.ModelFile;
 import com.magento.idea.magento2plugin.magento.files.ResourceModelFile;
@@ -60,30 +59,19 @@ public class ModuleModelGenerator extends PhpFileGenerator {
      */
     @Override
     protected void fillAttributes(final @NotNull Properties attributes) {
-        final PhpClassTypesBuilder phpClassTypesBuilder = new PhpClassTypesBuilder();
         final ResourceModelFile resourceModelFile =
                 new ResourceModelFile(data.getModuleName(), data.getResourceName());
 
-        phpClassTypesBuilder
-                .appendProperty("NAME", data.getModelName())
-                .appendProperty(
-                        "NAMESPACE",
-                        file.getNamespace()
-                )
-                .appendProperty("DB_NAME", data.getDbTableName())
+        typesBuilder
+                .append("NAME", data.getModelName(), false)
+                .append("NAMESPACE", file.getNamespace(), false)
+                .append("DB_NAME", data.getDbTableName(), false)
+                .append("RESOURCE_MODEL", resourceModelFile.getClassFqn(), ResourceModelFile.ALIAS)
                 .append(
-                        "RESOURCE_MODEL",
-                        resourceModelFile.getClassFqn(),
-                        ResourceModelFile.ALIAS
-                )
-                .appendProperty(
                         "EXTENDS",
-                        PhpClassGeneratorUtil.getNameFromFqn(ModelFile.ABSTRACT_MODEL)
+                        PhpClassGeneratorUtil.getNameFromFqn(ModelFile.ABSTRACT_MODEL),
+                        false
                 )
-                .append("ABSTRACT_MODEL", ModelFile.ABSTRACT_MODEL)
-                .mergeProperties(attributes);
-
-        attributes.setProperty("USES",
-                PhpClassGeneratorUtil.formatUses(phpClassTypesBuilder.getUses()));
+                .append("ABSTRACT_MODEL", ModelFile.ABSTRACT_MODEL);
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleResourceModelGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleResourceModelGenerator.java
@@ -7,11 +7,8 @@ package com.magento.idea.magento2plugin.actions.generation.generator;
 
 import com.intellij.openapi.project.Project;
 import com.magento.idea.magento2plugin.actions.generation.data.ResourceModelData;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassTypesBuilder;
 import com.magento.idea.magento2plugin.magento.files.AbstractPhpFile;
 import com.magento.idea.magento2plugin.magento.files.ResourceModelFile;
-import java.util.List;
 import java.util.Properties;
 import org.jetbrains.annotations.NotNull;
 
@@ -60,20 +57,11 @@ public class ModuleResourceModelGenerator extends PhpFileGenerator {
      */
     @Override
     protected void fillAttributes(final @NotNull Properties attributes) {
-        final PhpClassTypesBuilder phpClassTypesBuilder = new PhpClassTypesBuilder();
-
-        phpClassTypesBuilder
-                .appendProperty("NAME", data.getResourceModelName())
-                .appendProperty(
-                        "NAMESPACE",
-                        file.getNamespace()
-                )
-                .appendProperty("DB_NAME", data.getDbTableName())
-                .appendProperty("ENTITY_ID_COLUMN", data.getEntityIdColumn())
-                .append("EXTENDS", ResourceModelFile.ABSTRACT_DB)
-                .mergeProperties(attributes);
-
-        final List<String> uses = phpClassTypesBuilder.getUses();
-        attributes.setProperty("USES", PhpClassGeneratorUtil.formatUses(uses));
+        typesBuilder
+                .append("NAME", data.getResourceModelName(), false)
+                .append("NAMESPACE", file.getNamespace(), false)
+                .append("DB_NAME", data.getDbTableName(), false)
+                .append("ENTITY_ID_COLUMN", data.getEntityIdColumn(), false)
+                .append("EXTENDS", ResourceModelFile.ABSTRACT_DB);
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/NewActionEntityControllerFileGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/NewActionEntityControllerFileGenerator.java
@@ -7,8 +7,6 @@ package com.magento.idea.magento2plugin.actions.generation.generator;
 
 import com.intellij.openapi.project.Project;
 import com.magento.idea.magento2plugin.actions.generation.data.NewActionEntityControllerFileData;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassTypesBuilder;
 import com.magento.idea.magento2plugin.magento.files.AbstractPhpFile;
 import com.magento.idea.magento2plugin.magento.files.actions.NewActionFile;
 import com.magento.idea.magento2plugin.magento.packages.HttpMethod;
@@ -58,22 +56,16 @@ public class NewActionEntityControllerFileGenerator extends PhpFileGenerator {
 
     @Override
     protected void fillAttributes(final @NotNull Properties attributes) {
-        final PhpClassTypesBuilder phpClassTypesBuilder = new PhpClassTypesBuilder();
-
-        phpClassTypesBuilder
-                .appendProperty("NAMESPACE", data.getNamespace())
-                .appendProperty("ENTITY_NAME", data.getEntityName())
-                .appendProperty("CLASS_NAME", file.getClassName())
-                .appendProperty("ADMIN_RESOURCE", data.getAcl())
-                .appendProperty("MENU_IDENTIFIER", data.getMenu())
+        typesBuilder
+                .append("NAMESPACE", data.getNamespace(), false)
+                .append("ENTITY_NAME", data.getEntityName(), false)
+                .append("CLASS_NAME", file.getClassName(), false)
+                .append("ADMIN_RESOURCE", data.getAcl(), false)
+                .append("MENU_IDENTIFIER", data.getMenu(), false)
                 .append("EXTENDS", BackendModuleType.EXTENDS.getType())
                 .append("IMPLEMENTS", HttpMethod.GET.getInterfaceFqn())
                 .append("RESULT_INTERFACE", FrameworkLibraryType.RESULT_INTERFACE.getType())
                 .append("RESULT_FACTORY", FrameworkLibraryType.RESULT_FACTORY.getType())
-                .append("RESULT_PAGE", BackendModuleType.RESULT_PAGE.getType())
-                .mergeProperties(attributes);
-
-        attributes.setProperty("USES",
-                PhpClassGeneratorUtil.formatUses(phpClassTypesBuilder.getUses()));
+                .append("RESULT_PAGE", BackendModuleType.RESULT_PAGE.getType());
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/PhpFileGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/PhpFileGenerator.java
@@ -11,17 +11,24 @@ import com.intellij.psi.PsiFile;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.magento.idea.magento2plugin.actions.generation.generator.util.DirectoryGenerator;
 import com.magento.idea.magento2plugin.actions.generation.generator.util.FileFromTemplateGenerator;
+import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
+import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassTypesBuilder;
 import com.magento.idea.magento2plugin.bundles.CommonBundle;
 import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
 import com.magento.idea.magento2plugin.indexes.ModuleIndex;
 import com.magento.idea.magento2plugin.magento.files.AbstractPhpFile;
 import com.magento.idea.magento2plugin.util.GetPhpClassByFQN;
 import javax.swing.JOptionPane;
+import java.util.Properties;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class PhpFileGenerator extends FileGenerator {
 
+    private static final String IMPORT_PROPERTY_NAME = "USES";
+
     protected AbstractPhpFile file;
+    // Util that simplifies file properties definition.
+    protected final PhpClassTypesBuilder typesBuilder;
     private final ValidatorBundle validatorBundle;
     private final CommonBundle commonBundle;
     private final FileFromTemplateGenerator fileFromTemplateGenerator;
@@ -46,6 +53,7 @@ public abstract class PhpFileGenerator extends FileGenerator {
         fileFromTemplateGenerator = new FileFromTemplateGenerator(project);
         directoryGenerator = DirectoryGenerator.getInstance();
         moduleIndex = new ModuleIndex(project);
+        typesBuilder = new PhpClassTypesBuilder();
     }
 
     /**
@@ -142,5 +150,23 @@ public abstract class PhpFileGenerator extends FileGenerator {
         }
 
         return file;
+    }
+
+    @Override
+    protected Properties getAttributes() {
+        final @NotNull Properties attributes = super.getAttributes();
+
+        if (typesBuilder.hasProperties()) {
+            typesBuilder.mergeProperties(attributes);
+        }
+
+        if (!typesBuilder.getUses().isEmpty() && !typesBuilder.hasProperty(IMPORT_PROPERTY_NAME)) {
+            attributes.setProperty(
+                    IMPORT_PROPERTY_NAME,
+                    PhpClassGeneratorUtil.formatUses(typesBuilder.getUses())
+            );
+        }
+
+        return attributes;
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/PhpFileGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/PhpFileGenerator.java
@@ -18,8 +18,8 @@ import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
 import com.magento.idea.magento2plugin.indexes.ModuleIndex;
 import com.magento.idea.magento2plugin.magento.files.AbstractPhpFile;
 import com.magento.idea.magento2plugin.util.GetPhpClassByFQN;
-import javax.swing.JOptionPane;
 import java.util.Properties;
+import javax.swing.JOptionPane;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class PhpFileGenerator extends FileGenerator {

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/SaveEntityCommandGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/SaveEntityCommandGenerator.java
@@ -8,8 +8,6 @@ package com.magento.idea.magento2plugin.actions.generation.generator;
 import com.google.common.base.CaseFormat;
 import com.intellij.openapi.project.Project;
 import com.magento.idea.magento2plugin.actions.generation.data.SaveEntityCommandData;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassTypesBuilder;
 import com.magento.idea.magento2plugin.magento.files.AbstractPhpFile;
 import com.magento.idea.magento2plugin.magento.files.DataModelFile;
 import com.magento.idea.magento2plugin.magento.files.DataModelInterfaceFile;
@@ -66,12 +64,10 @@ public class SaveEntityCommandGenerator extends PhpFileGenerator {
      */
     @Override
     protected void fillAttributes(final @NotNull Properties attributes) {
-        final PhpClassTypesBuilder phpClassTypesBuilder = new PhpClassTypesBuilder();
-
-        phpClassTypesBuilder
-                .appendProperty("NAMESPACE", file.getNamespace())
-                .appendProperty("ENTITY_NAME", data.getEntityName())
-                .appendProperty("CLASS_NAME", SaveEntityCommandFile.CLASS_NAME)
+        typesBuilder
+                .append("NAMESPACE", file.getNamespace(), false)
+                .append("ENTITY_NAME", data.getEntityName(), false)
+                .append("CLASS_NAME", SaveEntityCommandFile.CLASS_NAME, false)
                 .append("EXCEPTION", "Exception")
                 .append("DATA_OBJECT", FrameworkLibraryType.DATA_OBJECT.getType())
                 .append("COULD_NOT_SAVE", ExceptionType.COULD_NOT_SAVE.getType())
@@ -89,29 +85,22 @@ public class SaveEntityCommandGenerator extends PhpFileGenerator {
             final DataModelInterfaceFile dataModelInterfaceFile =
                     new DataModelInterfaceFile(data.getModuleName(), data.getDtoInterfaceName());
             final String dtoType = dataModelInterfaceFile.getClassFqn();
-            phpClassTypesBuilder.append("DTO", dtoType);
+            typesBuilder.append("DTO", dtoType);
         } else {
             final DataModelFile dataModelFile =
                     new DataModelFile(data.getModuleName(), data.getDtoName());
             final String dtoType = dataModelFile.getClassFqn();
-            phpClassTypesBuilder.append("DTO", dtoType);
+            typesBuilder.append("DTO", dtoType);
         }
 
         final String dtoProperty = CaseFormat.UPPER_CAMEL.to(
                 CaseFormat.LOWER_CAMEL, data.getEntityName()
         );
 
-        phpClassTypesBuilder
-                .appendProperty("DTO_PROPERTY", dtoProperty)
+        typesBuilder
+                .append("DTO_PROPERTY", dtoProperty, false)
                 .append("MODEL", modelType)
                 .append("MODEL_FACTORY", modelFactoryType)
                 .append("RESOURCE", resourceType);
-
-        phpClassTypesBuilder.mergeProperties(attributes);
-
-        attributes.setProperty(
-                "USES",
-                PhpClassGeneratorUtil.formatUses(phpClassTypesBuilder.getUses())
-        );
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/SaveEntityControllerFileGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/SaveEntityControllerFileGenerator.java
@@ -7,8 +7,6 @@ package com.magento.idea.magento2plugin.actions.generation.generator;
 
 import com.intellij.openapi.project.Project;
 import com.magento.idea.magento2plugin.actions.generation.data.SaveEntityControllerFileData;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassTypesBuilder;
 import com.magento.idea.magento2plugin.magento.files.AbstractPhpFile;
 import com.magento.idea.magento2plugin.magento.files.DataModelFile;
 import com.magento.idea.magento2plugin.magento.files.DataModelInterfaceFile;
@@ -65,7 +63,6 @@ public class SaveEntityControllerFileGenerator extends PhpFileGenerator {
      */
     @Override
     protected void fillAttributes(final @NotNull Properties attributes) {
-        final PhpClassTypesBuilder phpClassTypesBuilder = new PhpClassTypesBuilder();
         String dtoType;
 
         if (data.isDtoWithInterface()) {
@@ -78,12 +75,12 @@ public class SaveEntityControllerFileGenerator extends PhpFileGenerator {
             dtoType = dataModelFile.getClassFqn();
         }
 
-        phpClassTypesBuilder
-                .appendProperty("NAMESPACE", file.getNamespace())
-                .appendProperty("ENTITY_NAME", data.getEntityName())
-                .appendProperty("CLASS_NAME", SaveActionFile.CLASS_NAME)
-                .appendProperty("ENTITY_ID", data.getEntityId())
-                .appendProperty("ADMIN_RESOURCE", data.getAcl())
+        typesBuilder
+                .append("NAMESPACE", file.getNamespace(), false)
+                .append("ENTITY_NAME", data.getEntityName(), false)
+                .append("CLASS_NAME", SaveActionFile.CLASS_NAME, false)
+                .append("ENTITY_ID", data.getEntityId(), false)
+                .append("ADMIN_RESOURCE", data.getAcl(), false)
                 .append("IMPLEMENTS", HttpMethod.POST.getInterfaceFqn())
                 .append("DATA_PERSISTOR", FrameworkLibraryType.DATA_PERSISTOR.getType())
                 .append("EXTENDS", BackendModuleType.EXTENDS.getType())
@@ -99,10 +96,6 @@ public class SaveEntityControllerFileGenerator extends PhpFileGenerator {
                 .append("COULD_NOT_SAVE", SaveActionFile.COULD_NOT_SAVE)
                 .append("CONTEXT", BackendModuleType.CONTEXT.getType())
                 .append("RESPONSE_INTERFACE", FrameworkLibraryType.RESPONSE_INTERFACE.getType())
-                .append("RESULT_INTERFACE", FrameworkLibraryType.RESULT_INTERFACE.getType())
-                .mergeProperties(attributes);
-
-        attributes.setProperty("USES",
-                PhpClassGeneratorUtil.formatUses(phpClassTypesBuilder.getUses()));
+                .append("RESULT_INTERFACE", FrameworkLibraryType.RESULT_INTERFACE.getType());
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/UiComponentDataProviderGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/UiComponentDataProviderGenerator.java
@@ -7,8 +7,6 @@ package com.magento.idea.magento2plugin.actions.generation.generator;
 
 import com.intellij.openapi.project.Project;
 import com.magento.idea.magento2plugin.actions.generation.data.UiComponentDataProviderData;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassTypesBuilder;
 import com.magento.idea.magento2plugin.magento.files.AbstractPhpFile;
 import com.magento.idea.magento2plugin.magento.files.UiComponentDataProviderFile;
 import com.magento.idea.magento2plugin.magento.files.queries.GetListQueryFile;
@@ -67,19 +65,17 @@ public class UiComponentDataProviderGenerator extends PhpFileGenerator {
      */
     @Override
     protected void fillAttributes(final @NotNull Properties attributes) {
-        final PhpClassTypesBuilder phpClassTypesBuilder = new PhpClassTypesBuilder();
-
-        phpClassTypesBuilder
-                .appendProperty("NAMESPACE", file.getNamespace())
-                .appendProperty("CLASS_NAME", data.getName())
-                .appendProperty("HAS_GET_LIST_QUERY", "false")
+        typesBuilder
+                .append("NAMESPACE", file.getNamespace(), false)
+                .append("CLASS_NAME", data.getName(), false)
+                .append("HAS_GET_LIST_QUERY", "false", false)
                 .append("EXTENDS", UiComponentDataProviderFile.DEFAULT_DATA_PROVIDER);
 
         if (data.getEntityIdFieldName() != null && data.getEntityName() != null) {
-            phpClassTypesBuilder.appendProperty("ENTITY_ID", data.getEntityIdFieldName());
+            typesBuilder.append("ENTITY_ID", data.getEntityIdFieldName(), false);
 
-            phpClassTypesBuilder
-                    .appendProperty("HAS_GET_LIST_QUERY", "true")
+            typesBuilder
+                    .append("HAS_GET_LIST_QUERY", "true", false)
                     .append(
                             "GET_LIST_QUERY_TYPE",
                             new GetListQueryFile(moduleName, data.getEntityName()).getClassFqn()
@@ -92,9 +88,5 @@ public class UiComponentDataProviderGenerator extends PhpFileGenerator {
                     .append("SEARCH_RESULT_FACTORY",
                             UiComponentDataProviderFile.SEARCH_RESULT_FACTORY);
         }
-        phpClassTypesBuilder.mergeProperties(attributes);
-
-        attributes.setProperty("USES",
-                PhpClassGeneratorUtil.formatUses(phpClassTypesBuilder.getUses()));
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/php/WebApiInterfaceGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/php/WebApiInterfaceGenerator.java
@@ -11,7 +11,6 @@ import com.jetbrains.php.lang.psi.elements.Method;
 import com.magento.idea.magento2plugin.actions.generation.data.php.WebApiInterfaceData;
 import com.magento.idea.magento2plugin.actions.generation.generator.PhpFileGenerator;
 import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
-import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassTypesBuilder;
 import com.magento.idea.magento2plugin.magento.files.AbstractPhpFile;
 import com.magento.idea.magento2plugin.magento.files.WebApiInterfaceFile;
 import com.magento.idea.magento2plugin.util.php.PhpTypeMetadataParserUtil;
@@ -75,7 +74,6 @@ public class WebApiInterfaceGenerator extends PhpFileGenerator {
 
     @Override
     protected void fillAttributes(final @NotNull Properties attributes) {
-        final PhpClassTypesBuilder phpClassTypesBuilder = new PhpClassTypesBuilder();
         final StringBuilder methodsString = new StringBuilder();
         final List<String> typeList = new ArrayList<>();
 
@@ -99,13 +97,12 @@ public class WebApiInterfaceGenerator extends PhpFileGenerator {
             }
         }
 
-        phpClassTypesBuilder
-                .appendProperty("NAMESPACE", file.getNamespace())
-                .appendProperty("DESCRIPTION", data.getDescription())
-                .appendProperty("INTERFACE_NAME", data.getName())
-                .appendProperty("METHODS_DELIMITER", WebApiInterfaceFile.METHODS_DELIMITER)
-                .appendProperty("METHODS", methodsString.toString())
-                .mergeProperties(attributes);
+        typesBuilder
+                .append("NAMESPACE", file.getNamespace(), false)
+                .append("DESCRIPTION", data.getDescription(), false)
+                .append("INTERFACE_NAME", data.getName(), false)
+                .append("METHODS_DELIMITER", WebApiInterfaceFile.METHODS_DELIMITER, false)
+                .append("METHODS", methodsString.toString(), false);
 
         if (!typeList.isEmpty()) {
             attributes.setProperty(

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/PhpClassGeneratorUtil.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/PhpClassGeneratorUtil.java
@@ -7,6 +7,8 @@ package com.magento.idea.magento2plugin.actions.generation.generator.util;
 
 import java.util.Collections;
 import java.util.List;
+import com.jetbrains.php.lang.PhpLangUtil;
+import com.magento.idea.magento2plugin.util.RegExUtil;
 import org.jetbrains.annotations.NotNull;
 
 public final class PhpClassGeneratorUtil {
@@ -37,5 +39,16 @@ public final class PhpClassGeneratorUtil {
         final String[] fqnArray = fqn.split("\\\\");
 
         return fqnArray[fqnArray.length - 1];
+    }
+
+    /**
+     * Check if provided string is a valid PHP class FQN.
+     *
+     * @param fqnCandidate String
+     *
+     * @return boolean
+     */
+    public static boolean isValidFqn(final @NotNull String fqnCandidate) {
+        return PhpLangUtil.isFqn(fqnCandidate) || fqnCandidate.matches(RegExUtil.PhpRegex.FQN);
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/PhpClassGeneratorUtil.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/PhpClassGeneratorUtil.java
@@ -5,10 +5,10 @@
 
 package com.magento.idea.magento2plugin.actions.generation.generator.util;
 
-import java.util.Collections;
-import java.util.List;
 import com.jetbrains.php.lang.PhpLangUtil;
 import com.magento.idea.magento2plugin.util.RegExUtil;
+import java.util.Collections;
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 
 public final class PhpClassGeneratorUtil {

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/PhpClassTypesBuilder.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/PhpClassTypesBuilder.java
@@ -42,18 +42,39 @@ public final class PhpClassTypesBuilder {
     }
 
     /**
-     * Append type.
+     * Append property or type.
      *
      * @param propertyName String
-     * @param typeFqn String
+     * @param propertyValue String
      *
      * @return PhpClassTypesBuilder
      */
     public PhpClassTypesBuilder append(
             final @NotNull String propertyName,
-            final @NotNull String typeFqn
+            final @NotNull String propertyValue
     ) {
-        return append(propertyName, typeFqn, null);
+        return append(propertyName, propertyValue, true);
+    }
+
+    /**
+     * Append property or type.
+     *
+     * @param propertyName String
+     * @param propertyValue String
+     * @param isAddToImports boolean
+     *
+     * @return PhpClassTypesBuilder
+     */
+    public PhpClassTypesBuilder append(
+            final @NotNull String propertyName,
+            final @NotNull String propertyValue,
+            final boolean isAddToImports
+    ) {
+        if (isAddToImports && PhpClassGeneratorUtil.isValidFqn(propertyValue)) {
+            return append(propertyName, propertyValue, null);
+        }
+
+        return appendProperty(propertyName, propertyValue);
     }
 
     /**
@@ -120,6 +141,26 @@ public final class PhpClassTypesBuilder {
         }
 
         return uses;
+    }
+
+    /**
+     * Check if any property exists.
+     *
+     * @return boolean
+     */
+    public boolean hasProperties() {
+        return !properties.isEmpty();
+    }
+
+    /**
+     * Check if property exists.
+     *
+     * @param propertyName String
+     *
+     * @return boolean
+     */
+    public boolean hasProperty(final @NotNull String propertyName) {
+        return properties.containsKey(propertyName);
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/util/RegExUtil.java
+++ b/src/com/magento/idea/magento2plugin/util/RegExUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
@@ -47,6 +47,7 @@ public class RegExUtil {
             = "(\\d+)\\.(\\d+)\\.(\\d+)[a-zA-Z0-9_\\-]*";
 
     public static class Magento {
+
         public static final String PHP_CLASS
                 = "[A-Z][a-zA-Z0-9]+";
 


### PR DESCRIPTION
**Description** (*)
It is an improvement for the tool that simplifies file properties definition. 
The main points of this enhancement:

1. extract initialisation of the PhpClassTypesBuilder instance to the base class for all PHP generators (PhpFileGenerator)
2. extract file attributes merging and the "USES" attribute definition to the base class
3. simplifying access to set properties and types through the one method

Before we had to call the appendProperty method to add simple property and append to add a type. Now we can use the append method for both cases. There is the syntax/metadata for this method:
``` java
public PhpClassTypesBuilder append(final @NotNull String propertyName, final @NotNull String propertyValue, final boolean isAddToImports) {...}
```
To add a simple property we just need to specify the isAddToImports argument as false. This argument is used to define if that property needs to be added to the imports (uses) section of the file.

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
