### PR TITLE
Autofocus on a field for all existent dialogs

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/AbstractDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/AbstractDialog.java
@@ -16,6 +16,8 @@ import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
 import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.Toolkit;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
 import java.lang.reflect.Field;
 import java.util.LinkedList;
 import java.util.List;
@@ -246,5 +248,61 @@ public abstract class AbstractDialog extends JDialog {
         }
 
         return getParentTabPaneForComponent(parent);
+    }
+
+    /**
+     * Listener that helps focus on a field for dialogues after it is opened.
+     *
+     * <p><b>This inner class designed to simplify focusing on a field for the
+     * implementations of this abstract class.</b></p>
+     * <p><b>To use this listener:</b></p>
+     * <p>1) specify method in which desired field is focused:</p><br/>
+     * <pre>
+     *     public void focusOnTheSampleField() {
+     *             sampleField.requestFocusInWindow();
+     *     }
+     * </pre>
+     *
+     * <p>2) call in the constructor method:</p><br/>
+     * <pre>
+     *     addComponentListener(
+     *             new FocusOnAFieldListener(this::focusOnTheSampleField)
+     *     )
+     * </pre>
+     *
+     * @see #requestFocusInWindow()
+     */
+    public static final class FocusOnAFieldListener implements ComponentListener {
+
+        private final @NotNull Runnable makeAFieldFocusedAction;
+
+        /**
+         * Focus on a field listener constructor.
+         *
+         * @param makeAFieldFocused Runnable method in which desired field is focused.
+         */
+        public FocusOnAFieldListener(final @NotNull Runnable makeAFieldFocused) {
+            makeAFieldFocusedAction = makeAFieldFocused;
+        }
+
+        @Override
+        @SuppressWarnings("PMD.UncommentedEmptyMethodBody")
+        public void componentResized(final ComponentEvent event) {
+        }
+
+        @Override
+        @SuppressWarnings("PMD.UncommentedEmptyMethodBody")
+        public void componentMoved(final ComponentEvent event) {
+        }
+
+        @Override
+        public void componentShown(final ComponentEvent event) {
+            makeAFieldFocusedAction.run();
+        }
+
+        @Override
+        @SuppressWarnings("PMD.UncommentedEmptyMethodBody")
+        public void componentHidden(final ComponentEvent event) {
+        }
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAPluginDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAPluginDialog.java
@@ -140,6 +140,8 @@ public class CreateAPluginDialog extends AbstractDialog {
                 KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
                 JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT
         );
+
+        addComponentListener(new FocusOnAFieldListener(() -> pluginModule.requestFocusInWindow()));
     }
 
     private void fillPluginTypeOptions() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAnObserverDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAnObserverDialog.java
@@ -120,6 +120,8 @@ public class CreateAnObserverDialog extends AbstractDialog {
                 KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
                 JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT
         );
+
+        addComponentListener(new FocusOnAFieldListener(() -> observerName.requestFocusInWindow()));
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/InjectAViewModelDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/InjectAViewModelDialog.java
@@ -123,6 +123,10 @@ public class InjectAViewModelDialog extends AbstractDialog {
                 KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
                 JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT
         );
+
+        addComponentListener(
+                new FocusOnAFieldListener(() -> viewModelClassName.requestFocusInWindow())
+        );
     }
 
     protected void updateArgumentText() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewBlockDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewBlockDialog.java
@@ -93,6 +93,8 @@ public class NewBlockDialog extends AbstractDialog {
                 KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
                 JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT
         );
+
+        addComponentListener(new FocusOnAFieldListener(() -> blockName.requestFocusInWindow()));
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCLICommandDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCLICommandDialog.java
@@ -107,6 +107,10 @@ public class NewCLICommandDialog extends AbstractDialog {
                 KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
                 JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT
         );
+
+        addComponentListener(
+                new FocusOnAFieldListener(() -> cliCommandClassNameField.requestFocusInWindow())
+        );
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewControllerDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewControllerDialog.java
@@ -107,6 +107,10 @@ public class NewControllerDialog extends AbstractDialog {
                 KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
                 JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT
         );
