### PR TITLE
Fixed issue with too long URI for generated bug report by diagnostic feature

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -270,8 +270,8 @@
         <internalFileTemplate name="Magento Delete Entity By Id Command"/>
         <internalFileTemplate name="Magento Entity Edit Action Controller Class"/>
         <internalFileTemplate name="Magento Entity Delete Controller Class"/>
-        <internalFileTemplate name="Magento Web Api XML"/>
-        <internalFileTemplate name="Web Api Interface"/>
+        <internalFileTemplate name="Magento Web API XML"/>
+        <internalFileTemplate name="Web API Interface"/>
 
         <defaultLiveTemplates file="/liveTemplates/MagentoPWA.xml"/>
 

--- a/src/com/magento/idea/magento2plugin/project/diagnostic/DefaultErrorReportSubmitter.java
+++ b/src/com/magento/idea/magento2plugin/project/diagnostic/DefaultErrorReportSubmitter.java
@@ -17,7 +17,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.NlsActions;
 import com.intellij.util.Consumer;
 import com.magento.idea.magento2plugin.bundles.CommonBundle;
-import com.magento.idea.magento2plugin.project.diagnostic.github.GitHubNewIssueBodyBuilderUtil;
 import com.magento.idea.magento2plugin.project.diagnostic.github.GitHubNewIssueUrlBuilderUtil;
 import java.awt.Component;
 import java.time.LocalDateTime;
@@ -70,16 +69,12 @@ public class DefaultErrorReportSubmitter extends ErrorReportSubmitter {
             stackTrace.append(event.getThrowableText()).append("\r\n");
         }
 
-        final String bugReportBody = GitHubNewIssueBodyBuilderUtil.buildNewBugReportBody(
-                project,
-                additionalInfo == null ? DEFAULT_ISSUE_DESCRIPTION : additionalInfo,
-                stackTrace.toString()
-        );
-
         BrowserUtil.browse(
                 GitHubNewIssueUrlBuilderUtil.buildNewBugIssueUrl(
                         getDefaultIssueTitle(),
-                        bugReportBody
+                        additionalInfo == null ? DEFAULT_ISSUE_DESCRIPTION : additionalInfo,
+                        stackTrace.toString(),
+                        project
                 )
         );
 

--- a/src/com/magento/idea/magento2plugin/project/diagnostic/github/GitHubNewIssueBodyBuilderUtil.java
+++ b/src/com/magento/idea/magento2plugin/project/diagnostic/github/GitHubNewIssueBodyBuilderUtil.java
@@ -9,6 +9,9 @@ import com.intellij.ide.fileTemplates.FileTemplate;
 import com.intellij.ide.fileTemplates.FileTemplateManager;
 import com.intellij.openapi.project.Project;
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import org.jetbrains.annotations.NotNull;
 
