### PR TITLE
Fixed plugin generation issues

### DIFF
--- a/resources/fileTemplates/code/Magento Plugin After Method.php.ft
+++ b/resources/fileTemplates/code/Magento Plugin After Method.php.ft
@@ -1,8 +1,12 @@
 /**
 ${PARAM_DOC}
  */
-public function ${NAME}(${PARAM_LIST})
+public function ${NAME}(${PARAM_LIST})#if (${RETURN_TYPE}): ${RETURN_TYPE}#end
 {
     // TODO: Implement plugin method.
+    #if (${RETURN_TYPE})
+    #if (${RETURN_VARIABLES} && ${RETURN_TYPE} != "void")return ${RETURN_VARIABLES}; #end
+    #else
     #if (${RETURN_VARIABLES})return ${RETURN_VARIABLES}; #end
+    #end
 }

--- a/resources/fileTemplates/code/Magento Plugin Around Method.php.ft
+++ b/resources/fileTemplates/code/Magento Plugin Around Method.php.ft
@@ -1,8 +1,12 @@
 /**
 ${PARAM_DOC}
  */
-public function ${NAME}(${PARAM_LIST})
+public function ${NAME}(${PARAM_LIST})#if (${RETURN_TYPE}): ${RETURN_TYPE}#end
 {
     // TODO: Implement plugin method.
+    #if (${RETURN_TYPE})
+    #if (${RETURN_TYPE} != "void")return #end$proceed(#if(${RETURN_VARIABLES})${RETURN_VARIABLES}#end);
+    #else
     return $proceed(#if(${RETURN_VARIABLES})${RETURN_VARIABLES}#end);
+    #end
 }

--- a/resources/fileTemplates/code/Magento Plugin Before Method.php.ft
+++ b/resources/fileTemplates/code/Magento Plugin Before Method.php.ft
@@ -1,10 +1,8 @@
 /**
 ${PARAM_DOC}
-#if (${RETURN_VARIABLES})* @return array
-#end
  */
 public function ${NAME}(${PARAM_LIST})#if (${RETURN_TYPE}): ${RETURN_TYPE}#end
 {
     // TODO: Implement plugin method.
-    #if (${RETURN_VARIABLES})return [${RETURN_VARIABLES}]; #end
+    #if (${RETURN_VARIABLES})return [${RETURN_VARIABLES}];#else return [];#end
 }

--- a/resources/fileTemplates/code/Magento Plugin Before Method.php.ft
+++ b/resources/fileTemplates/code/Magento Plugin Before Method.php.ft
@@ -3,7 +3,7 @@ ${PARAM_DOC}
 #if (${RETURN_VARIABLES})* @return array
 #end
  */
-public function ${NAME}(${PARAM_LIST})
+public function ${NAME}(${PARAM_LIST})#if (${RETURN_TYPE}): ${RETURN_TYPE}#end
 {
     // TODO: Implement plugin method.
     #if (${RETURN_VARIABLES})return [${RETURN_VARIABLES}]; #end

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/PluginClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/PluginClassGenerator.java
@@ -242,18 +242,32 @@ public class PluginClassGenerator extends FileGenerator {
         return pluginFileData.getPluginModule();
     }
 
+    /**
+     * Get methods insert position.
+     *
+     * @param pluginClass PhpClass
+     *
+     * @return int
+     */
     private int getInsertPos(final PhpClass pluginClass) {
         int insertPos = -1;
+
         final LeafPsiElement[] leafElements = PsiTreeUtil.getChildrenOfType(
                 pluginClass,
                 LeafPsiElement.class
         );
+
+        if (leafElements == null) {
+            return insertPos;
+        }
+
         for (final LeafPsiElement leafPsiElement: leafElements) {
             if (!leafPsiElement.getText().equals(MagentoPhpClass.CLOSING_TAG)) {
                 continue;
             }
             insertPos = leafPsiElement.getTextOffset();
         }
-        return insertPos;
+
+        return insertPos == -1 ? insertPos : insertPos - 1;
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/code/PluginMethodsGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/code/PluginMethodsGenerator.java
@@ -105,18 +105,30 @@ public class PluginMethodsGenerator {
         return pluginMethods.toArray(new PluginMethodData[0]);
     }
 
+    /**
+     * Fill attributes for plugin method.
+     *
+     * @param scopeForUseOperator PhpPsiElement
+     * @param type Plugin.PluginType
+     *
+     * @return Properties
+     */
     private Properties getAccessMethodAttributes(
             final @Nullable PhpPsiElement scopeForUseOperator,
             final @NotNull Plugin.PluginType type
     ) {
         final Properties attributes = new Properties();
-        final String typeHint = this.fillAttributes(scopeForUseOperator, attributes, type);
-        this.addTypeHintsAndReturnType(attributes, typeHint);
+        final String pluginMethodReturnType = this.fillAttributes(
+                scopeForUseOperator,
+                attributes,
+                type
+        );
+        this.addReturnType(attributes, pluginMethodReturnType);
+
         return attributes;
     }
 
-    @NotNull
-    private String fillAttributes(
+    private @NotNull String fillAttributes(
             final @Nullable PhpPsiElement scopeForUseOperator,
             final Properties attributes,
             final @NotNull Plugin.PluginType type
@@ -128,10 +140,16 @@ public class PluginMethodsGenerator {
 
         attributes.setProperty("NAME", pluginMethodName);
         final PhpReturnType targetMethodReturnType = myMethod.getReturnType();
-        String typeHint = "";
-        if (targetMethodReturnType != null) {
-            typeHint = targetMethodReturnType.getText();
+        String returnType = "";
+
+        if (targetMethodReturnType != null
+                && (type.equals(Plugin.PluginType.after) || type.equals(Plugin.PluginType.around))
+        ) {
+            returnType = targetMethodReturnType.getText();
+        } else if (type.equals(Plugin.PluginType.before)) {
+            returnType = MagentoPhpClass.ARRAY_TYPE;
         }
+
         final Collection<PsiElement> parameters = new ArrayList();
         parameters.add(myTargetClass);
         parameters.addAll(Arrays.asList(myMethod.getParameters()));
@@ -148,29 +166,35 @@ public class PluginMethodsGenerator {
             attributes.setProperty("RETURN_VARIABLES", returnVariables);
         }
 
-        return typeHint;
+        return returnType;
     }
 
-    private void addTypeHintsAndReturnType(final Properties attributes, final String typeHint) {
+    /**
+     * Add return type to the properties.
+     *
+     * @param attributes Properties
+     * @param returnDocType String
+     */
+    private void addReturnType(final Properties attributes, final String returnDocType) {
         final Project project = this.pluginClass.getProject();
-        if (PhpLanguageFeature.SCALAR_TYPE_HINTS.isSupported(project)
-                && isDocTypeConvertable(typeHint)) {
-            attributes.setProperty("SCALAR_TYPE_HINT", convertDocTypeToHint(project, typeHint));
-        }
-
-        final boolean hasFeatureVoid = PhpLanguageFeature.RETURN_VOID.isSupported(project);
-        if (hasFeatureVoid) {
-            attributes.setProperty("VOID_RETURN_TYPE", MagentoPhpClass.VOID_RETURN_TYPE);
-        }
 
         if (PhpLanguageFeature.RETURN_TYPES.isSupported(project)
-                && isDocTypeConvertable(typeHint)) {
-            attributes.setProperty("RETURN_TYPE", convertDocTypeToHint(project, typeHint));
+                && isDocTypeConvertable(returnDocType)) {
+            attributes.setProperty(
+                    "RETURN_TYPE",
+                    convertDocTypeToHint(project, returnDocType)
+            );
         }
-
     }
 
-    private static boolean isDocTypeConvertable(final String typeHint) {
+    /**
+     * Check if PHP DOC type could be converted to scalar PHP type.
+     *
+     * @param typeHint String
+     *
+     * @return boolean
+     */
+    private static boolean isDocTypeConvertable(final @NotNull String typeHint) {
         return !typeHint.equalsIgnoreCase(MagentoPhpClass.MIXED_RETURN_TYPE)
             && !typeHint.equalsIgnoreCase(MagentoPhpClass.STATIC_MODIFIER)
             && !typeHint.equalsIgnoreCase(MagentoPhpClass.PHP_TRUE)
@@ -193,12 +217,28 @@ public class PluginMethodsGenerator {
                 : (hasNullableTypeFeature ? "?" : "") + split[0];
     }
 
-    @NotNull
-    private static String convertDocTypeToHint(final Project project, final String typeHint) {
+    /**
+     * Convert PHP DOC type to hint.
+     *
+     * @param project Project
+     * @param typeHint String
+     *
+     * @return String
+     */
+    private static @NotNull String convertDocTypeToHint(
+            final @NotNull Project project,
+            final @NotNull String typeHint
+    ) {
         String hint = typeHint.contains("[]") ? "array" : typeHint;
         hint = hint.contains("boolean") ? "bool" : hint;
+
         if (typeWithNull(typeHint)) {
             hint = convertNullableType(project, hint);
+        }
+
+        if (PhpLanguageFeature.RETURN_VOID.isSupported(project)
+                && typeHint.equals(MagentoPhpClass.VOID_RETURN_TYPE)) {
+            hint = MagentoPhpClass.VOID_RETURN_TYPE;
         }
 
         return hint;

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/code/util/ConvertPluginParamsToPhpDocStringUtil.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/code/util/ConvertPluginParamsToPhpDocStringUtil.java
@@ -8,15 +8,19 @@ package com.magento.idea.magento2plugin.actions.generation.generator.code.util;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.jetbrains.php.codeInsight.PhpCodeInsightUtil;
+import com.jetbrains.php.lang.PhpLangUtil;
 import com.jetbrains.php.lang.documentation.phpdoc.PhpDocUtil;
 import com.jetbrains.php.lang.psi.elements.Method;
 import com.jetbrains.php.lang.psi.elements.PhpNamedElement;
+import com.jetbrains.php.lang.psi.elements.PhpPsiElement;
 import com.jetbrains.php.lang.psi.elements.PhpReturnType;
+import com.jetbrains.php.lang.psi.resolve.types.PhpType;
+import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
 import com.magento.idea.magento2plugin.magento.files.Plugin;
 import com.magento.idea.magento2plugin.magento.packages.MagentoPhpClass;
-import com.magento.idea.magento2plugin.magento.packages.Package;
 import java.util.Collection;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public final class ConvertPluginParamsToPhpDocStringUtil {
 
@@ -38,36 +42,34 @@ public final class ConvertPluginParamsToPhpDocStringUtil {
             final Project project,
             final Method myMethod
     ) {
-        final StringBuilder stringBuilder = new StringBuilder();//NOPMD
+        final StringBuilder stringBuilder = new StringBuilder(155);
         final PhpReturnType returnType = myMethod.getReturnType();
-
         int increment = 0;
+
         for (final PsiElement parameter : parameters) {
             final PhpNamedElement element = (PhpNamedElement) parameter;
+
             if (stringBuilder.length() > 0) {
                 stringBuilder.append('\n');
             }
-
             stringBuilder.append("* @param ");
-
             String typeStr;
+
             if (increment == 0) {
-                typeStr = PhpDocUtil.getTypePresentation(project, element.getType(), null);
+                typeStr = getStringTypePresentation(project, element.getType(), null);
             } else {
-                typeStr = PhpDocUtil.getTypePresentation(
-                    project, element.getType(),
-                    PhpCodeInsightUtil.findScopeForUseOperator(element)
+                typeStr = getStringTypePresentation(
+                        project,
+                        element.getType(),
+                        PhpCodeInsightUtil.findScopeForUseOperator(element)
                 );
-                if (typeStr.indexOf(Package.fqnSeparator, 1) > 0) {
-                    final String[] fqnArray = typeStr.split("\\\\");
-                    typeStr = fqnArray[fqnArray.length - 1];
-                }
             }
 
             if (!typeStr.isEmpty()) {
                 stringBuilder.append(typeStr).append(' ');
             }
             String paramName = element.getName();
+
             if (increment == 0) {
                 paramName = "subject";
             }
@@ -76,17 +78,24 @@ public final class ConvertPluginParamsToPhpDocStringUtil {
             if (type.equals(Plugin.PluginType.around) && increment == 0) {
                 stringBuilder.append("\n* @param callable $proceed");
             }
+
             if (type.equals(Plugin.PluginType.after) && increment == 0) {
                 if (returnType != null) {
                     if (returnType.getText().equals(MagentoPhpClass.VOID_RETURN_TYPE)) {
                         stringBuilder.append("\n* @param null $result");
                     } else {
-                        stringBuilder.append("\n* @param ").append(returnType.getText())
+                        final String returnTypeStr = getStringTypePresentation(
+                                project,
+                                returnType.getType(),
+                                null
+                        );
+                        stringBuilder.append("\n* @param ")
+                                .append(returnTypeStr)
                                 .append(" $result");
                     }
+                    increment++;
                     continue;
                 }
-
                 stringBuilder.append("\n* @param $result");
             }
 
@@ -97,9 +106,36 @@ public final class ConvertPluginParamsToPhpDocStringUtil {
             if (returnType.getText().equals(MagentoPhpClass.VOID_RETURN_TYPE)) {
                 stringBuilder.append("\n* @return ").append(MagentoPhpClass.VOID_RETURN_TYPE);
             } else {
-                stringBuilder.append("\n* @return ").append(returnType.getText());
+                final String returnTypeStr = getStringTypePresentation(
+                        project,
+                        returnType.getType(),
+                        null
+                );
+                stringBuilder.append("\n* @return ").append(returnTypeStr);
             }
         }
         return stringBuilder.toString();
+    }
+
+    /**
+     * Get string type representation in the DOC format.
+     *
+     * @param project Project
+     * @param type PhpType
+     *
+     * @return String
+     */
+    private static String getStringTypePresentation(
+            final @NotNull Project project,
+            final @NotNull PhpType type,
+            final @Nullable PhpPsiElement scope
+    ) {
+        String typeStr = PhpDocUtil.getTypePresentation(project, type, scope);
+
+        if (PhpLangUtil.isFqn(typeStr)) {
+            typeStr = PhpClassGeneratorUtil.getNameFromFqn(typeStr);
+        }
+
+        return typeStr;
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/code/util/ConvertPluginParamsToString.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/code/util/ConvertPluginParamsToString.java
@@ -11,6 +11,7 @@ import com.intellij.psi.PsiElement;
 import com.jetbrains.php.codeInsight.PhpCodeInsightUtil;
 import com.jetbrains.php.config.PhpLanguageFeature;
 import com.jetbrains.php.lang.PhpCodeUtil;
+import com.jetbrains.php.lang.PhpLangUtil;
 import com.jetbrains.php.lang.documentation.phpdoc.PhpDocUtil;
 import com.jetbrains.php.lang.psi.elements.Method;
 import com.jetbrains.php.lang.psi.elements.Parameter;
@@ -18,6 +19,7 @@ import com.jetbrains.php.lang.psi.elements.PhpNamedElement;
 import com.jetbrains.php.lang.psi.elements.PhpPsiElement;
 import com.jetbrains.php.lang.psi.elements.PhpReturnType;
 import com.jetbrains.php.lang.psi.resolve.types.PhpType;
+import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
 import com.magento.idea.magento2plugin.magento.files.Plugin;
 import com.magento.idea.magento2plugin.magento.packages.MagentoPhpClass;
 import com.magento.idea.magento2plugin.magento.packages.Package;
@@ -28,6 +30,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class ConvertPluginParamsToString {
+
     private ConvertPluginParamsToString() {}
 
     /**
@@ -36,6 +39,7 @@ public final class ConvertPluginParamsToString {
      * @param parameters Collection
      * @param type       PluginType
      * @param myMethod   Method
+     *
      * @return String
      */
     @SuppressWarnings({"PMD.NPathComplexity", "PMD.CyclomaticComplexity"})
@@ -44,19 +48,20 @@ public final class ConvertPluginParamsToString {
             final @NotNull Plugin.PluginType type,
             final Method myMethod
     ) {
-        final StringBuilder buf = new StringBuilder();//NOPMD
+        final StringBuilder buf = new StringBuilder(155);
         final PhpReturnType returnType = myMethod.getReturnType();
-        final Iterator parametersIterator = parameters.iterator();
+        final Iterator<PsiElement> parametersIterator = parameters.iterator();
+        int iterator = 0;
 
-        Integer iterator = 0;
         while (parametersIterator.hasNext()) {
             final PhpNamedElement element = (PhpNamedElement) parametersIterator.next();
+
             if (iterator != 0) {
                 buf.append(',');
             }
-
             if (element instanceof Parameter) {
                 String parameterText = PhpCodeUtil.paramToString(element);
+
                 if (parameterText.indexOf(Package.fqnSeparator, 1) > 0) {
                     final String[] fqnArray = parameterText.split("\\\\");
                     parameterText = fqnArray[fqnArray.length - 1];
@@ -64,23 +69,35 @@ public final class ConvertPluginParamsToString {
                 buf.append(parameterText);
             } else {
                 final Boolean globalType = iterator != 0;
-                final String typeHint = getTypeHint(element, globalType, myMethod.getProject());
+                String typeHint = getNonPrimitiveTypeForElement(
+                        element,
+                        globalType,
+                        myMethod.getProject()
+                );
+
                 if (typeHint != null && !typeHint.isEmpty()) {
+                    if (PhpLangUtil.isFqn(typeHint)) {
+                        typeHint = PhpClassGeneratorUtil.getNameFromFqn(typeHint);
+                    }
                     buf.append(typeHint).append(' ');
                 }
 
                 String paramName = element.getName();
+
                 if (iterator == 0) {
                     paramName = "subject";
                 }
                 buf.append('$').append(paramName);
             }
+
             if (type.equals(Plugin.PluginType.after) && iterator == 0) {
-                if (returnType != null && !returnType.getText()//NOPMD
-                        .equals(MagentoPhpClass.VOID_RETURN_TYPE)) {
-                    buf.append(", ").append(returnType.getText()).append(" $result");
-                } else {
+                if (returnType != null
+                        && returnType.getText().equals(MagentoPhpClass.VOID_RETURN_TYPE)) {
                     buf.append(", $result");
+                } else {
+                    if (returnType != null) {
+                        buf.append(", ").append(returnType.getText()).append(" $result");
+                    }
                 }
             }
             if (type.equals(Plugin.PluginType.around) && iterator == 0) {
@@ -92,53 +109,63 @@ public final class ConvertPluginParamsToString {
         return buf.toString();
     }
 
-    @Nullable
-    private static String getTypeHint(
+    /**
+     * Get type hint for the specified element.
+     *
+     * @param element PhpNamedElement
+     * @param globalType Boolean
+     * @param project Project
+     *
+     * @return String
+     */
+    private static @Nullable String getNonPrimitiveTypeForElement(
             final @NotNull PhpNamedElement element,
             final Boolean globalType,
             final Project project
     ) {
         final PhpType filedType = element.getType().global(project);
-        final Set<String> typeStrings = filedType.getTypes();
-        String typeString = null;
-        if (typeStrings.size() == 1) { //NOPMD
-            typeString = convertTypeToString(element, typeStrings, globalType);
-        }
+        final Set<String> typeStrings = filterNullType(filedType).getTypes();
+        String typeString = convertNonPrimitiveTypeToString(element, typeStrings, globalType);
 
-        if (typeStrings.size() == 2) { //NOPMD
-            final PhpType filteredNullType = filterNullCaseInsensitive(filedType);
-            if (filteredNullType.getTypes().size() == 1) { //NOPMD
-                typeString = convertTypeToString(
-                        element,
-                        filteredNullType.getTypes(),
-                        globalType
-                );
-                if (PhpLanguageFeature.NULLABLES.isSupported(element.getProject())) {
-                    typeString = "?".concat(typeString);
-                }
-            }
+        if (typeString != null
+                && filedType.getTypes().size() != typeStrings.size()
+                && PhpLanguageFeature.NULLABLES.isSupported(element.getProject())) {
+            typeString = "?".concat(typeString);
         }
 
         return typeString;
     }
 
-    @Nullable
-    private static String convertTypeToString(
+    /**
+     * Convert non primitive PHP type to string for specified PhpNamedElement.
+     *
+     * @param element PhpNamedElement
+     * @param typeStrings Set[String]
+     * @param globalType Boolean
+     *
+     * @return String
+     */
+    private static @Nullable String convertNonPrimitiveTypeToString(
             final @NotNull PhpNamedElement element,
             final Set<String> typeStrings,
             final Boolean globalType
     ) {
         String simpleType = typeStrings.iterator().next();
         simpleType = StringUtil.trimStart(simpleType, "\\");
+
         if (!PhpType.isPrimitiveType(simpleType)
                 || PhpLanguageFeature.SCALAR_TYPE_HINTS.isSupported(element.getProject())
                 || MagentoPhpClass.ARRAY_TYPE.equalsIgnoreCase(simpleType)
                 || Plugin.CALLABLE_PARAM.equalsIgnoreCase(simpleType)) {
-            final String typeString = simpleType.endsWith("]") ? MagentoPhpClass.ARRAY_TYPE
-                    : getFieldTypeString(element,
-                    filterNullCaseInsensitive(element.getType()),
-                    globalType
-            );
+
+            final String typeString = simpleType.endsWith("]")
+                    ? MagentoPhpClass.ARRAY_TYPE
+                    : convertPhpTypeToString(
+                            element,
+                            filterNullType(element.getType()),
+                            globalType
+                    );
+
             if (!typeString.isEmpty()) {
                 return typeString;
             }
@@ -147,31 +174,47 @@ public final class ConvertPluginParamsToString {
         return null;
     }
 
-    private static PhpType filterNullCaseInsensitive(final PhpType filedType) {
+    /**
+     * Filter null type.
+     *
+     * @param filedType PhpType
+     *
+     * @return PhpType
+     */
+    private static PhpType filterNullType(final PhpType filedType) {
         if (filedType.getTypes().isEmpty()) {
             return PhpType.EMPTY;
-        } else {
-            final PhpType phpType = new PhpType();
-            final Iterator iterator = filedType.getTypes().iterator();
-
-            while (iterator.hasNext()) {
-                final String type = (String) iterator.next();
-                if (!type.equalsIgnoreCase("\\null")) { //NOPMD
-                    phpType.add(type);
-                }
-            }
-
-            return phpType;
         }
+        final PhpType phpType = new PhpType();
+
+        for (final String type : filedType.getTypes()) {
+            if ("\\null".equalsIgnoreCase(type)) {
+                continue;
+            }
+            phpType.add(type);
+        }
+
+        return phpType;
     }
 
-    private static String getFieldTypeString(
+    /**
+     * Convert PHP type to string for specified PhpNamedElement.
+     *
+     * @param element PhpNamedElement
+     * @param type PhpType
+     * @param globalType Boolean
+     *
+     * @return String
+     */
+    private static String convertPhpTypeToString(
             final PhpNamedElement element,
             final @NotNull PhpType type,
             final Boolean globalType
     ) {
-        final PhpPsiElement scope = (globalType) //NOPMD
-                ? PhpCodeInsightUtil.findScopeForUseOperator(element) : null;
+        final PhpPsiElement scope = globalType
+                ? PhpCodeInsightUtil.findScopeForUseOperator(element)
+                : null;
+
         return PhpDocUtil.getTypePresentation(element.getProject(), type, scope);
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/code/util/ConvertPluginParamsToString.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/code/util/ConvertPluginParamsToString.java
@@ -42,7 +42,7 @@ public final class ConvertPluginParamsToString {
      *
      * @return String
      */
-    @SuppressWarnings({"PMD.NPathComplexity", "PMD.CyclomaticComplexity"})
+    @SuppressWarnings({"PMD.NPathComplexity", "PMD.CyclomaticComplexity", "PMD.ConfusingTernary"})
     public static String execute(
             final Collection<PsiElement> parameters,
             final @NotNull Plugin.PluginType type,

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/code/util/ConvertPluginParamsToString.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/code/util/ConvertPluginParamsToString.java
@@ -92,12 +92,10 @@ public final class ConvertPluginParamsToString {
 
             if (type.equals(Plugin.PluginType.after) && iterator == 0) {
                 if (returnType != null
-                        && returnType.getText().equals(MagentoPhpClass.VOID_RETURN_TYPE)) {
-                    buf.append(", $result");
+                        && !returnType.getText().equals(MagentoPhpClass.VOID_RETURN_TYPE)) {
+                    buf.append(", ").append(returnType.getText()).append(" $result");
                 } else {
-                    if (returnType != null) {
-                        buf.append(", ").append(returnType.getText()).append(" $result");
-                    }
+                    buf.append(", $result");
                 }
             }
             if (type.equals(Plugin.PluginType.around) && iterator == 0) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/util/FillTextBufferWithPluginMethods.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/util/FillTextBufferWithPluginMethods.java
@@ -8,11 +8,13 @@ package com.magento.idea.magento2plugin.actions.generation.util;
 import com.intellij.openapi.util.Key;
 import com.intellij.psi.PsiElement;
 import com.jetbrains.php.lang.documentation.phpdoc.psi.PhpDocComment;
+import com.jetbrains.php.lang.psi.PhpPsiElementFactory;
 import com.jetbrains.php.lang.psi.elements.Method;
 import com.jetbrains.php.lang.psi.elements.Parameter;
 import com.jetbrains.php.lang.psi.elements.PhpReturnType;
 import com.magento.idea.magento2plugin.actions.generation.data.code.PluginMethodData;
 import com.magento.idea.magento2plugin.actions.generation.references.PhpClassReferenceResolver;
+import com.magento.idea.magento2plugin.util.php.PhpTypeMetadataParserUtil;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -53,7 +55,17 @@ public class FillTextBufferWithPluginMethods {
             final PsiElement targetClass = (PsiElement) pluginMethod.getTargetMethod()
                     .getUserData(targetClassKey);
             resolver.processElement(targetClass);
-            final PhpReturnType returnType = targetMethod.getReturnType();
+            PhpReturnType returnType = targetMethod.getReturnType();
+            final String returnTypeFqn =
+                    PhpTypeMetadataParserUtil.getMethodReturnType(targetMethod);
+
+            if (returnType == null && returnTypeFqn != null) {
+                returnType = PhpPsiElementFactory.createReturnType(
+                        pluginMethod.getTargetMethod().getProject(),
+                        returnTypeFqn
+                );
+            }
+
             if (returnType != null) {
                 resolver.processElement(returnType);
             }

--- a/testData/actions/generation/generator/PluginClassGenerator/generatePluginClassFile/TestPlugin.php
+++ b/testData/actions/generation/generator/PluginClassGenerator/generatePluginClassFile/TestPlugin.php
@@ -8,38 +8,37 @@ use Foo\Bar\Service\SimpleService;
 
 class TestPlugin
 {
-
     /**
-     * @param \Foo\Bar\Service\SimpleService $subject
+     * @param SimpleService $subject
      * @param int $param1
      * @param string $param2
      * @return array
      */
-    public function beforeExecute(\Foo\Bar\Service\SimpleService $subject, int $param1, string $param2)
+    public function beforeExecute(SimpleService $subject, int $param1, string $param2)
     {
         // TODO: Implement plugin method.
         return [$param1, $param2];
     }
 
     /**
-     * @param \Foo\Bar\Service\SimpleService $subject
+     * @param SimpleService $subject
      * @param callable $proceed
      * @param int $param1
      * @param string $param2
      */
-    public function aroundExecute(\Foo\Bar\Service\SimpleService $subject, callable $proceed, int $param1, string $param2)
+    public function aroundExecute(SimpleService $subject, callable $proceed, int $param1, string $param2)
     {
         // TODO: Implement plugin method.
         return $proceed($param1, $param2);
     }
 
     /**
-     * @param \Foo\Bar\Service\SimpleService $subject
+     * @param SimpleService $subject
      * @param $result
      * @param int $param1
      * @param string $param2
      */
-    public function afterExecute(\Foo\Bar\Service\SimpleService $subject, $result, int $param1, string $param2)
+    public function afterExecute(SimpleService $subject, $result, int $param1, string $param2)
     {
         // TODO: Implement plugin method.
         return $result;

--- a/tests/com/magento/idea/magento2plugin/actions/generation/generator/PluginClassGeneratorTest.java
+++ b/tests/com/magento/idea/magento2plugin/actions/generation/generator/PluginClassGeneratorTest.java
@@ -16,13 +16,13 @@ import org.jetbrains.annotations.NotNull;
 
 public class PluginClassGeneratorTest extends BaseGeneratorTestCase {
 
-    private static final String targetClassFnq = "Foo\\Bar\\Service\\SimpleService";
-    private static final String targetMethodName = "execute";
-    private static final String module = "Foo_Bar";
-    private static final String pluginNamespace = "Foo\\Bar\\Plugin";
-    private static final String pluginFqn = "Foo\\Bar\\Plugin\\TestPlugin";
-    private static final String pluginClassName = "TestPlugin";
-    private static final String pluginDir = "Plugin";
+    private static final String TARGET_CLASS_FQN = "Foo\\Bar\\Service\\SimpleService";
+    private static final String TARGET_METHOD_NAME = "execute";
+    private static final String MODULE_NAME = "Foo_Bar";
+    private static final String PLUGIN_NAMESPACE = "Foo\\Bar\\Plugin";
+    private static final String PLUGIN_FQN = "Foo\\Bar\\Plugin\\TestPlugin";
+    private static final String PLUGIN_CLASS_NAME = "TestPlugin";
+    private static final String PLUGIN_DIR = "Plugin";
 
     /**
      * Test of plugin generation.
@@ -33,8 +33,8 @@ public class PluginClassGeneratorTest extends BaseGeneratorTestCase {
         addPluginToTargetClass(Plugin.PluginType.around.toString());
         pluginClassFile = addPluginToTargetClass(Plugin.PluginType.after.toString());
 
-        String filePath = this.getFixturePath(pluginClassName.concat(".php"));
-        PsiFile expectedFile = myFixture.configureByFile(filePath);
+        final String filePath = this.getFixturePath(PLUGIN_CLASS_NAME.concat(".php"));
+        final PsiFile expectedFile = myFixture.configureByFile(filePath);
 
         assertGeneratedFileIsCorrect(
                 expectedFile,
@@ -51,21 +51,22 @@ public class PluginClassGeneratorTest extends BaseGeneratorTestCase {
      * @return PsiFile
      */
     private PsiFile addPluginToTargetClass(final @NotNull String pluginType) {
-        Project project = myFixture.getProject();
-        PhpClass targetClass = GetPhpClassByFQN.getInstance(project).execute(targetClassFnq);
-        Method targetMethod = targetClass.findMethodByName(targetMethodName);
+        final Project project = myFixture.getProject();
+        final PhpClass targetClass = 
+                GetPhpClassByFQN.getInstance(project).execute(TARGET_CLASS_FQN);
+        final Method targetMethod = targetClass.findMethodByName(TARGET_METHOD_NAME);
 
-        PluginFileData pluginClass = new PluginFileData(
-                pluginDir,
-                pluginClassName,
+        final PluginFileData pluginClass = new PluginFileData(
+                PLUGIN_DIR,
+                PLUGIN_CLASS_NAME,
                 pluginType,
-                module,
+                MODULE_NAME,
                 targetClass,
                 targetMethod,
-                pluginFqn,
-                pluginNamespace
+                PLUGIN_FQN,
+                PLUGIN_NAMESPACE
         );
-        PluginClassGenerator pluginClassGenerator = new PluginClassGenerator(
+        final PluginClassGenerator pluginClassGenerator = new PluginClassGenerator(
                 pluginClass,
                 project
         );

--- a/tests/com/magento/idea/magento2plugin/actions/generation/generator/PluginClassGeneratorTest.java
+++ b/tests/com/magento/idea/magento2plugin/actions/generation/generator/PluginClassGeneratorTest.java
@@ -2,6 +2,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 package com.magento.idea.magento2plugin.actions.generation.generator;
 
 import com.intellij.openapi.project.Project;
@@ -11,8 +12,10 @@ import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.magento.idea.magento2plugin.actions.generation.data.PluginFileData;
 import com.magento.idea.magento2plugin.magento.files.Plugin;
 import com.magento.idea.magento2plugin.util.GetPhpClassByFQN;
+import org.jetbrains.annotations.NotNull;
 
 public class PluginClassGeneratorTest extends BaseGeneratorTestCase {
+
     private static final String targetClassFnq = "Foo\\Bar\\Service\\SimpleService";
     private static final String targetMethodName = "execute";
     private static final String module = "Foo_Bar";
@@ -21,8 +24,10 @@ public class PluginClassGeneratorTest extends BaseGeneratorTestCase {
     private static final String pluginClassName = "TestPlugin";
     private static final String pluginDir = "Plugin";
 
-    public void testGeneratePluginClassFile()
-    {
+    /**
+     * Test of plugin generation.
+     */
+    public void testGeneratePluginClassFile() {
         PsiFile pluginClassFile;
         addPluginToTargetClass(Plugin.PluginType.before.toString());
         addPluginToTargetClass(Plugin.PluginType.around.toString());
@@ -38,8 +43,14 @@ public class PluginClassGeneratorTest extends BaseGeneratorTestCase {
         );
     }
 
-    private PsiFile addPluginToTargetClass(String pluginType)
-    {
+    /**
+     * Add plugins for the target class.
+     *
+     * @param pluginType String
+     *
+     * @return PsiFile
+     */
+    private PsiFile addPluginToTargetClass(final @NotNull String pluginType) {
         Project project = myFixture.getProject();
         PhpClass targetClass = GetPhpClassByFQN.getInstance(project).execute(targetClassFnq);
         Method targetMethod = targetClass.findMethodByName(targetMethodName);


### PR DESCRIPTION
**Description** (*)
I've prettified the plugin generation feature.

**What was done:**

1. fixed empty line after a class opening tag and before plugin method
2. fixed useless FQCN for subject method argument + in the PHP DOC
3. fixed wrong argument name in the PHP DOC for after plugin's original method argument
4. additionally fixed wrong null type in the PHP DOC for original method arguments and return type (not mentioned in issue #605, for example: ?int or ?SomeType that actually should be int|null and SomeType|null)
5. additionally fixed wrong returning for void plugin methods
5. additionally added an improvement to render strict type for plugin method return

<img width="1030" alt="Screenshot 2021-06-25 at 12 51 15" src="https://user-images.githubusercontent.com/31848341/123406872-0898e700-d5b4-11eb-8290-e9cf1a29b953.png">
<img width="1030" alt="Screenshot 2021-06-25 at 12 51 28" src="https://user-images.githubusercontent.com/31848341/123406904-10588b80-d5b4-11eb-8887-601301b01952.png">
<img width="1027" alt="Screenshot 2021-06-25 at 12 53 18" src="https://user-images.githubusercontent.com/31848341/123407165-51e93680-d5b4-11eb-8362-fe552ceee94c.png">

**Fixed Issues (if relevant)**
1. Fixes magento/magento2-phpstorm-plugin#605

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