+
+        addComponentListener(
+                new FocusOnAFieldListener(() -> controllerAreaSelect.requestFocusInWindow())
+        );
     }
 
     private String getModuleName() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCronGroupDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCronGroupDialog.java
@@ -100,6 +100,10 @@ public class NewCronGroupDialog extends AbstractDialog {
                 KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
                 JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT
         );
+
+        addComponentListener(
+                new FocusOnAFieldListener(() -> cronGroupName.requestFocusInWindow())
+        );
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCronjobDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCronjobDialog.java
@@ -193,7 +193,7 @@ public class NewCronjobDialog extends AbstractDialog {
         );
 
         addComponentListener(
-                new FocusOnAFieldListener(() -> cronjobNameField.requestFocusInWindow())
+                new FocusOnAFieldListener(() -> cronjobClassNameField.requestFocusInWindow())
         );
     }
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCronjobDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCronjobDialog.java
@@ -191,6 +191,10 @@ public class NewCronjobDialog extends AbstractDialog {
                 KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
                 JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT
         );
+
+        addComponentListener(
+                new FocusOnAFieldListener(() -> cronjobNameField.requestFocusInWindow())
+        );
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDataModelDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDataModelDialog.java
@@ -115,6 +115,8 @@ public class NewDataModelDialog extends AbstractDialog {
                 KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
                 JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT
         );
+
+        addComponentListener(new FocusOnAFieldListener(() -> modelName.requestFocusInWindow()));
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDbSchemaDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDbSchemaDialog.java
@@ -123,6 +123,8 @@ public class NewDbSchemaDialog extends AbstractDialog {
         );
         fillComboBoxes();
         initializeColumnsUiComponentGroup();
+
+        addComponentListener(new FocusOnAFieldListener(() -> tableName.requestFocusInWindow()));
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEmailTemplateDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEmailTemplateDialog.java
@@ -98,6 +98,8 @@ public class NewEmailTemplateDialog extends AbstractDialog {
                 KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
                 JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT
         );
+
+        addComponentListener(new FocusOnAFieldListener(() -> identifier.requestFocusInWindow()));
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewGraphQlResolverDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewGraphQlResolverDialog.java
@@ -89,6 +89,10 @@ public class NewGraphQlResolverDialog extends AbstractDialog {
                 KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
                 JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT
         );
+
+        addComponentListener(
+                new FocusOnAFieldListener(() -> graphQlResolverClassName.requestFocusInWindow())
+        );
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewInterfaceForServiceDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewInterfaceForServiceDialog.java
@@ -119,6 +119,8 @@ public class NewInterfaceForServiceDialog extends AbstractDialog {
         );
 
         fillPredefinedValuesAndDisableInputs();
+
+        addComponentListener(new FocusOnAFieldListener(() -> nameField.requestFocusInWindow()));
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewMessageQueueDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewMessageQueueDialog.java
@@ -200,6 +200,8 @@ public class NewMessageQueueDialog extends AbstractDialog {
         });
 
         connectionName.addActionListener(e -> toggleConsumer());
+
+        addComponentListener(new FocusOnAFieldListener(() -> topicName.requestFocusInWindow()));
     }
 
     private void toggleConsumer() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModelsDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModelsDialog.java
@@ -131,6 +131,8 @@ public class NewModelsDialog extends AbstractDialog {
                 updateText();
             }
         });
+
+        addComponentListener(new FocusOnAFieldListener(() -> modelName.requestFocusInWindow()));
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModuleDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModuleDialog.java
@@ -151,6 +151,8 @@ public class NewModuleDialog extends AbstractDialog implements ListSelectionList
                 KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
                 JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT
         );
+
+        addComponentListener(new FocusOnAFieldListener(() -> packageName.requestFocusInWindow()));
     }
 
     private void detectPackageName(final @NotNull PsiDirectory initialBaseDir) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModuleDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModuleDialog.java
