### PR TITLE
[4.2.0-develop] Bug-653: Fixed NullPointerException for InjectAViewModelAction#getElement

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/InjectAViewModelAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/InjectAViewModelAction.java
@@ -22,38 +22,45 @@ import com.magento.idea.magento2plugin.project.Settings;
 import org.jetbrains.annotations.NotNull;
 
 public class InjectAViewModelAction extends DumbAwareAction {
-    public static String actionName = "Inject a new View Model for this block";
-    public static String actionDescription = "Inject a new Magento 2 View Model";
+
+    public static final String ACTION_NAME = "Inject a new View Model for this block";
+    public static final String ACTION_DESCRIPTION = "Inject a new Magento 2 View Model";
     private XmlTag targetXmlTag;
 
+    /**
+     * An action constructor.
+     */
     public InjectAViewModelAction() {
-        super(actionName, actionDescription, MagentoIcons.MODULE);
+        super(ACTION_NAME, ACTION_DESCRIPTION, MagentoIcons.MODULE);
     }
 
     @Override
-    public void update(final AnActionEvent event) {
+    public void update(final @NotNull AnActionEvent event) {
+        this.setStatus(event, false);
         final Project project = event.getData(PlatformDataKeys.PROJECT);
+
+        if (project == null) {
+            return;
+        }
+
         if (Settings.isEnabled(project)) {
             final XmlTag element = getElement(event);
-            if (element == null) {
-                this.setStatus(event, false);
-            } else  {
+
+            if (element != null) {
                 targetXmlTag = element;
                 this.setStatus(event, true);
             }
-        } else {
-            this.setStatus(event, false);
         }
-    }
-
-    private void setStatus(final AnActionEvent event, final boolean status) {
-        event.getPresentation().setVisible(status);
-        event.getPresentation().setEnabled(status);
     }
 
     @Override
     public void actionPerformed(final @NotNull AnActionEvent event) {
-        InjectAViewModelDialog.open(event.getProject(), this.targetXmlTag);
+        final Project project = event.getData(PlatformDataKeys.PROJECT);
+
+        if (project == null || targetXmlTag == null) {
+            return;
+        }
+        InjectAViewModelDialog.open(project, targetXmlTag);
     }
 
     @Override
@@ -61,39 +68,64 @@ public class InjectAViewModelAction extends DumbAwareAction {
         return false;
     }
 
+    /**
+     * Get focused (target) element for the event.
+     *
+     * @param event AnActionEvent
+     *
+     * @return XmlTag
+     */
     private XmlTag getElement(final @NotNull AnActionEvent event) {
         final Caret caret = event.getData(PlatformDataKeys.CARET);
+
         if (caret == null) {
             return null;
         }
 
-        final int offset = caret.getOffset();
         final PsiFile psiFile = event.getData(PlatformDataKeys.PSI_FILE);
+
+        if (psiFile == null) {
+            return null;
+        }
+        final int offset = caret.getOffset();
         final PsiElement element = psiFile.findElementAt(offset);
+
         if (element == null) {
             return null;
         }
-
         final XmlTag xmlTag = PsiTreeUtil.getParentOfType(element, XmlTag.class);
 
         if (xmlTag == null) {
             return null;
         }
         XmlTag resultTag;
-        if (xmlTag.getName().equals(CommonXml.ATTRIBUTE_ARGUMENTS)) {
+
+        if (CommonXml.ATTRIBUTE_ARGUMENTS.equals(xmlTag.getName())) {
             resultTag = PsiTreeUtil.getParentOfType(xmlTag, XmlTag.class);
         } else {
             resultTag = xmlTag;
         }
+
         if (resultTag == null) {
             return null;
         }
 
-        if (!resultTag.getName().equals(LayoutXml.BLOCK_ATTRIBUTE_TAG_NAME)
-                && !resultTag.getName().equals(LayoutXml.REFERENCE_BLOCK_ATTRIBUTE_TAG_NAME)) {
+        if (!LayoutXml.BLOCK_ATTRIBUTE_TAG_NAME.equals(resultTag.getName())
+                && !LayoutXml.REFERENCE_BLOCK_ATTRIBUTE_TAG_NAME.equals(resultTag.getName())) {
             return null;
         }
 
         return resultTag;
+    }
+
+    /**
+     * Set presentation status.
+     *
+     * @param event AnActionEvent
+     * @param status boolean
+     */
+    private void setStatus(final AnActionEvent event, final boolean status) {
+        event.getPresentation().setVisible(status);
+        event.getPresentation().setEnabled(status);
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/InjectAViewModelDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/InjectAViewModelDialog.java
@@ -104,7 +104,7 @@ public class InjectAViewModelDialog extends AbstractDialog {
 
         setContentPane(contentPane);
         setModal(true);
-        setTitle(InjectAViewModelAction.actionDescription);
+        setTitle(InjectAViewModelAction.ACTION_DESCRIPTION);
         getRootPane().setDefaultButton(buttonOK);
 
         buttonOK.addActionListener((final ActionEvent event) -> onOK());
@@ -154,7 +154,7 @@ public class InjectAViewModelDialog extends AbstractDialog {
                 getViewModelClassName(),
                 moduleName,
                 namespaceBuilder.getNamespace()
-        ), project).generate(InjectAViewModelAction.actionName, true);
+        ), project).generate(InjectAViewModelAction.ACTION_NAME, true);
         if (viewModel == null) {
             final String errorMessage = validatorBundle.message(
                     "validator.class.alreadyDeclared",

--- a/src/com/magento/idea/magento2plugin/inspections/xml/ObserverDeclarationInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/xml/ObserverDeclarationInspection.java
@@ -44,7 +44,7 @@ public class ObserverDeclarationInspection extends PhpInspection {
 
     @NotNull
     @Override
-    @SuppressWarnings({"PMD.AvoidInstantiatingObjectsInLoops"})
+    @SuppressWarnings({"PMD.AvoidInstantiatingObjectsInLoops", "PMD.CognitiveComplexity"})
     public PsiElementVisitor buildVisitor(
             final @NotNull ProblemsHolder problemsHolder,
             final boolean isOnTheFly
@@ -56,8 +56,8 @@ public class ObserverDeclarationInspection extends PhpInspection {
             private final ProblemHighlightType errorSeverity = ProblemHighlightType.WARNING;
 
             @Override
-            public void visitFile(final PsiFile file) {
-                if (!file.getName().equals(ModuleEventsXml.FILE_NAME)) {
+            public void visitFile(final @NotNull PsiFile file) {
+                if (!ModuleEventsXml.FILE_NAME.equals(file.getName())) {
                     return;
                 }
 
@@ -72,12 +72,16 @@ public class ObserverDeclarationInspection extends PhpInspection {
 
                 for (final XmlTag eventXmlTag: xmlTags) {
                     final HashMap<String, XmlTag> eventProblems = new HashMap<>();
-                    if (!eventXmlTag.getName().equals(ModuleEventsXml.EVENT_TAG)) {
+                    if (!ModuleEventsXml.EVENT_TAG.equals(eventXmlTag.getName())) {
                         continue;
                     }
 
                     final XmlAttribute eventNameAttribute =
                             eventXmlTag.getAttribute(Observer.NAME_ATTRIBUTE);
+
+                    if (eventNameAttribute == null) {
+                        continue;
+                    }
 
                     final String eventNameAttributeValue = eventNameAttribute.getValue();
                     if (eventNameAttributeValue == null) {
@@ -133,13 +137,13 @@ public class ObserverDeclarationInspection extends PhpInspection {
                             @Nullable final XmlAttributeValue valueElement
                                     = observerNameAttribute.getValueElement();
                             if (modulesWithSameObserverName.isEmpty() && valueElement != null) {
-                                    problemsHolder.registerProblem(
-                                            valueElement,
-                                            inspectionBundle.message(
+                                problemsHolder.registerProblem(
+                                        valueElement,
+                                        inspectionBundle.message(
                                                 "inspection.observer.disabledObserverDoesNotExist"
-                                            ),
-                                            errorSeverity
-                                    );
+                                        ),
+                                        errorSeverity
+                                );
                             } else {
                                 continue;
                             }
@@ -159,11 +163,11 @@ public class ObserverDeclarationInspection extends PhpInspection {
                                 problemsHolder.registerProblem(
                                         observerNameAttribute.getValueElement(),
                                         inspectionBundle.message(
-                                            "inspection.observer.duplicateInOtherPlaces",
-                                            observerName,
-                                            eventNameAttributeValue,
-                                            moduleName,
-                                            scope
+                                                "inspection.observer.duplicateInOtherPlaces",
+                                                observerName,
+                                                eventNameAttributeValue,
+                                                moduleName,
+                                                scope
                                         ),
                                         errorSeverity
                                 );
@@ -188,9 +192,9 @@ public class ObserverDeclarationInspection extends PhpInspection {
                 final Collection<PsiElement> indexedEvents = eventIndex.getEventElements(
                         eventNameAttributeValue,
                         GlobalSearchScope.getScopeRestrictedByFileTypes(
-                        GlobalSearchScope.allScope(file.getProject()),
-                        XmlFileType.INSTANCE
-                ));
+                                GlobalSearchScope.allScope(file.getProject()),
+                                XmlFileType.INSTANCE
+                        ));
 
                 for (final PsiElement indexedEvent: indexedEvents) {
                     final PsiFile indexedAttributeParent =
@@ -247,7 +251,7 @@ public class ObserverDeclarationInspection extends PhpInspection {
                 }
 
                 for (final XmlTag observerXmlTag: observerXmlTags) {
-                    if (!observerXmlTag.getName().equals(ModuleEventsXml.OBSERVER_TAG)) {
+                    if (!ModuleEventsXml.OBSERVER_TAG.equals(observerXmlTag.getName())) {
                         continue;
                     }
 
@@ -268,7 +272,7 @@ public class ObserverDeclarationInspection extends PhpInspection {
                     return;
                 }
 
-                if (!moduleDeclarationTag.getName().equals(ModuleEventsXml.MODULE_TAG)) {
+                if (!ModuleEventsXml.MODULE_TAG.equals(moduleDeclarationTag.getName())) {
                     return;
                 }
                 final XmlAttribute moduleNameAttribute


### PR DESCRIPTION
**Description** (*)
Fixed NullPointerException for InjectAViewModelAction#getElement method call.

**Fixed Issues (if relevant)**
1. Fixes magento/magento2-phpstorm-plugin#653

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
