### PR TITLE
[4.2.0-develop] Bug-663: Fixed NullPointerException for PluginReferenceProvider

### DIFF
--- a/src/com/magento/idea/magento2plugin/reference/xml/XmlReferenceContributor.java
+++ b/src/com/magento/idea/magento2plugin/reference/xml/XmlReferenceContributor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
@@ -12,6 +12,7 @@ import com.intellij.psi.xml.XmlTokenType;
 import com.magento.idea.magento2plugin.magento.files.MftfActionGroup;
 import com.magento.idea.magento2plugin.magento.files.MftfTest;
 import com.magento.idea.magento2plugin.magento.files.ModuleDbSchemaXml;
+import com.magento.idea.magento2plugin.magento.files.ModuleDiXml;
 import com.magento.idea.magento2plugin.magento.files.ModuleMenuXml;
 import com.magento.idea.magento2plugin.magento.files.UiComponentXml;
 // CHECKSTYLE IGNORE check FOR NEXT 5 LINES
@@ -387,7 +388,7 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
                         XmlPatterns.xmlAttribute().withName("disabled")
                     )
                 )
-            ).inFile(xmlFile().withName(string().endsWith("di.xml"))),
+            ).inFile(xmlFile().withName(string().matches(ModuleDiXml.FILE_NAME))),
             new PluginReferenceProvider()
         );
 


### PR DESCRIPTION
**Description** (*)
I've successfully reproduced reported bug:
<img width="1378" alt="Screenshot 2021-09-29 at 17 43 52" src="https://user-images.githubusercontent.com/31848341/135297054-3b70bba5-7747-410c-be0b-0a50d39e3ca6.png">

The result of the bug fix:
<img width="1490" alt="Screenshot 2021-09-29 at 18 01 32" src="https://user-images.githubusercontent.com/31848341/135297112-a43a986a-bcbd-4af4-b808-72da3c20c483.png">

**Fixed Issues (if relevant)**
1. Fixes magento/magento2-phpstorm-plugin#663

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
