### PR TITLE
Update Platform Version In Setting Form

### DIFF
--- a/src/com/magento/idea/magento2plugin/magento/packages/code/MagentoVersion.java
+++ b/src/com/magento/idea/magento2plugin/magento/packages/code/MagentoVersion.java
@@ -11,21 +11,24 @@ import java.util.List;
 
 public enum MagentoVersion {
 
-    ENTERPRISE_EDITION("magento/product-enterprise-edition", 1),
-    COMMUNITY_EDITION("magento/product-community-edition", 2);
+    ENTERPRISE_EDITION("magento/product-enterprise-edition", 1, "Adobe Commerce"),
+    COMMUNITY_EDITION("magento/product-community-edition", 2, "Magento Open Source");
 
     private final String name;
     private final int priority;
+    private final String displayName;
 
     /**
      * Magento version Enum constructor.
      *
      * @param name String
      * @param priority int
+     * @param displayName String
      */
-    MagentoVersion(final String name, final int priority) {
+    MagentoVersion(final String name, final int priority, final String displayName) {
         this.name = name;
         this.priority = priority;
+        this.displayName = displayName;
     }
 
     public String getName() {
@@ -34,6 +37,10 @@ public enum MagentoVersion {
 
     public int getPriority() {
         return priority;
+    }
+
+    public String getDisplayName() {
+        return displayName;
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/project/Settings.java
+++ b/src/com/magento/idea/magento2plugin/project/Settings.java
@@ -34,6 +34,7 @@ public class Settings implements PersistentStateComponent<Settings.State> {
     public boolean mftfSupportEnabled;
     public boolean myDoNotAskContentConfigAgain;
     public String magentoVersion;
+    public String magentoEdition;
 
     @Override
     @Nullable
@@ -44,7 +45,8 @@ public class Settings implements PersistentStateComponent<Settings.State> {
                 defaultLicense,
                 this.mftfSupportEnabled,
                 this.myDoNotAskContentConfigAgain,
-                this.magentoVersion
+                this.magentoVersion,
+                this.magentoEdition
         );
     }
 
@@ -67,6 +69,7 @@ public class Settings implements PersistentStateComponent<Settings.State> {
         this.mftfSupportEnabled = state.isMftfSupportEnabled();
         this.myDoNotAskContentConfigAgain = state.isDoNotAskContentConfigAgain();
         this.magentoVersion = state.getMagentoVersion();
+        this.magentoEdition = state.getMagentoEdition();
     }
 
     public void addListener(final MagentoModuleDataListener listener) {
@@ -128,6 +131,7 @@ public class Settings implements PersistentStateComponent<Settings.State> {
         public boolean mftfSupportEnabled;
         public boolean myDoNotAskContentConfigAgain;
         public String magentoVersion;
+        public String magentoEdition;
 
         public State() {//NOPMD
         }
@@ -141,6 +145,7 @@ public class Settings implements PersistentStateComponent<Settings.State> {
          * @param mftfSupportEnabled boolean
          * @param myDoNotAskContentConfigAgain boolean
          * @param magentoVersion String
+         * @param magentoEdition String
          */
         public State(
                 final boolean pluginEnabled,
@@ -148,7 +153,8 @@ public class Settings implements PersistentStateComponent<Settings.State> {
                 final String defaultLicenseName,
                 final boolean mftfSupportEnabled,
                 final boolean myDoNotAskContentConfigAgain,
-                final String magentoVersion
+                final String magentoVersion,
+                final String magentoEdition
         ) {
             this.pluginEnabled = pluginEnabled;
             this.magentoPath = magentoPath;
@@ -156,6 +162,7 @@ public class Settings implements PersistentStateComponent<Settings.State> {
             this.mftfSupportEnabled = mftfSupportEnabled;
             this.myDoNotAskContentConfigAgain = myDoNotAskContentConfigAgain;
             this.magentoVersion = magentoVersion;
+            this.magentoEdition = magentoEdition;
         }
 
         @Attribute("enabled")
@@ -183,6 +190,15 @@ public class Settings implements PersistentStateComponent<Settings.State> {
         @Tag("magentoVersion")
         public void setMagentoVersion(final String magentoVersion) {
             this.magentoVersion = magentoVersion;
+        }
+
+        public String getMagentoEdition() {
+            return magentoEdition;
+        }
+
+        @Tag("magentoEdition")
+        public void setMagentoEdition(final String magentoEdition) {
+            this.magentoEdition = magentoEdition;
         }
 
         /**

--- a/src/com/magento/idea/magento2plugin/project/SettingsForm.form
+++ b/src/com/magento/idea/magento2plugin/project/SettingsForm.form
@@ -98,7 +98,7 @@
               <forms/>
             </constraints>
             <properties>
-              <text value="Magento version:"/>
+              <text value="Platform Version:"/>
             </properties>
           </component>
         </children>

--- a/src/com/magento/idea/magento2plugin/project/util/GetMagentoVersionUtil.java
+++ b/src/com/magento/idea/magento2plugin/project/util/GetMagentoVersionUtil.java
@@ -7,6 +7,7 @@ package com.magento.idea.magento2plugin.project.util;
 
 import com.intellij.json.psi.JsonObject;
 import com.intellij.json.psi.JsonProperty;
+import com.intellij.openapi.util.Pair;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.magento.idea.magento2plugin.magento.files.ComposerLock;
 import com.magento.idea.magento2plugin.magento.packages.code.MagentoVersion;
@@ -28,10 +29,10 @@ public final class GetMagentoVersionUtil {
      *
      * @param object JsonObject
      *
-     * @return String
+     * @return Pair[String, String]
      */
     @SuppressWarnings("PMD.CyclomaticComplexity")
-    public static @Nullable String getVersion(final @NotNull JsonObject object) {
+    public static @Nullable Pair<String, String> getVersion(final @NotNull JsonObject object) {
         final JsonProperty packagesProperty = object.findProperty(ComposerLock.PACKAGES_PROP);
 
         if (packagesProperty == null) {
@@ -77,7 +78,10 @@ public final class GetMagentoVersionUtil {
 
         for (final MagentoVersion version : versions) {
             if (foundMagentoPackages.containsKey(version.getName())) {
-                return foundMagentoPackages.get(version.getName());
+                return new Pair<>(
+                        foundMagentoPackages.get(version.getName()),
+                        version.getDisplayName()
+                );
             }
         }
 


### PR DESCRIPTION
**Description** (*)
This pull request adds the ability to display the Client's Platform Version in the settings form. For:
"magento/product-enterprise-edition" -> "Adobe Commerce"
![image](https://user-images.githubusercontent.com/33068778/141346233-adc176a0-8f8b-4d1b-a120-5bca30e48966.png)
"magento/product-community-edition" -> "Magento Open Source"
![image](https://user-images.githubusercontent.com/33068778/141346318-bebf6118-4872-4f91-9dc2-cd24d8501ea6.png)
If the platform has not been defined then "Platform Version:" will be shown.
![image](https://user-images.githubusercontent.com/33068778/141346400-345ac6a4-74d4-4548-baab-b67ba6973a79.png)

This will help the user to quickly understand what version of Magento2 is used.



**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