@@ -152,7 +152,13 @@ public class NewModuleDialog extends AbstractDialog implements ListSelectionList
                 JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT
         );
 
-        addComponentListener(new FocusOnAFieldListener(() -> packageName.requestFocusInWindow()));
+        addComponentListener(new FocusOnAFieldListener(() -> {
+            if (packageName.isVisible()) {
+                packageName.requestFocusInWindow();
+            } else {
+                moduleName.requestFocusInWindow();
+            }
+        }));
     }
 
     private void detectPackageName(final @NotNull PsiDirectory initialBaseDir) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewUiComponentFormDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewUiComponentFormDialog.java
@@ -244,6 +244,8 @@ public class NewUiComponentFormDialog extends AbstractDialog {
         formAreaSelect.addActionListener(e -> toggleAcl());
         formAreaSelect.setEnabled(false);
         acl.setText(getModuleName() + "::manage");
+
+        addComponentListener(new FocusOnAFieldListener(() -> formName.requestFocusInWindow()));
     }
 
     protected void initButtonsTable() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewUiComponentGridDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewUiComponentGridDialog.java
@@ -232,6 +232,10 @@ public class NewUiComponentGridDialog extends AbstractDialog {
 
         dataProviderParentDirectory.setVisible(false);
         dataProviderParentDirectoryLabel.setVisible(false);
+
+        addComponentListener(
+                new FocusOnAFieldListener(() -> uiComponentName.requestFocusInWindow())
+        );
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewViewModelDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewViewModelDialog.java
@@ -97,6 +97,10 @@ public class NewViewModelDialog extends AbstractDialog {
                 KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
                 JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT
         );
+
+        addComponentListener(
+                new FocusOnAFieldListener(() -> viewModelName.requestFocusInWindow())
+        );
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewWebApiDeclarationDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewWebApiDeclarationDialog.java
@@ -111,6 +111,8 @@ public class NewWebApiDeclarationDialog extends AbstractDialog {
         );
 
         fillPredefinedValuesAndDisableInputs();
+
+        addComponentListener(new FocusOnAFieldListener(() -> routeUrl.requestFocusInWindow()));
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideClassByAPreferenceDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideClassByAPreferenceDialog.java
@@ -135,6 +135,10 @@ public class OverrideClassByAPreferenceDialog extends AbstractDialog { //NOPMD
                 KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
                 JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT
         );
+
+        addComponentListener(
+                new FocusOnAFieldListener(() -> preferenceModule.requestFocusInWindow())
+        );
     }
 
     private void suggestPreferenceDirectory(final PhpClass targetClass) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideInThemeDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideInThemeDialog.java
@@ -80,6 +80,8 @@ public class OverrideInThemeDialog extends AbstractDialog {
                 KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
                 JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT
         );
+
+        addComponentListener(new FocusOnAFieldListener(() -> theme.requestFocusInWindow()));
     }
 
     private void onOverride() {


### PR DESCRIPTION
**Description** (*)
Developed autofocus on the first (in most cases) field for all existing custom dialogue forms.

The main place where focusing declaration occurs is the constructor of a dialogue. 
Focusing should be called in the **componentShown** method of the **ComponentListener** interface instance. 
To simplify and make a field focusing shortly I've created the **FocusOnAFieldListener** implementation of the **ComponentListener** interface as an inner class of the **AbstractDialog**. Also, I added detailed annotation on how to use it:

<img width="780" alt="Screenshot 2021-06-11 at 01 40 11" src="https://user-images.githubusercontent.com/31848341/121605963-008a6480-ca56-11eb-97ab-a9af429e2c77.png">

The result for one of the dialogues:

<img width="421" alt="Screenshot 2021-06-11 at 01 13 53" src="https://user-images.githubusercontent.com/31848341/121604964-2878c880-ca54-11eb-8ef7-f93c1799ef0b.png">

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
