### PR TITLE
Bug-667: Fixed dialog disposition issue

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/AbstractDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/AbstractDialog.java
@@ -59,8 +59,18 @@ public abstract class AbstractDialog extends JDialog {
         dialog.setLocation(coordinateX, coordinateY);
     }
 
+    /**
+     * Default on cancel action.
+     */
     protected void onCancel() {
-        this.setVisible(false);
+        this.exit();
+    }
+
+    /**
+     * Right way to hide dialog window.
+     */
+    protected void exit() {
+        dispose();
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAPluginDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAPluginDialog.java
@@ -157,30 +157,28 @@ public class CreateAPluginDialog extends AbstractDialog {
     }
 
     protected void onOK() {
-        if (!validateFormFields()) {
-            return;
+        if (validateFormFields()) {
+            new PluginClassGenerator(new PluginFileData(
+                    getPluginDirectory(),
+                    getPluginClassName(),
+                    getPluginType(),
+                    getPluginModule(),
+                    targetClass,
+                    targetMethod,
+                    getPluginClassFqn(),
+                    getNamespace()
+            ), project).generate(CreateAPluginAction.ACTION_NAME, true);
+
+            new PluginDiXmlGenerator(new PluginDiXmlData(
+                    getPluginArea(),
+                    getPluginModule(),
+                    targetClass,
+                    getPluginSortOrder(),
+                    getPluginName(),
+                    getPluginClassFqn()
+            ), project).generate(CreateAPluginAction.ACTION_NAME);
         }
-        new PluginClassGenerator(new PluginFileData(
-                getPluginDirectory(),
-                getPluginClassName(),
-                getPluginType(),
-                getPluginModule(),
-                targetClass,
-                targetMethod,
-                getPluginClassFqn(),
-                getNamespace()
-        ), project).generate(CreateAPluginAction.ACTION_NAME, true);
-
-        new PluginDiXmlGenerator(new PluginDiXmlData(
-                getPluginArea(),
-                getPluginModule(),
-                targetClass,
-                getPluginSortOrder(),
-                getPluginName(),
-                getPluginClassFqn()
-        ), project).generate(CreateAPluginAction.ACTION_NAME);
-
-        this.setVisible(false);
+        exit();
     }
 
     public String getPluginName() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAnObserverDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/CreateAnObserverDialog.java
@@ -150,27 +150,25 @@ public class CreateAnObserverDialog extends AbstractDialog {
      * Perform code generation using input data.
      */
     private void onOK() {
-        if (!validateFormFields()) {
-            return;
+        if (validateFormFields()) {
+            new ObserverClassGenerator(new ObserverFileData(
+                    getObserverDirectory(),
+                    getObserverClassName(),
+                    getObserverModule(),
+                    targetEvent,
+                    getObserverClassFqn(),
+                    getNamespace()
+            ), project).generate(CreateAnObserverAction.ACTION_NAME, true);
+
+            new ObserverEventsXmlGenerator(new ObserverEventsXmlData(
+                    getObserverArea(),
+                    getObserverModule(),
+                    targetEvent,
+                    getObserverName(),
+                    getObserverClassFqn()
+            ), project).generate(CreateAPluginAction.ACTION_NAME);
         }
-        new ObserverClassGenerator(new ObserverFileData(
-                getObserverDirectory(),
-                getObserverClassName(),
-                getObserverModule(),
-                targetEvent,
-                getObserverClassFqn(),
-                getNamespace()
-        ), project).generate(CreateAnObserverAction.ACTION_NAME, true);
-
-        new ObserverEventsXmlGenerator(new ObserverEventsXmlData(
-                getObserverArea(),
-                getObserverModule(),
-                targetEvent,
-                getObserverName(),
-                getObserverClassFqn()
-        ), project).generate(CreateAPluginAction.ACTION_NAME);
-
-        this.setVisible(false);
+        exit();
     }
 
     public String getObserverClassName() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/InjectAViewModelDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/InjectAViewModelDialog.java
@@ -138,6 +138,7 @@ public class InjectAViewModelDialog extends AbstractDialog {
 
     protected void onOK() {
         if (!validateFormFields()) {
+            exit();
             return;
         }
         final String moduleName = GetModuleNameByDirectoryUtil.execute(
@@ -168,6 +169,7 @@ public class InjectAViewModelDialog extends AbstractDialog {
                     JOptionPane.ERROR_MESSAGE
             );
 
+            exit();
             return;
         }
 
@@ -176,9 +178,9 @@ public class InjectAViewModelDialog extends AbstractDialog {
                         this.getViewModelArgumentName(),
                         XsiTypes.object.toString(),
                         namespaceBuilder.getClassFqn()
-                ).generate(targetBlockTag);
+        ).generate(targetBlockTag);
 
-        this.setVisible(false);
+        exit();
     }
 
     public String getViewModelClassName() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewBlockDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewBlockDialog.java
@@ -111,11 +111,10 @@ public class NewBlockDialog extends AbstractDialog {
     }
 
     protected void onOK() {
-        if (!validateFormFields()) {
-            return;
+        if (validateFormFields()) {
+            generateFile();
         }
-        generateFile();
-        this.setVisible(false);
+        exit();
     }
 
     private PsiFile generateFile() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCLICommandDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCLICommandDialog.java
@@ -179,11 +179,10 @@ public class NewCLICommandDialog extends AbstractDialog {
     }
 
     private void onOK() {
-        if (!validateFormFields() || !isPHPClassValid()) {
-            return;
+        if (validateFormFields() && isPHPClassValid()) {
+            this.generate();
         }
-        this.generate();
-        this.setVisible(false);
+        exit();
     }
 
     private Boolean isPHPClassValid() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewControllerDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewControllerDialog.java
@@ -194,12 +194,10 @@ public class NewControllerDialog extends AbstractDialog {
     }
 
     private void onOK() {
-        if (!validateFormFields()) {
-            return;
+        if (validateFormFields()) {
+            generateFile();
         }
-
-        generateFile();
-        this.setVisible(false);
+        exit();
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCronGroupDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCronGroupDialog.java
@@ -140,12 +140,10 @@ public class NewCronGroupDialog extends AbstractDialog {
     }
 
     private void onOK() {
-        if (!validateFormFields()) {
-            return;
+        if (validateFormFields()) {
+            generateFile();
         }
-
-        generateFile();
-        this.setVisible(false);
+        exit();
     }
 
     @Override

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCronjobDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCronjobDialog.java
@@ -281,6 +281,7 @@ public class NewCronjobDialog extends AbstractDialog {
      */
     private void onOK() {
         if (!validateFormFields()) {
+            exit();
             return;
         }
 
@@ -298,7 +299,7 @@ public class NewCronjobDialog extends AbstractDialog {
 
         // todo: catch validation exceptions
         this.generate(cronjobClassData, crontabXmlData);
-        this.setVisible(false);
+        exit();
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDataModelDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDataModelDialog.java
@@ -145,8 +145,8 @@ public class NewDataModelDialog extends AbstractDialog {
                 generateDataModelInterfaceFile();
                 generatePreferenceForInterface();
             }
-            this.setVisible(false);
         }
+        exit();
     }
 
     @Override

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDbSchemaDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDbSchemaDialog.java
@@ -135,21 +135,18 @@ public class NewDbSchemaDialog extends AbstractDialog {
             columnsTable.getCellEditor().stopCellEditing();
         }
 
-        if (!validateFormFields()) {
-            return;
+        if (validateFormFields()) {
+            final DbSchemaXmlData dbSchemaXmlData = new DbSchemaXmlData(
+                    getTableName(),
+                    getTableResource(),
+                    getTableEngine(),
+                    getTableComment(),
+                    getColumns()
+            );
+            generateDbSchemaXmlFile(dbSchemaXmlData);
+            generateWhitelistJsonFile(dbSchemaXmlData);
         }
-
-        final DbSchemaXmlData dbSchemaXmlData = new DbSchemaXmlData(
-                getTableName(),
-                getTableResource(),
-                getTableEngine(),
-                getTableComment(),
-                getColumns()
-        );
-        generateDbSchemaXmlFile(dbSchemaXmlData);
-        generateWhitelistJsonFile(dbSchemaXmlData);
-
-        this.setVisible(false);
+        exit();
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEmailTemplateDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEmailTemplateDialog.java
@@ -206,12 +206,14 @@ public class NewEmailTemplateDialog extends AbstractDialog {
 
     private void onOK() {
         final boolean emailTemplateCanBeDeclared = !this.validator.validate(this);
+
         if (!validateFormFields() || emailTemplateCanBeDeclared) {
+            exit();
             return;
         }
-
         generateFile();
-        this.setVisible(false);
+
+        exit();
     }
 
     private void generateFile() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEntityDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEntityDialog.java
@@ -441,7 +441,7 @@ public class NewEntityDialog extends AbstractDialog {
         buttonOK.setEnabled(true);
 
         if (onOkActionFired.isFinished()) {
-            this.setVisible(false);
+            exit();
         }
     }
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewGraphQlResolverDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewGraphQlResolverDialog.java
@@ -109,11 +109,10 @@ public class NewGraphQlResolverDialog extends AbstractDialog {
     }
 
     protected void onOK() {
-        if (!validateFormFields()) {
-            return;
+        if (validateFormFields()) {
+            generateFile();
         }
-        generateFile();
-        this.setVisible(false);
+        exit();
     }
 
     private PsiFile generateFile() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewInterfaceForServiceDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewInterfaceForServiceDialog.java
@@ -170,17 +170,15 @@ public class NewInterfaceForServiceDialog extends AbstractDialog {
      * Fire generation process if all fields are valid.
      */
     private void onOK() {
-        if (!validateFormFields()) {
-            return;
+        if (validateFormFields()) {
+            final WebApiInterfaceData data = getDialogDataObject();
+
+            new WebApiInterfaceGenerator(
+                    data,
+                    project
+            ).generate(NewWebApiInterfaceAction.ACTION_NAME, true);
         }
-        final WebApiInterfaceData data = getDialogDataObject();
-
-        new WebApiInterfaceGenerator(
-                data,
-                project
-        ).generate(NewWebApiInterfaceAction.ACTION_NAME, true);
-
-        this.setVisible(false);
+        exit();
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewMessageQueueDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewMessageQueueDialog.java
@@ -244,11 +244,12 @@ public class NewMessageQueueDialog extends AbstractDialog {
             generateTopology();
             generatePublisher();
             generateHandlerClass();
+
             if (getConnectionName().equals(MessageQueueConnections.DB.getType())) {
                 generateConsumerClass();
             }
-            this.setVisible(false);
         }
+        exit();
     }
 
     private void generateCommunication() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModelsDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModelsDialog.java
@@ -169,15 +169,12 @@ public class NewModelsDialog extends AbstractDialog {
      * Process generation.
      */
     private void onOK() {
-        if (!validateFormFields()) {
-            return;
+        if (validateFormFields()) {
+            generateModelFile();
+            generateResourceModelFile();
+            generateCollectionFile();
         }
-
-        generateModelFile();
-        generateResourceModelFile();
-        generateCollectionFile();
-
-        this.setVisible(false);
+        exit();
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModuleDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModuleDialog.java
@@ -172,11 +172,10 @@ public class NewModuleDialog extends AbstractDialog implements ListSelectionList
     }
 
     protected void onOK() {
-        if (!validateFormFields()) {
-            return;
+        if (validateFormFields()) {
+            generateFiles();
         }
-        generateFiles();
-        this.setVisible(false);
+        exit();
     }
 
     private void generateFiles() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewUiComponentFormDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewUiComponentFormDialog.java
@@ -416,18 +416,16 @@ public class NewUiComponentFormDialog extends AbstractDialog {
             fields.getCellEditor().stopCellEditing();
         }
 
-        if (!validateFormFields()) {
-            return;
+        if (validateFormFields()) {
+            generateRoutesXmlFile();
+            generateViewControllerFile();
+            generateSubmitControllerFile();
+            generateDataProviderFile();
+            generateLayoutFile();
+            generateFormFile();
+            generateAclXmlFile();
         }
-
-        generateRoutesXmlFile();
-        generateViewControllerFile();
-        generateSubmitControllerFile();
-        generateDataProviderFile();
-        generateLayoutFile();
-        generateFormFile();
-        generateAclXmlFile();
-        this.setVisible(false);
+        exit();
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewUiComponentGridDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewUiComponentGridDialog.java
@@ -303,19 +303,17 @@ public class NewUiComponentGridDialog extends AbstractDialog {
     }
 
     private void onOK() {
-        if (!validateFormFields()) {
-            return;
+        if (validateFormFields()) {
+            generateViewControllerFile();
+            generateLayoutFile();
+            generateMenuFile();
+            generateAclXmlFile();
+            generateRoutesXmlFile();
+            generateDataProviderClass();
+            generateDataProviderDeclaration();
+            generateUiComponentFile();
         }
-
-        generateViewControllerFile();
-        generateLayoutFile();
-        generateMenuFile();
-        generateAclXmlFile();
-        generateRoutesXmlFile();
-        generateDataProviderClass();
-        generateDataProviderDeclaration();
-        generateUiComponentFile();
-        this.setVisible(false);
+        exit();
     }
 
     private void setDefaultValues() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewViewModelDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewViewModelDialog.java
@@ -117,11 +117,10 @@ public class NewViewModelDialog extends AbstractDialog {
     }
 
     protected void onOK() {
-        if (!validateFormFields()) {
-            return;
+        if (validateFormFields()) {
+            generateFile();
         }
-        generateFile();
-        this.setVisible(false);
+        exit();
     }
 
     private PsiFile generateFile() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewWebApiDeclarationDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewWebApiDeclarationDialog.java
@@ -141,16 +141,13 @@ public class NewWebApiDeclarationDialog extends AbstractDialog {
      * Fire generation process if all fields are valid.
      */
     private void onOK() {
-        if (!validateFormFields()) {
-            return;
+        if (validateFormFields()) {
+            new WebApiDeclarationGenerator(
+                    getDialogDataObject(),
+                    project
+            ).generate(NewWebApiDeclarationAction.ACTION_NAME, true);
         }
-
-        new WebApiDeclarationGenerator(
-                getDialogDataObject(),
-                project
-        ).generate(NewWebApiDeclarationAction.ACTION_NAME, true);
-
-        this.setVisible(false);
+        exit();
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideClassByAPreferenceDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideClassByAPreferenceDialog.java
@@ -168,6 +168,7 @@ public class OverrideClassByAPreferenceDialog extends AbstractDialog { //NOPMD
 
     protected void onOK() {
         if (!validateFormFields()) {
+            exit();
             return;
         }
         final PsiFile diXml = new PreferenceDiXmlGenerator(new PreferenceDiXmFileData(
@@ -203,7 +204,7 @@ public class OverrideClassByAPreferenceDialog extends AbstractDialog { //NOPMD
                 isInterface
         ), project).generate(OverrideClassByAPreferenceAction.ACTION_NAME, true);
 
-        this.setVisible(false);
+        exit();
     }
 
     public String getPreferenceClassName() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideInThemeDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideInThemeDialog.java
@@ -95,15 +95,13 @@ public class OverrideInThemeDialog extends AbstractDialog {
     }
 
     private void onOK() {
-        if (!validateFormFields()) {
-            return;
+        if (validateFormFields()) {
+            final OverrideInThemeGenerator overrideInThemeGenerator =
+                    new OverrideInThemeGenerator(project);
+
+            overrideInThemeGenerator.execute(psiFile, this.getTheme(), this.isOverride());
         }
-
-        final OverrideInThemeGenerator overrideInThemeGenerator =
-                new OverrideInThemeGenerator(project);
-        overrideInThemeGenerator.execute(psiFile, this.getTheme(), this.isOverride());
-
-        this.setVisible(false);
+        exit();
     }
 
     public String getTheme() {

--- a/src/com/magento/idea/magento2uct/ui/ConfigurationDialog.java
+++ b/src/com/magento/idea/magento2uct/ui/ConfigurationDialog.java
@@ -156,7 +156,7 @@ public class ConfigurationDialog extends AbstractDialog {
         );
         settingsService.setIgnoreCurrentVersion(ignoreCurrentVersion.isSelected());
 
-        this.setVisible(false);
+        exit();
     }
 
     /**

--- a/src/com/magento/idea/magento2uct/ui/ReindexDialog.java
+++ b/src/com/magento/idea/magento2uct/ui/ReindexDialog.java
@@ -125,7 +125,7 @@ public class ReindexDialog extends AbstractDialog {
         );
         executor.run();
 
-        this.setVisible(false);
+        exit();
     }
 
     /**


### PR DESCRIPTION
**Description** (*)

Fixed issue with an overlay stays over the editor after any plugin dialog window is closed after successfully finished operation, cancelation, error showing.

**Successfully reproduced issue:**

<img width="1360" alt="Screenshot 2021-11-26 at 14 57 12" src="https://user-images.githubusercontent.com/31848341/143604085-ce46d78e-ccbc-4277-bedd-3c41aa35bfe9.png">

**Result:**

![overlay-issue-result-min](https://user-images.githubusercontent.com/31848341/143604621-5653abef-8925-4ada-af6b-a4af148a7e37.gif)

**Fixed Issues (if relevant)**

1. Fixes magento/magento2-phpstorm-plugin#667

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
