### PR TITLE
Bugfix-798: Fixed ArrayIndexOutOfBoundsException exception

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/CopyMagentoPath.java
+++ b/src/com/magento/idea/magento2plugin/actions/CopyMagentoPath.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class CopyMagentoPath extends CopyPathProvider {
+
     public static final String PHTML_EXTENSION = "phtml";
     public static final String JS_EXTENSION = "js";
     public static final String CSS_EXTENSION = "css";
@@ -56,23 +57,23 @@ public class CopyMagentoPath extends CopyPathProvider {
                 || virtualFile != null && !acceptedTypes.contains(virtualFile.getExtension());
     }
 
-    @Nullable
     @Override
-    public String getPathToElement(
-            @NotNull final Project project,
-            @Nullable final VirtualFile virtualFile,
-            @Nullable final Editor editor
+    public @Nullable String getPathToElement(
+            final @NotNull Project project,
+            final @Nullable VirtualFile virtualFile,
+            final @Nullable Editor editor
     ) {
         if (virtualFile == null) {
             return null;
         }
-        final PsiFile file
-                = PsiManager.getInstance(project).findFile(virtualFile);
+        final PsiFile file = PsiManager.getInstance(project).findFile(virtualFile);
+
         if (file == null) {
             return null;
         }
         final PsiDirectory directory = file.getContainingDirectory();
         final String moduleName = GetModuleNameByDirectoryUtil.execute(directory, project);
+
         if (moduleName == null) {
             return null;
         }
@@ -89,8 +90,14 @@ public class CopyMagentoPath extends CopyPathProvider {
         } else {
             return fullPath.toString();
         }
+        int endIndex;
 
-        final int endIndex = getIndexOf(paths, fullPath, paths[++index]);
+        try {
+            endIndex = getIndexOf(paths, fullPath, paths[++index]);
+        } catch (ArrayIndexOutOfBoundsException exception) {
+            // endIndex could not be found.
+            return "";
+        }
         final int offset = paths[index].length();
 
         fullPath.replace(0, endIndex + offset, "");
@@ -98,6 +105,15 @@ public class CopyMagentoPath extends CopyPathProvider {
         return moduleName + SEPARATOR + fullPath;
     }
 
+    /**
+     * Get index where web|template path starts in the fullPath.
+     *
+     * @param paths String[]
+     * @param fullPath StringBuilder
+     * @param path String
+     *
+     * @return int
+     */
     private int getIndexOf(final String[] paths, final StringBuilder fullPath, final String path) {
         return fullPath.lastIndexOf(path) == -1
                 ? getIndexOf(paths, fullPath, paths[++index])


### PR DESCRIPTION
**Description** (*)

Fixed ArrayIndexOutOfBoundsException exception when used Copy Path/Reference action on the requirejs-config.js file.

**Successfully reproduced before starting fixing it:**

<img width="1153" alt="Screenshot 2021-11-25 at 20 24 05" src="https://user-images.githubusercontent.com/31848341/143494386-36a6da7f-e068-45c4-93b6-df8426c77247.png">

**Result:**

<img width="706" alt="Screenshot 2021-11-25 at 20 41 29" src="https://user-images.githubusercontent.com/31848341/143494424-722fa28b-ba9a-4f59-b0e5-e0b7b01d61d8.png">

**Fixed Issues (if relevant)**
1. Fixes magento/magento2-phpstorm-plugin#798

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
