### PR TITLE
[4.1.1-develop] Fixed Bug with inspection observer null pointer for event name attribute

### DIFF
--- a/src/com/magento/idea/magento2plugin/inspections/xml/ObserverDeclarationInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/xml/ObserverDeclarationInspection.java
@@ -44,7 +44,7 @@ public class ObserverDeclarationInspection extends PhpInspection {
 
     @NotNull
     @Override
-    @SuppressWarnings({"PMD.AvoidInstantiatingObjectsInLoops"})
+    @SuppressWarnings({"PMD.AvoidInstantiatingObjectsInLoops", "PMD.CognitiveComplexity"})
     public PsiElementVisitor buildVisitor(
             final @NotNull ProblemsHolder problemsHolder,
             final boolean isOnTheFly
@@ -56,8 +56,8 @@ public class ObserverDeclarationInspection extends PhpInspection {
             private final ProblemHighlightType errorSeverity = ProblemHighlightType.WARNING;
 
             @Override
-            public void visitFile(final PsiFile file) {
-                if (!file.getName().equals(ModuleEventsXml.FILE_NAME)) {
+            public void visitFile(final @NotNull PsiFile file) {
+                if (!ModuleEventsXml.FILE_NAME.equals(file.getName())) {
                     return;
                 }
 
@@ -72,12 +72,16 @@ public class ObserverDeclarationInspection extends PhpInspection {
 
                 for (final XmlTag eventXmlTag: xmlTags) {
                     final HashMap<String, XmlTag> eventProblems = new HashMap<>();
-                    if (!eventXmlTag.getName().equals(ModuleEventsXml.EVENT_TAG)) {
+                    if (!ModuleEventsXml.EVENT_TAG.equals(eventXmlTag.getName())) {
                         continue;
                     }
 
                     final XmlAttribute eventNameAttribute =
                             eventXmlTag.getAttribute(Observer.NAME_ATTRIBUTE);
+
+                    if (eventNameAttribute == null) {
+                        continue;
+                    }
 
                     final String eventNameAttributeValue = eventNameAttribute.getValue();
                     if (eventNameAttributeValue == null) {
@@ -133,13 +137,13 @@ public class ObserverDeclarationInspection extends PhpInspection {
                             @Nullable final XmlAttributeValue valueElement
                                     = observerNameAttribute.getValueElement();
                             if (modulesWithSameObserverName.isEmpty() && valueElement != null) {
-                                    problemsHolder.registerProblem(
-                                            valueElement,
-                                            inspectionBundle.message(
+                                problemsHolder.registerProblem(
+                                        valueElement,
+                                        inspectionBundle.message(
                                                 "inspection.observer.disabledObserverDoesNotExist"
-                                            ),
-                                            errorSeverity
-                                    );
+                                        ),
+                                        errorSeverity
+                                );
                             } else {
                                 continue;
                             }
@@ -159,11 +163,11 @@ public class ObserverDeclarationInspection extends PhpInspection {
                                 problemsHolder.registerProblem(
                                         observerNameAttribute.getValueElement(),
                                         inspectionBundle.message(
-                                            "inspection.observer.duplicateInOtherPlaces",
-                                            observerName,
-                                            eventNameAttributeValue,
-                                            moduleName,
-                                            scope
+                                                "inspection.observer.duplicateInOtherPlaces",
+                                                observerName,
+                                                eventNameAttributeValue,
+                                                moduleName,
+                                                scope
                                         ),
                                         errorSeverity
                                 );
@@ -188,9 +192,9 @@ public class ObserverDeclarationInspection extends PhpInspection {
                 final Collection<PsiElement> indexedEvents = eventIndex.getEventElements(
                         eventNameAttributeValue,
                         GlobalSearchScope.getScopeRestrictedByFileTypes(
-                        GlobalSearchScope.allScope(file.getProject()),
-                        XmlFileType.INSTANCE
-                ));
+                                GlobalSearchScope.allScope(file.getProject()),
+                                XmlFileType.INSTANCE
+                        ));
 
                 for (final PsiElement indexedEvent: indexedEvents) {
                     final PsiFile indexedAttributeParent =
@@ -247,7 +251,7 @@ public class ObserverDeclarationInspection extends PhpInspection {
                 }
 
                 for (final XmlTag observerXmlTag: observerXmlTags) {
-                    if (!observerXmlTag.getName().equals(ModuleEventsXml.OBSERVER_TAG)) {
+                    if (!ModuleEventsXml.OBSERVER_TAG.equals(observerXmlTag.getName())) {
                         continue;
                     }
 
@@ -268,7 +272,7 @@ public class ObserverDeclarationInspection extends PhpInspection {
                     return;
                 }
 
-                if (!moduleDeclarationTag.getName().equals(ModuleEventsXml.MODULE_TAG)) {
+                if (!ModuleEventsXml.MODULE_TAG.equals(moduleDeclarationTag.getName())) {
                     return;
                 }
                 final XmlAttribute moduleNameAttribute


### PR DESCRIPTION
**Description** (*)
I've successfully reproduced reported bug:

<img width="1055" alt="Screenshot 2021-09-29 at 13 11 49" src="https://user-images.githubusercontent.com/31848341/135252484-7183c9ae-a6ec-4621-949b-da7f0b3f66ff.png">

The result after fixing it:

<img width="1343" alt="Screenshot 2021-09-29 at 13 23 30" src="https://user-images.githubusercontent.com/31848341/135252557-2a952e09-f878-4d6f-a28f-8f147a58aa1f.png">


**Fixed Issues (if relevant)**
1. Fixes magento/magento2-phpstorm-plugin#659

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
