### PR TITLE
PHP plugin version alignment (for v.4.0.1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'idea'
 apply plugin: 'groovy'
 apply plugin: 'org.jetbrains.changelog'
 
-def phpPluginVersion = System.getProperty("phpPluginVersion", "212.5080.71")
+def phpPluginVersion = System.getProperty("phpPluginVersion", "212.5080.55")
 def ideaVersion = System.getProperty("ideaVersion", "2021.2.1")
 def javaVersion = 11
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -24,7 +24,7 @@
     </change-notes>
 
     <!-- please see http://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-    <idea-version since-build="212.5080.71"/>
+    <idea-version since-build="212.5080.55"/>
 
     <!-- please see http://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
          on how to target different products -->


### PR DESCRIPTION
**Description** (*)
Specified phpPluginVersion in the Gradle wasn't actually built, so the plugin won't work if the same version is specified for since-build (production) attribute.

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
