### PR TITLE
UCT-768: Sort errors by lines

### DIFF
--- a/src/com/magento/idea/magento2uct/execution/GenerateUctReportCommand.java
+++ b/src/com/magento/idea/magento2uct/execution/GenerateUctReportCommand.java
@@ -32,6 +32,7 @@ import com.magento.idea.magento2uct.inspections.UctInspectionManager;
 import com.magento.idea.magento2uct.inspections.UctProblemsHolder;
 import com.magento.idea.magento2uct.packages.SupportedIssue;
 import com.magento.idea.magento2uct.settings.UctSettingsService;
+import com.magento.idea.magento2uct.util.inspection.SortDescriptorResultsUtil;
 import java.nio.file.Paths;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -129,7 +130,9 @@ public class GenerateUctReportCommand {
                         }
 
                         for (final ProblemDescriptor descriptor
-                                : fileProblemsHolder.getResults()) {
+                                : SortDescriptorResultsUtil.sort(
+                                        fileProblemsHolder.getResults()
+                        )) {
                             final Integer code = fileProblemsHolder.getErrorCodeForDescriptor(
                                     descriptor
                             );

--- a/src/com/magento/idea/magento2uct/execution/output/Summary.java
+++ b/src/com/magento/idea/magento2uct/execution/output/Summary.java
@@ -44,7 +44,7 @@ public class Summary {
      * @return String
      */
     public String getInstalledVersion() {
-        return installedVersion == null ? "" : installedVersion.getVersion();
+        return installedVersion == null ? "Less than 2.3.0" : installedVersion.getVersion();
     }
 
     /**

--- a/src/com/magento/idea/magento2uct/inspections/UctInspectionManager.java
+++ b/src/com/magento/idea/magento2uct/inspections/UctInspectionManager.java
@@ -62,9 +62,10 @@ public class UctInspectionManager {
                 psiFile,
                 false
         );
+        final List<PsiElementVisitor> visitors = SupportedIssue.getVisitors(problemsHolder);
 
         for (final PsiElement element : collectElements(phpClass)) {
-            for (final PsiElementVisitor visitor : SupportedIssue.getVisitors(problemsHolder)) {
+            for (final PsiElementVisitor visitor : visitors) {
                 element.accept(visitor);
             }
         }

--- a/src/com/magento/idea/magento2uct/settings/UctSettingsService.java
+++ b/src/com/magento/idea/magento2uct/settings/UctSettingsService.java
@@ -162,6 +162,17 @@ public class UctSettingsService implements PersistentStateComponent<UctSettingsS
     }
 
     /**
+     * Get current version or default version instead.
+     *
+     * @return SupportedVersion
+     */
+    public @NotNull SupportedVersion getCurrentVersionOrDefault() {
+        final SupportedVersion currentVersion = getCurrentVersion();
+
+        return currentVersion == null ? SupportedVersion.V230 : currentVersion;
+    }
+
+    /**
      * Set target version.
      *
      * @param version SupportedVersion

--- a/src/com/magento/idea/magento2uct/ui/ConfigurationDialog.java
+++ b/src/com/magento/idea/magento2uct/ui/ConfigurationDialog.java
@@ -127,7 +127,14 @@ public class ConfigurationDialog extends AbstractDialog {
             return;
         }
         settingsService.setEnabled(enable.isSelected());
-        final String currentVersionValue = currentVersion.getSelectedItem().toString();
+
+        final ComboBoxItemData currentVersionItemData =
+                (ComboBoxItemData) currentVersion.getSelectedItem();
+        String currentVersionValue = "";
+
+        if (currentVersionItemData != null) {
+            currentVersionValue = currentVersionItemData.getKey();
+        }
 
         settingsService.setCurrentVersion(
                 currentVersionValue.isEmpty()

--- a/src/com/magento/idea/magento2uct/util/inspection/SortDescriptorResultsUtil.java
+++ b/src/com/magento/idea/magento2uct/util/inspection/SortDescriptorResultsUtil.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2uct.util.inspection;
+
+import com.intellij.codeInspection.ProblemDescriptor;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+
+public final class SortDescriptorResultsUtil {
+
+    private SortDescriptorResultsUtil() {
+    }
+
+    /**
+     * Get problems sorted by its lines.
+     *
+     * @param problems List[ProblemDescriptor]
+     *
+     * @return List[ProblemDescriptor]
+     */
+    public static List<ProblemDescriptor> sort(final List<ProblemDescriptor> problems) {
+        if (problems.isEmpty()) {
+            return problems;
+        }
+        problems.sort(Comparator.comparingInt(ProblemDescriptor::getLineNumber));
+
+        return new LinkedList<>(problems);
+    }
+}

--- a/src/com/magento/idea/magento2uct/versioning/VersionStateManager.java
+++ b/src/com/magento/idea/magento2uct/versioning/VersionStateManager.java
@@ -42,7 +42,7 @@ public final class VersionStateManager {
 
         if (instance == null
                 || !instance.isValidFor(settingsService.shouldIgnoreCurrentVersion(),
-                settingsService.getCurrentVersion(),
+                settingsService.getCurrentVersionOrDefault(),
                 settingsService.getTargetVersion()
         )) {
             instance = new VersionStateManager(project);
@@ -111,7 +111,7 @@ public final class VersionStateManager {
     private VersionStateManager(final @NotNull Project project) {
         final UctSettingsService settingsService = UctSettingsService.getInstance(project);
         isSetIgnoreFlag = settingsService.shouldIgnoreCurrentVersion();
-        currentVersion = settingsService.getCurrentVersion();
+        currentVersion = settingsService.getCurrentVersionOrDefault();
         targetVersion = settingsService.getTargetVersion();
         versionsToLoad = new LinkedList<>();
 


### PR DESCRIPTION
**Description** (*)

**What was done:**

- refactored code, added some improvements
- all errors sorted by their line number

### Results:

<img width="1134" alt="Screenshot 2021-11-19 at 13 59 52" src="https://user-images.githubusercontent.com/31848341/142627576-9f73a86a-a341-453e-8f74-0c166f3e8a81.png">

**Fixed Issues (if relevant)**
1. Fixes magento/magento2-phpstorm-plugin#768

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)