@@ -24,10 +27,44 @@ public final class GitHubNewIssueBodyBuilderUtil {
      * @param project Project
      * @param bugDescription String
      * @param stackTrace String
+     * @param maxAllowedBodyLength short
      *
      * @return String
      */
     public static String buildNewBugReportBody(
+            final @NotNull Project project,
+            final @NotNull String bugDescription,
+            final @NotNull String stackTrace,
+            final short maxAllowedBodyLength
+    ) {
+        final short maxAllowedStackTraceLength = getMaxAllowedStackTraceLength(
+                project,
+                bugDescription,
+                maxAllowedBodyLength
+        );
+
+        if (encode(stackTrace).length() <= maxAllowedStackTraceLength) {
+            return buildTemplate(project, bugDescription, stackTrace);
+        }
+
+        final String cutStackTrace = encode(stackTrace).substring(
+                0,
+                maxAllowedStackTraceLength - 1
+        );
+
+        return buildTemplate(project, bugDescription, decode(cutStackTrace));
+    }
+
+    /**
+     * Build bug report body template.
+     *
+     * @param project Project
+     * @param bugDescription String
+     * @param stackTrace String
+     *
+     * @return String
+     */
+    private static String buildTemplate(
             final @NotNull Project project,
             final @NotNull String bugDescription,
             final @NotNull String stackTrace
@@ -45,5 +82,46 @@ public final class GitHubNewIssueBodyBuilderUtil {
         } catch (IOException exception) {
             return "";
         }
+    }
+
+    /**
+     * Get max allowed stacktrace length.
+     *
+     * @param project Project
+     * @param bugDescription String
+     * @param maxAllowedBodyLength String
+     *
+     * @return short
+     */
+    private static short getMaxAllowedStackTraceLength(
+            final @NotNull Project project,
+            final @NotNull String bugDescription,
+            final short maxAllowedBodyLength
+    ) {
+        final String builtTemplateWithoutStackTrace = buildTemplate(project, bugDescription, "");
+
+        return (short) (maxAllowedBodyLength - encode(builtTemplateWithoutStackTrace).length());
+    }
+
+    /**
+     * Encode string to be used in URI.
+     *
+     * @param value String
+     *
+     * @return String
+     */
+    private static String encode(final @NotNull String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Decode string that was encoded to be used in URI.
+     *
+     * @param value String
+     *
+     * @return String
+     */
+    private static String decode(final @NotNull String value) {
+        return URLDecoder.decode(value, StandardCharsets.UTF_8);
     }
 }

--- a/src/com/magento/idea/magento2plugin/project/diagnostic/github/GitHubNewIssueBodyBuilderUtil.java
+++ b/src/com/magento/idea/magento2plugin/project/diagnostic/github/GitHubNewIssueBodyBuilderUtil.java
@@ -27,7 +27,7 @@ public final class GitHubNewIssueBodyBuilderUtil {
      * @param project Project
      * @param bugDescription String
      * @param stackTrace String
-     * @param maxAllowedBodyLength short
+     * @param maxAllowedBodyLength int
      *
      * @return String
      */
@@ -35,9 +35,9 @@ public final class GitHubNewIssueBodyBuilderUtil {
             final @NotNull Project project,
             final @NotNull String bugDescription,
             final @NotNull String stackTrace,
-            final short maxAllowedBodyLength
+            final int maxAllowedBodyLength
     ) {
-        final short maxAllowedStackTraceLength = getMaxAllowedStackTraceLength(
+        final int maxAllowedStackTraceLength = getMaxAllowedStackTraceLength(
                 project,
                 bugDescription,
                 maxAllowedBodyLength
@@ -91,16 +91,16 @@ public final class GitHubNewIssueBodyBuilderUtil {
      * @param bugDescription String
      * @param maxAllowedBodyLength String
      *
-     * @return short
+     * @return int
      */
-    private static short getMaxAllowedStackTraceLength(
+    private static int getMaxAllowedStackTraceLength(
             final @NotNull Project project,
             final @NotNull String bugDescription,
-            final short maxAllowedBodyLength
+            final int maxAllowedBodyLength
     ) {
         final String builtTemplateWithoutStackTrace = buildTemplate(project, bugDescription, "");
 
-        return (short) (maxAllowedBodyLength - encode(builtTemplateWithoutStackTrace).length());
+        return maxAllowedBodyLength - encode(builtTemplateWithoutStackTrace).length();
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/project/diagnostic/github/GitHubNewIssueUrlBuilderUtil.java
+++ b/src/com/magento/idea/magento2plugin/project/diagnostic/github/GitHubNewIssueUrlBuilderUtil.java
@@ -16,7 +16,7 @@ public final class GitHubNewIssueUrlBuilderUtil {
             + "magento2-phpstorm-plugin/issues/new"
             + "?assignees=&labels=bug&template=bug_report.md";
     private static final String URI_PARAMS_PART = "&title=%title&body=%body";
-    private static final short MAX_URI_LENGTH = 8000;
+    private static final int MAX_URI_LENGTH = 8000;
 
     private GitHubNewIssueUrlBuilderUtil() {}
 
@@ -73,9 +73,9 @@ public final class GitHubNewIssueUrlBuilderUtil {
      *
      * @param title String
      *
-     * @return short
+     * @return int
      */
-    private static short getAllowedBodyLength(final @NotNull String title) {
-        return (short) (MAX_URI_LENGTH - formatNewBugIssueUrl(title, "").length());
+    private static int getAllowedBodyLength(final @NotNull String title) {
+        return MAX_URI_LENGTH - formatNewBugIssueUrl(title, "").length();
     }
 }

--- a/src/com/magento/idea/magento2plugin/project/diagnostic/github/GitHubNewIssueUrlBuilderUtil.java
+++ b/src/com/magento/idea/magento2plugin/project/diagnostic/github/GitHubNewIssueUrlBuilderUtil.java
@@ -5,6 +5,7 @@
 
 package com.magento.idea.magento2plugin.project.diagnostic.github;
 
+import com.intellij.openapi.project.Project;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import org.jetbrains.annotations.NotNull;
@@ -14,6 +15,8 @@ public final class GitHubNewIssueUrlBuilderUtil {
     private static final String NEW_BUG_ISSUE_BASE_URL = "https://github.com/magento/"
             + "magento2-phpstorm-plugin/issues/new"
             + "?assignees=&labels=bug&template=bug_report.md";
+    private static final String URI_PARAMS_PART = "&title=%title&body=%body";
+    private static final short MAX_URI_LENGTH = 8000;
 
     private GitHubNewIssueUrlBuilderUtil() {}
 
@@ -21,19 +24,58 @@ public final class GitHubNewIssueUrlBuilderUtil {
      * Build new issue url (template -> bug_report).
      *
      * @param title String
-     * @param body String
+     * @param bugDescription String
+     * @param stackTrace String
+     * @param project Project
      *
      * @return String
      */
     public static String buildNewBugIssueUrl(
+            final @NotNull String title,
+            final @NotNull String bugDescription,
+            final @NotNull String stackTrace,
+            final @NotNull Project project
+    ) {
+        final String bugReportBody = GitHubNewIssueBodyBuilderUtil.buildNewBugReportBody(
+                project,
+                bugDescription,
+                stackTrace,
+                getAllowedBodyLength(title)
+        );
+
+        return formatNewBugIssueUrl(title, bugReportBody);
+    }
+
+    /**
+     * Format URL with encoded url parameters.
+     *
+     * @param title String
+     * @param body String
+     *
+     * @return String
+     */
+    private static String formatNewBugIssueUrl(
             final @NotNull String title,
             final @NotNull String body
     ) {
         final String encodedTitle = URLEncoder.encode(title, StandardCharsets.UTF_8);
         final String encodedBody = URLEncoder.encode(body, StandardCharsets.UTF_8);
 
-        return NEW_BUG_ISSUE_BASE_URL
-                .concat("&title=" + encodedTitle)
-                .concat("&body=" + encodedBody);
+        final String paramsPart = URI_PARAMS_PART
+                .replace("%title", encodedTitle)
+                .replace("%body", encodedBody);
+
+        return NEW_BUG_ISSUE_BASE_URL.concat(paramsPart);
+    }
+
+    /**
+     * Calculate max allowed body length.
+     *
+     * @param title String
+     *
+     * @return short
+     */
+    private static short getAllowedBodyLength(final @NotNull String title) {
+        return (short) (MAX_URI_LENGTH - formatNewBugIssueUrl(title, "").length());
     }
 }


### PR DESCRIPTION
**Description** (*) 
When we want to report some issues by the diagnostic feature, we can get the next output on the GitHub side:
<img width="1558" alt="Screenshot 2021-05-07 at 16 16 14" src="https://user-images.githubusercontent.com/31848341/117538950-cec64e00-b010-11eb-9828-0c90c1fb421f.png">

It is caused because generated URI on the plugin side didn't consider max allowed URI length on the GitHub side. If the stack trace for an error is too long, we could have such an error while trying to report an issue. I have fixed that issue:
<img width="1558" alt="Screenshot 2021-05-08 at 15 13 32" src="https://user-images.githubusercontent.com/31848341/117539029-41cfc480-b011-11eb-813d-6d0e9afe9372.png">

Also was found and fixed names for registered templates: Magento Web API XML and Web API Interface.

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
