### PR TITLE
Bugfix/765: Fixed stack overflow error for line-marker providers

### DIFF
--- a/src/com/magento/idea/magento2plugin/linemarker/php/PluginLineMarkerProvider.java
+++ b/src/com/magento/idea/magento2plugin/linemarker/php/PluginLineMarkerProvider.java
@@ -92,6 +92,9 @@ public class PluginLineMarkerProvider implements LineMarkerProvider {
             );
 
             for (final PhpClass parent : phpClass.getSupers()) {
+                if (classPluginsMap.containsKey(parent.getFQN().substring(1))) {
+                    continue;
+                }
                 pluginsForClass.addAll(getPluginsForClass(parent));
             }
 

--- a/src/com/magento/idea/magento2plugin/linemarker/php/PluginLineMarkerProvider.java
+++ b/src/com/magento/idea/magento2plugin/linemarker/php/PluginLineMarkerProvider.java
@@ -2,6 +2,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 package com.magento.idea.magento2plugin.linemarker.php;
 
 import com.intellij.codeInsight.daemon.LineMarkerInfo;
@@ -17,33 +18,49 @@ import com.jetbrains.php.lang.psi.elements.Method;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.magento.idea.magento2plugin.project.Settings;
 import com.magento.idea.magento2plugin.stubs.indexes.PluginIndex;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.commons.lang.WordUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
-
 public class PluginLineMarkerProvider implements LineMarkerProvider {
-    @Nullable
+
+    private static final String TOOLTIP_TEXT = "Navigate to plugins";
+    private static final int MIN_PLUGIN_METHOD_NAME_LENGTH = 6;
+
     @Override
-    public LineMarkerInfo getLineMarkerInfo(@NotNull PsiElement psiElement) {
+    public @Nullable LineMarkerInfo<?> getLineMarkerInfo(final @NotNull PsiElement psiElement) {
         return null;
     }
 
     @Override
-    public void collectSlowLineMarkers(@NotNull List<? extends PsiElement> psiElements, @NotNull Collection<? super LineMarkerInfo<?>> collection) {
-        if (psiElements.size() > 0) {
-            if (!Settings.isEnabled(psiElements.get(0).getProject())) {
-                return;
-            }
+    public void collectSlowLineMarkers(
+            final @NotNull List<? extends PsiElement> psiElements,
+            final @NotNull Collection<? super LineMarkerInfo<?>> collection
+    ) {
+        if (psiElements.isEmpty()) {
+            return;
         }
-        PluginClassCache pluginClassCache = new PluginClassCache();
-        ClassPluginCollector classPluginCollector = new ClassPluginCollector(pluginClassCache);
-        MethodPluginCollector methodPluginCollector = new MethodPluginCollector(pluginClassCache);
 
-        for (PsiElement psiElement : psiElements) {
+        if (!Settings.isEnabled(psiElements.get(0).getProject())) {
+            return;
+        }
+        final PluginClassCache pluginClassCache = new PluginClassCache();
+        final ClassPluginCollector classPluginCollector = new ClassPluginCollector(
+                pluginClassCache
+        );
+        final MethodPluginCollector methodPluginCollector = new MethodPluginCollector(
+                pluginClassCache
+        );
+
+        for (final PsiElement psiElement : psiElements) {
             if (psiElement instanceof PhpClass || psiElement instanceof Method) {
-                List<? extends PsiElement> results;
+                final List<? extends PsiElement> results;
 
                 if (psiElement instanceof PhpClass) {
                     results = classPluginCollector.collect((PhpClass) psiElement);
@@ -51,12 +68,13 @@ public class PluginLineMarkerProvider implements LineMarkerProvider {
                     results = methodPluginCollector.collect((Method) psiElement);
                 }
 
-                if (results.size() > 0 ) {
-                    collection.add(NavigationGutterIconBuilder
-                            .create(AllIcons.Nodes.Plugin)
-                            .setTargets(results)
-                            .setTooltipText("Navigate to plugins")
-                            .createLineMarkerInfo(PsiTreeUtil.getDeepestFirst(psiElement))
+                if (!results.isEmpty()) {
+                    collection.add(
+                            NavigationGutterIconBuilder
+                                    .create(AllIcons.Nodes.Plugin)
+                                    .setTargets(results)
+                                    .setTooltipText(TOOLTIP_TEXT)
+                                    .createLineMarkerInfo(PsiTreeUtil.getDeepestFirst(psiElement))
                     );
                 }
             }
@@ -64,109 +82,137 @@ public class PluginLineMarkerProvider implements LineMarkerProvider {
     }
 
     private static class PluginClassCache {
-        private HashMap<String, List<PhpClass>> classPluginsMap = new HashMap<String, List<PhpClass>>();
 
-        List<PhpClass> getPluginsForClass(@NotNull PhpClass phpClass, @NotNull String classFQN) {
-            List<PhpClass> results = new ArrayList<>();
+        private final Map<String, List<PhpClass>> classPluginsMap = new HashMap<>();
 
-            if (classPluginsMap.containsKey(classFQN)) {
-                return classPluginsMap.get(classFQN);
-            }
+        public List<PhpClass> getPluginsForClass(final @NotNull PhpClass phpClass) {
+            final List<PhpClass> pluginsForClass = getPluginsForClass(
+                    phpClass,
+                    phpClass.getPresentableFQN()
+            );
 
-            List<Set<String>> plugins = FileBasedIndex.getInstance()
-                .getValues(PluginIndex.KEY, classFQN, GlobalSearchScope.allScope(phpClass.getProject()));
-
-            if (plugins.size() == 0) {
-                classPluginsMap.put(classFQN, results);
-                return results;
-            }
-
-            PhpIndex phpIndex = PhpIndex.getInstance(phpClass.getProject());
-
-            for (Set<String> pluginClassNames: plugins) {
-                for (String pluginClassName: pluginClassNames) {
-                    results.addAll(phpIndex.getClassesByFQN(pluginClassName));
-                }
-            }
-            classPluginsMap.put(classFQN, results);
-            return results;
-        }
-
-        List<PhpClass> getPluginsForClass(@NotNull PhpClass phpClass)
-        {
-            List<PhpClass> pluginsForClass = getPluginsForClass(phpClass, phpClass.getPresentableFQN());
-            for (PhpClass parent: phpClass.getSupers()) {
+            for (final PhpClass parent : phpClass.getSupers()) {
                 pluginsForClass.addAll(getPluginsForClass(parent));
             }
 
             return pluginsForClass;
         }
 
-        List<Method> getPluginMethods(@NotNull PhpClass plugin) {
-            List<Method> methodList = new ArrayList<Method>();
-            for (Method method : plugin.getMethods()) {
+        public List<PhpClass> getPluginsForClass(
+                final @NotNull PhpClass phpClass,
+                final @NotNull String classFQN
+        ) {
+            if (classPluginsMap.containsKey(classFQN)) {
+                return classPluginsMap.get(classFQN);
+            }
+
+            final List<Set<String>> plugins = FileBasedIndex.getInstance()
+                    .getValues(
+                            PluginIndex.KEY,
+                            classFQN,
+                            GlobalSearchScope.allScope(phpClass.getProject())
+                    );
+            final List<PhpClass> results = new ArrayList<>();
+
+            if (plugins.isEmpty()) {
+                classPluginsMap.put(classFQN, results);
+
+                return results;
+            }
+            final PhpIndex phpIndex = PhpIndex.getInstance(phpClass.getProject());
+
+            for (final Set<String> pluginClassNames : plugins) {
+                for (final String pluginClassName: pluginClassNames) {
+                    results.addAll(phpIndex.getClassesByFQN(pluginClassName));
+                }
+            }
+            classPluginsMap.put(classFQN, results);
+
+            return results;
+        }
+
+        public List<Method> getPluginMethods(final List<PhpClass> plugins) {
+            final List<Method> methodList = new ArrayList<>();
+
+            for (final PhpClass plugin: plugins) {
+                methodList.addAll(getPluginMethods(plugin));
+            }
+
+            return methodList;
+        }
+
+        public List<Method> getPluginMethods(final @NotNull PhpClass pluginClass) {
+            final List<Method> methodList = new ArrayList<>();
+
+            for (final Method method : pluginClass.getMethods()) {
                 if (method.getAccess().isPublic()) {
-                    String pluginMethodName = method.getName();
-                    if (pluginMethodName.length() > 6) {
+                    final String pluginMethodName = method.getName();
+
+                    if (pluginMethodName.length() > MIN_PLUGIN_METHOD_NAME_LENGTH) {
                         methodList.add(method);
                     }
                 }
             }
-            return methodList;
-        }
 
-        List<Method> getPluginMethods(List<PhpClass> plugins) {
-            List<Method> methodList = new ArrayList<Method>();
-            for (PhpClass plugin: plugins) {
-                methodList.addAll(getPluginMethods(plugin));
-            }
             return methodList;
         }
     }
 
     private static class ClassPluginCollector implements Collector<PhpClass, PhpClass> {
-        private PluginLineMarkerProvider.PluginClassCache pluginClassCache;
 
-        ClassPluginCollector(PluginLineMarkerProvider.PluginClassCache pluginClassCache) {
+        private final PluginLineMarkerProvider.PluginClassCache pluginClassCache;
+
+        public ClassPluginCollector(
+                final PluginLineMarkerProvider.PluginClassCache pluginClassCache
+        ) {
             this.pluginClassCache = pluginClassCache;
         }
 
         @Override
-        public List<PhpClass> collect(@NotNull PhpClass psiElement) {
+        public List<PhpClass> collect(final @NotNull PhpClass psiElement) {
             return pluginClassCache.getPluginsForClass(psiElement);
         }
     }
 
     private static class MethodPluginCollector implements Collector<Method, Method> {
-        private PluginLineMarkerProvider.PluginClassCache pluginClassCache;
 
-        MethodPluginCollector(PluginLineMarkerProvider.PluginClassCache pluginClassCache) {
+        private final PluginLineMarkerProvider.PluginClassCache pluginClassCache;
+
+        public MethodPluginCollector(
+                final PluginLineMarkerProvider.PluginClassCache pluginClassCache
+        ) {
             this.pluginClassCache = pluginClassCache;
         }
 
         @Override
-        public List<Method> collect(@NotNull Method psiElement) {
-            List<Method> results = new ArrayList<>();
+        public List<Method> collect(final @NotNull Method psiElement) {
+            final List<Method> results = new ArrayList<>();
 
-            PhpClass methodClass = psiElement.getContainingClass();
+            final PhpClass methodClass = psiElement.getContainingClass();
+
             if (methodClass == null) {
                 return results;
             }
+            final List<PhpClass> pluginsList = pluginClassCache.getPluginsForClass(methodClass);
+            final List<Method> pluginMethods = pluginClassCache.getPluginMethods(pluginsList);
 
-            List<PhpClass> pluginsList = pluginClassCache.getPluginsForClass(methodClass);
-            List<Method> pluginMethods = pluginClassCache.getPluginMethods(pluginsList);
+            final String classMethodName = WordUtils.capitalize(psiElement.getName());
 
-            String classMethodName = WordUtils.capitalize(psiElement.getName());
-            for (Method pluginMethod: pluginMethods) {
+            for (final Method pluginMethod: pluginMethods) {
                 if (isPluginMethodName(pluginMethod.getName(), classMethodName)) {
                     results.add(pluginMethod);
                 }
             }
+
             return results;
         }
 
-        private boolean isPluginMethodName(String pluginMethodName, String classMethodName) {
-            return pluginMethodName.substring(5).equals(classMethodName) || pluginMethodName.substring(6).equals(classMethodName);
+        private boolean isPluginMethodName(
+                final String pluginMethodName,
+                final String classMethodName
+        ) {
+            return pluginMethodName.substring(5).equals(classMethodName)
+                    || pluginMethodName.substring(6).equals(classMethodName);
         }
     }
 

--- a/src/com/magento/idea/magento2plugin/linemarker/php/PluginTargetLineMarkerProvider.java
+++ b/src/com/magento/idea/magento2plugin/linemarker/php/PluginTargetLineMarkerProvider.java
@@ -21,13 +21,17 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class PluginTargetLineMarkerProvider implements LineMarkerProvider {
-    @Nullable
+
+    private static final String TARGET_CLASS_TOOLTIP_TEXT = "Navigate to target class";
+    private static final String TARGET_METHOD_TOOLTIP_TEXT = "Navigate to target method";
+
     @Override
-    public LineMarkerInfo getLineMarkerInfo(@NotNull final PsiElement psiElement) {
+    public @Nullable LineMarkerInfo<?> getLineMarkerInfo(final @NotNull PsiElement psiElement) {
         return null;
     }
 
@@ -36,48 +40,52 @@ public class PluginTargetLineMarkerProvider implements LineMarkerProvider {
             final @NotNull List<? extends PsiElement> psiElements,
             final @NotNull Collection<? super LineMarkerInfo<?>> collection
     ) {
-        if (!psiElements.isEmpty() && !Settings.isEnabled(psiElements.get(0).getProject())) {
+        if (psiElements.isEmpty()) {
+            return;
+        }
+
+        if (!Settings.isEnabled(psiElements.get(0).getProject())) {
             return;
         }
         final PluginClassCache pluginClassCache = new PluginClassCache();
-        final TargetClassesCollector targetClassesCollector =
-                new TargetClassesCollector(pluginClassCache);
-        final TargetMethodsCollector targetMethodsCollector =
-                new TargetMethodsCollector(pluginClassCache);
+        final TargetClassesCollector targetClassesCollector = new TargetClassesCollector(
+                pluginClassCache
+        );
+        final TargetMethodsCollector targetMethodsCollector = new TargetMethodsCollector(
+                pluginClassCache
+        );
 
         for (final PsiElement psiElement : psiElements) {
-            if (psiElement instanceof PhpClass || psiElement instanceof Method) {
-                List<? extends PsiElement> results;
+            if (psiElement instanceof PhpClass) {
+                final List<? extends PsiElement> results =
+                        targetClassesCollector.collect((PhpClass) psiElement);
 
-                if (psiElement instanceof PhpClass) {
-                    results = targetClassesCollector.collect((PhpClass) psiElement);
-                    if (!results.isEmpty()) {
-                        collection.add(NavigationGutterIconBuilder
-                                .create(AllIcons.Nodes.Class)
-                                .setTargets(results)
-                                .setTooltipText("Navigate to target class")
-                                .createLineMarkerInfo(PsiTreeUtil.getDeepestFirst(psiElement))
-                        );
-                    }
-                } else {
-                    results = targetMethodsCollector.collect((Method) psiElement);
-                    if (!results.isEmpty()) {
-                        collection.add(NavigationGutterIconBuilder
-                                .create(AllIcons.Nodes.Method)
-                                .setTargets(results)
-                                .setTooltipText("Navigate to target method")
-                                .createLineMarkerInfo(PsiTreeUtil.getDeepestFirst(psiElement))
-                        );
-                    }
+                if (!results.isEmpty()) {
+                    collection.add(NavigationGutterIconBuilder
+                            .create(AllIcons.Nodes.Class)
+                            .setTargets(results)
+                            .setTooltipText(TARGET_CLASS_TOOLTIP_TEXT)
+                            .createLineMarkerInfo(PsiTreeUtil.getDeepestFirst(psiElement))
+                    );
                 }
+            } else if (psiElement instanceof Method) {
+                final List<? extends PsiElement> results =
+                        targetMethodsCollector.collect((Method) psiElement);
 
+                if (!results.isEmpty()) {
+                    collection.add(NavigationGutterIconBuilder
+                            .create(AllIcons.Nodes.Method)
+                            .setTargets(results)
+                            .setTooltipText(TARGET_METHOD_TOOLTIP_TEXT)
+                            .createLineMarkerInfo(PsiTreeUtil.getDeepestFirst(psiElement))
+                    );
+                }
             }
         }
     }
 
     private static class PluginClassCache {
-        private final HashMap<String, List<PhpClass>> pluginClassesMap = // NOPMD
-                new HashMap<>();
+        private final Map<String, List<PhpClass>> pluginClassesMap = new HashMap<>();
 
         private List<PhpClass> getTargetClassesForPlugin(
                 @NotNull final PhpClass phpClass,
@@ -127,9 +135,10 @@ public class PluginTargetLineMarkerProvider implements LineMarkerProvider {
     }
 
     private static class TargetClassesCollector implements Collector<PhpClass, PhpClass> {
+
         private final PluginTargetLineMarkerProvider.PluginClassCache pluginClassCache;
 
-        TargetClassesCollector(// NOPMD
+        public TargetClassesCollector(
                 final PluginTargetLineMarkerProvider.PluginClassCache pluginClassCache
         ) {
             this.pluginClassCache = pluginClassCache;
@@ -142,9 +151,10 @@ public class PluginTargetLineMarkerProvider implements LineMarkerProvider {
     }
 
     private static class TargetMethodsCollector implements Collector<Method, Method> {
+
         private final PluginTargetLineMarkerProvider.PluginClassCache pluginClassCache;
 
-        TargetMethodsCollector(// NOPMD
+        public TargetMethodsCollector(
                 final PluginTargetLineMarkerProvider.PluginClassCache pluginClassCache
         ) {
             this.pluginClassCache = pluginClassCache;
@@ -158,32 +168,33 @@ public class PluginTargetLineMarkerProvider implements LineMarkerProvider {
             if (null == getPluginPrefix(pluginMethod)) {
                 return results;
             }
-
             final PhpClass pluginClass = pluginMethod.getContainingClass();
+
             if (pluginClass == null) {
                 return results;
             }
 
             final List<PhpClass> targetClasses
                     = pluginClassCache.getTargetClassesForPlugin(pluginClass);
+
             if (targetClasses.isEmpty()) {
                 return results;
             }
 
-            for (final PhpClass targetClass: targetClasses) {
+            for (final PhpClass targetClass : targetClasses) {
                 final String pluginPrefix = getPluginPrefix(pluginMethod);
                 final String targetClassMethodName = getTargetMethodName(
                         pluginMethod, pluginPrefix
                 );
+
                 if (targetClassMethodName == null) {
                     continue;
                 }
-
                 final Method targetMethod = targetClass.findMethodByName(targetClassMethodName);
+
                 if (targetMethod == null) {
                     continue;
                 }
-
                 results.add(targetMethod);
             }
 
@@ -192,25 +203,31 @@ public class PluginTargetLineMarkerProvider implements LineMarkerProvider {
 
         private String getTargetMethodName(final Method pluginMethod, final String pluginPrefix) {
             final String targetClassMethodName = pluginMethod.getName().replace(pluginPrefix, "");
+
             if (targetClassMethodName.isEmpty()) {
                 return null;
             }
             final char firstCharOfTargetName = targetClassMethodName.charAt(0);
+
             if (Character.getType(firstCharOfTargetName) == Character.LOWERCASE_LETTER) {
                 return null;
             }
+
             return Character.toLowerCase(firstCharOfTargetName)
                     + targetClassMethodName.substring(1);
         }
 
         private String getPluginPrefix(final Method pluginMethod) {
             final String pluginMethodName = pluginMethod.getName();
+
             if (pluginMethodName.startsWith(Plugin.PluginType.around.toString())) {
                 return Plugin.PluginType.around.toString();
             }
+
             if (pluginMethodName.startsWith(Plugin.PluginType.before.toString())) {
                 return Plugin.PluginType.before.toString();
             }
+
             if (pluginMethodName.startsWith(Plugin.PluginType.after.toString())) {
                 return Plugin.PluginType.after.toString();
             }

--- a/src/com/magento/idea/magento2plugin/linemarker/php/PluginTargetLineMarkerProvider.java
+++ b/src/com/magento/idea/magento2plugin/linemarker/php/PluginTargetLineMarkerProvider.java
@@ -127,6 +127,9 @@ public class PluginTargetLineMarkerProvider implements LineMarkerProvider {
                     phpClass, phpClass.getPresentableFQN()
             );
             for (final PhpClass parent: phpClass.getSupers()) {
+                if (pluginClassesMap.containsKey(parent.getFQN().substring(1))) {
+                    continue;
+                }
                 classesForPlugin.addAll(getTargetClassesForPlugin(parent));
             }
 

--- a/src/com/magento/idea/magento2plugin/linemarker/php/WebApiLineMarkerProvider.java
+++ b/src/com/magento/idea/magento2plugin/linemarker/php/WebApiLineMarkerProvider.java
@@ -1,7 +1,8 @@
-/**
+/*
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 package com.magento.idea.magento2plugin.linemarker.php;
 
 import com.intellij.codeInsight.daemon.LineMarkerInfo;
@@ -15,10 +16,13 @@ import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.magento.idea.magento2plugin.MagentoIcons;
 import com.magento.idea.magento2plugin.project.Settings;
 import com.magento.idea.magento2plugin.stubs.indexes.WebApiTypeIndex;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.*;
 
 /**
  * Line marker for methods and classes which are exposed as web APIs.
@@ -28,34 +32,42 @@ import java.util.*;
  */
 public class WebApiLineMarkerProvider implements LineMarkerProvider {
 
-    @Nullable
     @Override
-    public LineMarkerInfo getLineMarkerInfo(@NotNull PsiElement psiElement) {
+    public @Nullable LineMarkerInfo<?> getLineMarkerInfo(final @NotNull PsiElement psiElement) {
         return null;
     }
 
     @Override
-    public void collectSlowLineMarkers(@NotNull List<? extends PsiElement> psiElements, @NotNull Collection<? super LineMarkerInfo<?>> collection) {
-        if (psiElements.size() > 0) {
-            if (!Settings.isEnabled(psiElements.get(0).getProject())) {
-                return;
-            }
+    public void collectSlowLineMarkers(
+            final @NotNull List<? extends PsiElement> psiElements,
+            final @NotNull Collection<? super LineMarkerInfo<?>> collection
+    ) {
+        if (psiElements.isEmpty()) {
+            return;
         }
-        for (PsiElement psiElement: psiElements) {
-            WebApiRoutesCollector collector = new WebApiRoutesCollector();
+
+        if (!Settings.isEnabled(psiElements.get(0).getProject())) {
+            return;
+        }
+
+        for (final PsiElement psiElement : psiElements) {
+            final WebApiRoutesCollector collector = new WebApiRoutesCollector();
             List<XmlTag> results = new ArrayList<>();
+
             if (psiElement instanceof Method) {
                 results = collector.getRoutes((Method) psiElement);
             } else if (psiElement instanceof PhpClass) {
                 results = collector.getRoutes((PhpClass) psiElement);
             }
 
-            if (!(results.size() > 0)) {
+            if (results.isEmpty()) {
                 continue;
             }
 
-            StringBuilder tooltipText = new StringBuilder("Navigate to Web API configuration:<pre>");
-            for (XmlTag routeTag : results) {
+            StringBuilder tooltipText = new StringBuilder(
+                    "Navigate to Web API configuration:<pre>"
+            );
+            for (final XmlTag routeTag : results) {
                 tooltipText.append(routeTag.getName()).append("\n");
             }
             tooltipText.append("</pre>");
@@ -72,24 +84,27 @@ public class WebApiLineMarkerProvider implements LineMarkerProvider {
      */
     private static class WebApiRoutesCollector {
 
-        private HashMap<String, List<XmlTag>> routesCache = new HashMap<>();
-
-        private static final Map<String, Integer> HTTP_METHODS_SORT_ORDER = new HashMap<String, Integer>() {{
-            put("GET", 1);
-            put("PUT", 2);
-            put("POS", 3);
-            put("DEL", 4);
-        }};
+        private final Map<String, List<XmlTag>> routesCache = new HashMap<>();
+        private static final Map<String, Integer> HTTP_METHODS_SORT_ORDER = new HashMap<>() {
+            {
+                put("GET", 1);
+                put("PUT", 2);
+                put("POS", 3);
+                put("DEL", 4);
+            }
+        };
 
         /**
          * Get sorted list of Web API routes related to the specified class.
          */
-        List<XmlTag> getRoutes(@NotNull PhpClass phpClass) {
-            List<XmlTag> routesForClass = new ArrayList<>();
-            for (Method method : phpClass.getMethods()) {
+        public List<XmlTag> getRoutes(final @NotNull PhpClass phpClass) {
+            final List<XmlTag> routesForClass = new ArrayList<>();
+
+            for (final Method method : phpClass.getMethods()) {
                 routesForClass.addAll(getRoutes(method));
             }
             sortRoutes(routesForClass);
+
             return routesForClass;
         }
 
@@ -98,13 +113,15 @@ public class WebApiLineMarkerProvider implements LineMarkerProvider {
          * <p/>
          * Results are cached.
          */
-        List<XmlTag> getRoutes(@NotNull Method method) {
-            String methodFqn = method.getFQN();
+        public List<XmlTag> getRoutes(final @NotNull Method method) {
+            final String methodFqn = method.getFQN();
+
             if (!routesCache.containsKey(methodFqn)) {
                 List<XmlTag> routesForMethod = extractRoutesForMethod(method);
                 sortRoutes(routesForMethod);
                 routesCache.put(methodFqn, routesForMethod);
             }
+
             return routesCache.get(methodFqn);
         }
 
@@ -114,37 +131,42 @@ public class WebApiLineMarkerProvider implements LineMarkerProvider {
          * Web API declarations for parent classes are taken into account.
          * Results are not cached.
          */
-        List<XmlTag> extractRoutesForMethod(@NotNull Method method) {
-            List<XmlTag> routesForMethod = WebApiTypeIndex.getWebApiRoutes(method);
-            PhpClass phpClass = method.getContainingClass();
+        public List<XmlTag> extractRoutesForMethod(final @NotNull Method method) {
+            final List<XmlTag> routesForMethod = WebApiTypeIndex.getWebApiRoutes(method);
+            final PhpClass phpClass = method.getContainingClass();
+
             if (phpClass == null) {
                 return routesForMethod;
             }
-            for (PhpClass parent : method.getContainingClass().getSupers()) {
+            for (final PhpClass parent : method.getContainingClass().getSupers()) {
                 for (Method parentMethod : parent.getMethods()) {
                     if (parentMethod.getName().equals(method.getName())) {
                         routesForMethod.addAll(extractRoutesForMethod(parentMethod));
                     }
                 }
             }
+
             return routesForMethod;
         }
 
         /**
          * Make sure that routes are sorted as follows: GET, PUT, POST, DELETE. Then by path.
          */
-        private void sortRoutes(List<XmlTag> routes) {
+        private void sortRoutes(final List<XmlTag> routes) {
             routes.sort(
-                (firstTag, secondTag) -> {
-                    String substring = firstTag.getName().substring(2, 5);
-                    Integer firstSortOrder = HTTP_METHODS_SORT_ORDER.get(substring);
-                    Integer secondSortOrder = HTTP_METHODS_SORT_ORDER.get(secondTag.getName().substring(2, 5));
-                    if (firstSortOrder.compareTo(secondSortOrder) == 0) {
-                        // Sort by route if HTTP methods are equal
-                        return firstTag.getName().compareTo(secondTag.getName());
+                    (firstTag, secondTag) -> {
+                        String substring = firstTag.getName().substring(2, 5);
+                        Integer firstSortOrder = HTTP_METHODS_SORT_ORDER.get(substring);
+                        Integer secondSortOrder = HTTP_METHODS_SORT_ORDER.get(
+                                secondTag.getName().substring(2, 5)
+                        );
+                        if (firstSortOrder.compareTo(secondSortOrder) == 0) {
+                            // Sort by route if HTTP methods are equal
+                            return firstTag.getName().compareTo(secondTag.getName());
+                        }
+
+                        return firstSortOrder.compareTo(secondSortOrder);
                     }
-                    return firstSortOrder.compareTo(secondSortOrder);
-                }
             );
         }
     }

--- a/src/com/magento/idea/magento2plugin/linemarker/php/WebApiLineMarkerProvider.java
+++ b/src/com/magento/idea/magento2plugin/linemarker/php/WebApiLineMarkerProvider.java
@@ -37,6 +37,7 @@ public class WebApiLineMarkerProvider implements LineMarkerProvider {
         return null;
     }
 
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     @Override
     public void collectSlowLineMarkers(
             final @NotNull List<? extends PsiElement> psiElements,
@@ -82,10 +83,11 @@ public class WebApiLineMarkerProvider implements LineMarkerProvider {
     /**
      * Web API config nodes collector for service methods and classes. Has built in caching.
      */
+    @SuppressWarnings("PMD.AvoidDoubleBraceInitializationCheck")
     private static class WebApiRoutesCollector {
 
         private final Map<String, List<XmlTag>> routesCache = new HashMap<>();
-        private static final Map<String, Integer> HTTP_METHODS_SORT_ORDER = new HashMap<>() {//NOPMD
+        private static final Map<String, Integer> HTTP_METHODS_SORT_ORDER = new HashMap<>() {
             {
                 put("GET", 1);
                 put("PUT", 2);

--- a/src/com/magento/idea/magento2plugin/linemarker/php/WebApiLineMarkerProvider.java
+++ b/src/com/magento/idea/magento2plugin/linemarker/php/WebApiLineMarkerProvider.java
@@ -83,18 +83,18 @@ public class WebApiLineMarkerProvider implements LineMarkerProvider {
     /**
      * Web API config nodes collector for service methods and classes. Has built in caching.
      */
-    @SuppressWarnings("PMD.AvoidDoubleBraceInitializationCheck")
     private static class WebApiRoutesCollector {
 
         private final Map<String, List<XmlTag>> routesCache = new HashMap<>();
-        private static final Map<String, Integer> HTTP_METHODS_SORT_ORDER = new HashMap<>() {
-            {
-                put("GET", 1);
-                put("PUT", 2);
-                put("POS", 3);
-                put("DEL", 4);
-            }
-        };
+        private final Map<String, Integer> httpMethodsSortOrder;
+
+        public WebApiRoutesCollector() {
+            httpMethodsSortOrder = new HashMap<>();
+            httpMethodsSortOrder.put("GET", 1);
+            httpMethodsSortOrder.put("PUT", 2);
+            httpMethodsSortOrder.put("POS", 3);
+            httpMethodsSortOrder.put("DEL", 4);
+        }
 
         /**
          * Get sorted list of Web API routes related to the specified class.
@@ -182,8 +182,8 @@ public class WebApiLineMarkerProvider implements LineMarkerProvider {
             routes.sort(
                     (firstTag, secondTag) -> {
                         final String substring = firstTag.getName().substring(2, 5);
-                        final Integer firstSortOrder = HTTP_METHODS_SORT_ORDER.get(substring);
-                        final Integer secondSortOrder = HTTP_METHODS_SORT_ORDER.get(
+                        final Integer firstSortOrder = httpMethodsSortOrder.get(substring);
+                        final Integer secondSortOrder = httpMethodsSortOrder.get(
                                 secondTag.getName().substring(2, 5)
                         );
                         if (firstSortOrder.compareTo(secondSortOrder) == 0) {

--- a/src/com/magento/idea/magento2plugin/linemarker/php/WebApiLineMarkerProvider.java
+++ b/src/com/magento/idea/magento2plugin/linemarker/php/WebApiLineMarkerProvider.java
@@ -49,9 +49,9 @@ public class WebApiLineMarkerProvider implements LineMarkerProvider {
         if (!Settings.isEnabled(psiElements.get(0).getProject())) {
             return;
         }
+        final WebApiRoutesCollector collector = new WebApiRoutesCollector();
 
         for (final PsiElement psiElement : psiElements) {
-            final WebApiRoutesCollector collector = new WebApiRoutesCollector();
             List<XmlTag> results = new ArrayList<>();
 
             if (psiElement instanceof Method) {
@@ -64,14 +64,14 @@ public class WebApiLineMarkerProvider implements LineMarkerProvider {
                 continue;
             }
 
-            StringBuilder tooltipText = new StringBuilder(
+            final StringBuilder tooltipText = new StringBuilder(
                     "Navigate to Web API configuration:<pre>"
             );
             for (final XmlTag routeTag : results) {
-                tooltipText.append(routeTag.getName()).append("\n");
+                tooltipText.append(routeTag.getName()).append('\n');
             }
             tooltipText.append("</pre>");
-            NavigationGutterIconBuilder<PsiElement> builder = NavigationGutterIconBuilder
+            final NavigationGutterIconBuilder<PsiElement> builder = NavigationGutterIconBuilder
                     .create(MagentoIcons.WEB_API)
                     .setTargets(results)
                     .setTooltipText(tooltipText.toString());
@@ -85,7 +85,7 @@ public class WebApiLineMarkerProvider implements LineMarkerProvider {
     private static class WebApiRoutesCollector {
 
         private final Map<String, List<XmlTag>> routesCache = new HashMap<>();
-        private static final Map<String, Integer> HTTP_METHODS_SORT_ORDER = new HashMap<>() {
+        private static final Map<String, Integer> HTTP_METHODS_SORT_ORDER = new HashMap<>() {//NOPMD
             {
                 put("GET", 1);
                 put("PUT", 2);
@@ -155,7 +155,7 @@ public class WebApiLineMarkerProvider implements LineMarkerProvider {
             }
 
             for (final PhpClass parent : method.getContainingClass().getSupers()) {
-                for (Method parentMethod : parent.getMethods()) {
+                for (final Method parentMethod : parent.getMethods()) {
                     if (parentMethod.getName().equals(method.getName())) {
                         if (routesForMethod.containsKey(parentMethod.getFQN())) {
                             continue;
@@ -179,9 +179,9 @@ public class WebApiLineMarkerProvider implements LineMarkerProvider {
         private void sortRoutes(final List<XmlTag> routes) {
             routes.sort(
                     (firstTag, secondTag) -> {
-                        String substring = firstTag.getName().substring(2, 5);
-                        Integer firstSortOrder = HTTP_METHODS_SORT_ORDER.get(substring);
-                        Integer secondSortOrder = HTTP_METHODS_SORT_ORDER.get(
+                        final String substring = firstTag.getName().substring(2, 5);
+                        final Integer firstSortOrder = HTTP_METHODS_SORT_ORDER.get(substring);
+                        final Integer secondSortOrder = HTTP_METHODS_SORT_ORDER.get(
                                 secondTag.getName().substring(2, 5)
                         );
                         if (firstSortOrder.compareTo(secondSortOrder) == 0) {


### PR DESCRIPTION
**Description** (*)

Fixed stack overflow error for the next line-marker providers:

- com.magento.idea.magento2plugin.linemarker.php.PluginLineMarkerProvider
- com.magento.idea.magento2plugin.linemarker.php.PluginTargetLineMarkerProvider
- com.magento.idea.magento2plugin.linemarker.php.WebApiLineMarkerProvider

**The bug was successfully reproduced by the next steps:**

1. created new class A
2. created new class B
3. added plugins for class A
4. made class A extends class B
5. made class B extends class A

<img width="1156" alt="Screenshot 2021-11-29 at 11 31 44" src="https://user-images.githubusercontent.com/31848341/143884282-67eeb18f-f122-42e7-9e4b-55bcc9e0f892.png">

**The results after fixing it:**

<img width="1004" alt="Screenshot 2021-11-29 at 15 14 34" src="https://user-images.githubusercontent.com/31848341/143884353-fa144763-02f1-4bf9-98f3-450286b29424.png">
<img width="1004" alt="Screenshot 2021-11-29 at 15 14 49" src="https://user-images.githubusercontent.com/31848341/143884369-e8396e40-0152-41cf-94fc-5896662eb6a0.png">

**Fixed Issues (if relevant)**

1. Fixes magento/magento2-phpstorm-plugin#765

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
