### PR TITLE
Bugfix-645: Fixed failed to build require-js index

### DIFF
--- a/src/com/magento/idea/magento2plugin/stubs/indexes/js/RequireJsIndex.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/js/RequireJsIndex.java
@@ -103,18 +103,7 @@ public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
                 if (mappingWrapper == null) {
                     continue;
                 }
-                final JSProperty[] allConfigs = mappingWrapper.getProperties();
-
-                for (final JSProperty mapping : allConfigs) {
-                    final String nameConfig = mapping.getName();
-                    final JSExpression value = mapping.getValue();
-
-                    if (value == null) {
-                        continue;
-                    }
-                    final String valueConfig = value.getText();
-                    map.put(nameConfig, valueConfig);
-                }
+                processObjectProperties(map, mappingWrapper.getProperties());
             }
         }
     }
@@ -136,18 +125,23 @@ public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
         }
 
         for (final JSObjectLiteralExpression pathGroupsWrapper : pathGroupsWrappers) {
-            final JSProperty[] allConfigs = pathGroupsWrapper.getProperties();
+            processObjectProperties(map, pathGroupsWrapper.getProperties());
+        }
+    }
 
-            for (final JSProperty mapping : allConfigs) {
-                final String nameConfig = mapping.getName();
-                final JSExpression value = mapping.getValue();
+    private void processObjectProperties(
+            final Map<String, String> map,
+            final JSProperty... allConfigs
+    ) {
+        for (final JSProperty mapping : allConfigs) {
+            final String nameConfig = mapping.getName();
+            final JSExpression value = mapping.getValue();
 
-                if (value == null) {
-                    continue;
-                }
-                final String valueConfig = value.getText();
-                map.put(nameConfig, valueConfig);
+            if (value == null) {
+                continue;
             }
+            final String valueConfig = value.getText();
+            map.put(nameConfig, valueConfig);
         }
     }
 

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/js/RequireJsIndex.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/js/RequireJsIndex.java
@@ -66,29 +66,7 @@ public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
                         return map;
                     }
                     parseConfigMap(map, config);
-
-                    final JSProperty pathsMap = config.findProperty("paths");
-
-                    if (pathsMap == null) {
-                        return map;
-                    }
-                    final JSObjectLiteralExpression[] pathGroupsWrappers = PsiTreeUtil
-                            .getChildrenOfType(pathsMap, JSObjectLiteralExpression.class);
-
-                    for (final JSObjectLiteralExpression pathGroupsWrapper : pathGroupsWrappers) {
-                        final JSProperty[] allConfigs = pathGroupsWrapper.getProperties();
-
-                        for (final JSProperty mapping : allConfigs) {
-                            final String nameConfig = mapping.getName();
-                            final JSExpression value = mapping.getValue();
-
-                            if (value == null) {
-                                continue;
-                            }
-                            final String valueConfig = value.getText();
-                            map.put(nameConfig, valueConfig);
-                        }
-                    }
+                    parseConfigPaths(map, config);
                 }
             }
 
@@ -105,11 +83,11 @@ public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
         if (configMap == null) {
             return;
         }
-
         final JSObjectLiteralExpression[] configGroupsWrappers = PsiTreeUtil.getChildrenOfType(
                 configMap,
                 JSObjectLiteralExpression.class
         );
+
         for (final JSObjectLiteralExpression configGroupsWrapper : configGroupsWrappers) {
             final PsiElement[] configGroups = configGroupsWrapper.getChildren();
 
@@ -130,6 +108,34 @@ public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
                     final String valueConfig = value.getText();
                     map.put(nameConfig, valueConfig);
                 }
+            }
+        }
+    }
+
+    private void parseConfigPaths(
+            final Map<String, String> map,
+            final JSObjectLiteralExpression config
+    ) {
+        final JSProperty pathsMap = config.findProperty("paths");
+
+        if (pathsMap == null) {
+            return;
+        }
+        final JSObjectLiteralExpression[] pathGroupsWrappers = PsiTreeUtil
+                .getChildrenOfType(pathsMap, JSObjectLiteralExpression.class);
+
+        for (final JSObjectLiteralExpression pathGroupsWrapper : pathGroupsWrappers) {
+            final JSProperty[] allConfigs = pathGroupsWrapper.getProperties();
+
+            for (final JSProperty mapping : allConfigs) {
+                final String nameConfig = mapping.getName();
+                final JSExpression value = mapping.getValue();
+
+                if (value == null) {
+                    continue;
+                }
+                final String valueConfig = value.getText();
+                map.put(nameConfig, valueConfig);
             }
         }
     }

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/js/RequireJsIndex.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/js/RequireJsIndex.java
@@ -40,37 +40,37 @@ public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
     @Override
     public @NotNull DataIndexer<String, String, FileContent> getIndexer() {
         return inputData -> {
-            Map<String, String> map = new HashMap<>();
-            JSFile jsFile = (JSFile) inputData.getPsiFile();
+            final Map<String, String> map = new HashMap<>();
+            final JSFile jsFile = (JSFile) inputData.getPsiFile();
 
-            JSVarStatement jsVarStatement = PsiTreeUtil.getChildOfType(jsFile, JSVarStatement.class);
+            final JSVarStatement jsVarStatement = PsiTreeUtil.getChildOfType(jsFile, JSVarStatement.class);
             if (jsVarStatement == null) {
                 return map;
             }
-            JSVariable[] jsVariableList = jsVarStatement.getVariables();
-            for (JSVariable jsVariable : jsVariableList) {
-                String name = jsVariable.getName();
+            final JSVariable[] jsVariableList = jsVarStatement.getVariables();
+            for (final JSVariable jsVariable : jsVariableList) {
+                final String name = jsVariable.getName();
                 if (name.equals("config")) {
-                    JSObjectLiteralExpression config = PsiTreeUtil.getChildOfType(jsVariable, JSObjectLiteralExpression.class);
+                    final JSObjectLiteralExpression config = PsiTreeUtil.getChildOfType(jsVariable, JSObjectLiteralExpression.class);
                     if (config == null) {
                         return map;
                     }
                     parseConfigMap(map, config);
 
-                    JSProperty pathsMap = config.findProperty("paths");
+                    final JSProperty pathsMap = config.findProperty("paths");
                     if (pathsMap == null) {
                         return map;
                     }
-                    JSObjectLiteralExpression[] pathGroupsWrappers = PsiTreeUtil.getChildrenOfType(pathsMap, JSObjectLiteralExpression.class);
-                    for (JSObjectLiteralExpression pathGroupsWrapper : pathGroupsWrappers) {
-                        JSProperty[] allConfigs = pathGroupsWrapper.getProperties();
-                        for (JSProperty mapping : allConfigs) {
-                            String nameConfig = mapping.getName();
-                            JSExpression value = mapping.getValue();
+                    final JSObjectLiteralExpression[] pathGroupsWrappers = PsiTreeUtil.getChildrenOfType(pathsMap, JSObjectLiteralExpression.class);
+                    for (final JSObjectLiteralExpression pathGroupsWrapper : pathGroupsWrappers) {
+                        final JSProperty[] allConfigs = pathGroupsWrapper.getProperties();
+                        for (final JSProperty mapping : allConfigs) {
+                            final String nameConfig = mapping.getName();
+                            final JSExpression value = mapping.getValue();
                             if (value == null) {
                                 continue;
                             }
-                            String valueConfig = value.getText();
+                            final String valueConfig = value.getText();
                             map.put(nameConfig, valueConfig);
                         }
                     }
@@ -85,26 +85,26 @@ public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
             final Map<String, String> map,
             final JSObjectLiteralExpression config
     ) {
-        JSProperty configMap = config.findProperty("map");
+        final JSProperty configMap = config.findProperty("map");
         if (configMap == null) {
             return;
         }
 
-        JSObjectLiteralExpression[] configGroupsWrappers = PsiTreeUtil.getChildrenOfType(configMap, JSObjectLiteralExpression.class);
-        for (JSObjectLiteralExpression configGroupsWrapper : configGroupsWrappers) {
-            PsiElement[] configGroups = configGroupsWrapper.getChildren();
+        final JSObjectLiteralExpression[] configGroupsWrappers = PsiTreeUtil.getChildrenOfType(configMap, JSObjectLiteralExpression.class);
+        for (final JSObjectLiteralExpression configGroupsWrapper : configGroupsWrappers) {
+            final PsiElement[] configGroups = configGroupsWrapper.getChildren();
 
-            for (PsiElement configGroup : configGroups) {
-                JSObjectLiteralExpression mappingWrapper = PsiTreeUtil.getChildOfType(configGroup, JSObjectLiteralExpression.class);
-                JSProperty[] allConfigs = mappingWrapper.getProperties();
+            for (final PsiElement configGroup : configGroups) {
+                final JSObjectLiteralExpression mappingWrapper = PsiTreeUtil.getChildOfType(configGroup, JSObjectLiteralExpression.class);
+                final JSProperty[] allConfigs = mappingWrapper.getProperties();
 
-                for (JSProperty mapping : allConfigs) {
-                    String nameConfig = mapping.getName();
-                    JSExpression value = mapping.getValue();
+                for (final JSProperty mapping : allConfigs) {
+                    final String nameConfig = mapping.getName();
+                    final JSExpression value = mapping.getValue();
                     if (value == null) {
                         continue;
                     }
-                    String valueConfig = value.getText();
+                    final String valueConfig = value.getText();
                     map.put(nameConfig, valueConfig);
                 }
             }

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/js/RequireJsIndex.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/js/RequireJsIndex.java
@@ -81,7 +81,10 @@ public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
         };
     }
 
-    private void parseConfigMap(Map<String, String> map, JSObjectLiteralExpression config) {
+    private void parseConfigMap(
+            final Map<String, String> map,
+            final JSObjectLiteralExpression config
+    ) {
         JSProperty configMap = config.findProperty("map");
         if (configMap == null) {
             return;

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/js/RequireJsIndex.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/js/RequireJsIndex.java
@@ -56,7 +56,7 @@ public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
             for (final JSVariable jsVariable : jsVariableList) {
                 final String name = jsVariable.getName();
 
-                if (name.equals("config")) {
+                if ("config".equals(name)) {
                     final JSObjectLiteralExpression config = PsiTreeUtil.getChildOfType(
                             jsVariable,
                             JSObjectLiteralExpression.class
@@ -143,7 +143,7 @@ public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
     public @NotNull FileBasedIndex.InputFilter getInputFilter() {
         return virtualFile ->
                 virtualFile.getFileType().equals(JavaScriptFileType.INSTANCE)
-                        && virtualFile.getName().equals("requirejs-config.js");
+                        && "requirejs-config.js".equals(virtualFile.getName());
     }
 
     @Override

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/js/RequireJsIndex.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/js/RequireJsIndex.java
@@ -2,36 +2,46 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 package com.magento.idea.magento2plugin.stubs.indexes.js;
 
 import com.intellij.lang.javascript.JavaScriptFileType;
-import com.intellij.lang.javascript.psi.*;
+import com.intellij.lang.javascript.psi.JSExpression;
+import com.intellij.lang.javascript.psi.JSFile;
+import com.intellij.lang.javascript.psi.JSObjectLiteralExpression;
+import com.intellij.lang.javascript.psi.JSProperty;
+import com.intellij.lang.javascript.psi.JSVarStatement;
+import com.intellij.lang.javascript.psi.JSVariable;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
-import com.intellij.util.indexing.*;
+import com.intellij.util.indexing.DataIndexer;
+import com.intellij.util.indexing.FileBasedIndex;
+import com.intellij.util.indexing.FileBasedIndexExtension;
+import com.intellij.util.indexing.FileContent;
+import com.intellij.util.indexing.ID;
 import com.intellij.util.io.DataExternalizer;
 import com.intellij.util.io.EnumeratorStringDescriptor;
 import com.intellij.util.io.KeyDescriptor;
-import org.jetbrains.annotations.NotNull;
 import java.util.HashMap;
 import java.util.Map;
+import org.jetbrains.annotations.NotNull;
 
 public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
-    public static final ID<String, String> KEY =
-            ID.create("com.magento.idea.magento2plugin.stubs.indexes.require_js");
 
-    @NotNull
+    public static final ID<String, String> KEY = ID.create(
+            "com.magento.idea.magento2plugin.stubs.indexes.require_js"
+    );
+
     @Override
-    public ID<String, String> getName() {
+    public @NotNull ID<String, String> getName() {
         return KEY;
     }
 
-    @NotNull
     @Override
-    public DataIndexer<String, String, FileContent> getIndexer() {
+    public @NotNull DataIndexer<String, String, FileContent> getIndexer() {
         return inputData -> {
             Map<String, String> map = new HashMap<>();
-            JSFile jsFile = (JSFile)inputData.getPsiFile();
+            JSFile jsFile = (JSFile) inputData.getPsiFile();
 
             JSVarStatement jsVarStatement = PsiTreeUtil.getChildOfType(jsFile, JSVarStatement.class);
             if (jsVarStatement == null) {
@@ -98,17 +108,16 @@ public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
         }
     }
 
-    @NotNull
     @Override
-    public KeyDescriptor<String> getKeyDescriptor() {
+    public @NotNull KeyDescriptor<String> getKeyDescriptor() {
         return new EnumeratorStringDescriptor();
     }
 
-    @NotNull
     @Override
-    public FileBasedIndex.InputFilter getInputFilter() {
+    public @NotNull FileBasedIndex.InputFilter getInputFilter() {
         return virtualFile -> (
-                virtualFile.getFileType().equals(JavaScriptFileType.INSTANCE) && virtualFile.getName().equals("requirejs-config.js")
+                virtualFile.getFileType().equals(JavaScriptFileType.INSTANCE)
+                        && virtualFile.getName().equals("requirejs-config.js")
         );
     }
 
@@ -122,8 +131,7 @@ public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
         return 1;
     }
 
-    @NotNull
-    public DataExternalizer<String> getValueExternalizer() {
+    public @NotNull DataExternalizer<String> getValueExternalizer() {
         return EnumeratorStringDescriptor.INSTANCE;
     }
 }

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/js/RequireJsIndex.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/js/RequireJsIndex.java
@@ -43,30 +43,45 @@ public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
             final Map<String, String> map = new HashMap<>();
             final JSFile jsFile = (JSFile) inputData.getPsiFile();
 
-            final JSVarStatement jsVarStatement = PsiTreeUtil.getChildOfType(jsFile, JSVarStatement.class);
+            final JSVarStatement jsVarStatement = PsiTreeUtil.getChildOfType(
+                    jsFile,
+                    JSVarStatement.class
+            );
+
             if (jsVarStatement == null) {
                 return map;
             }
             final JSVariable[] jsVariableList = jsVarStatement.getVariables();
+
             for (final JSVariable jsVariable : jsVariableList) {
                 final String name = jsVariable.getName();
+
                 if (name.equals("config")) {
-                    final JSObjectLiteralExpression config = PsiTreeUtil.getChildOfType(jsVariable, JSObjectLiteralExpression.class);
+                    final JSObjectLiteralExpression config = PsiTreeUtil.getChildOfType(
+                            jsVariable,
+                            JSObjectLiteralExpression.class
+                    );
+
                     if (config == null) {
                         return map;
                     }
                     parseConfigMap(map, config);
 
                     final JSProperty pathsMap = config.findProperty("paths");
+
                     if (pathsMap == null) {
                         return map;
                     }
-                    final JSObjectLiteralExpression[] pathGroupsWrappers = PsiTreeUtil.getChildrenOfType(pathsMap, JSObjectLiteralExpression.class);
+                    final JSObjectLiteralExpression[] pathGroupsWrappers = PsiTreeUtil
+                            .getChildrenOfType(pathsMap, JSObjectLiteralExpression.class);
+
                     for (final JSObjectLiteralExpression pathGroupsWrapper : pathGroupsWrappers) {
                         final JSProperty[] allConfigs = pathGroupsWrapper.getProperties();
+
                         for (final JSProperty mapping : allConfigs) {
                             final String nameConfig = mapping.getName();
                             final JSExpression value = mapping.getValue();
+
                             if (value == null) {
                                 continue;
                             }
@@ -86,21 +101,29 @@ public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
             final JSObjectLiteralExpression config
     ) {
         final JSProperty configMap = config.findProperty("map");
+
         if (configMap == null) {
             return;
         }
 
-        final JSObjectLiteralExpression[] configGroupsWrappers = PsiTreeUtil.getChildrenOfType(configMap, JSObjectLiteralExpression.class);
+        final JSObjectLiteralExpression[] configGroupsWrappers = PsiTreeUtil.getChildrenOfType(
+                configMap,
+                JSObjectLiteralExpression.class
+        );
         for (final JSObjectLiteralExpression configGroupsWrapper : configGroupsWrappers) {
             final PsiElement[] configGroups = configGroupsWrapper.getChildren();
 
             for (final PsiElement configGroup : configGroups) {
-                final JSObjectLiteralExpression mappingWrapper = PsiTreeUtil.getChildOfType(configGroup, JSObjectLiteralExpression.class);
+                final JSObjectLiteralExpression mappingWrapper = PsiTreeUtil.getChildOfType(
+                        configGroup,
+                        JSObjectLiteralExpression.class
+                );
                 final JSProperty[] allConfigs = mappingWrapper.getProperties();
 
                 for (final JSProperty mapping : allConfigs) {
                     final String nameConfig = mapping.getName();
                     final JSExpression value = mapping.getValue();
+
                     if (value == null) {
                         continue;
                     }
@@ -118,10 +141,9 @@ public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
 
     @Override
     public @NotNull FileBasedIndex.InputFilter getInputFilter() {
-        return virtualFile -> (
+        return virtualFile ->
                 virtualFile.getFileType().equals(JavaScriptFileType.INSTANCE)
-                        && virtualFile.getName().equals("requirejs-config.js")
-        );
+                        && virtualFile.getName().equals("requirejs-config.js");
     }
 
     @Override
@@ -134,6 +156,7 @@ public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
         return 1;
     }
 
+    @Override
     public @NotNull DataExternalizer<String> getValueExternalizer() {
         return EnumeratorStringDescriptor.INSTANCE;
     }

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/js/RequireJsIndex.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/js/RequireJsIndex.java
@@ -87,6 +87,9 @@ public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
                 configMap,
                 JSObjectLiteralExpression.class
         );
+        if (configGroupsWrappers == null) {
+            return;
+        }
 
         for (final JSObjectLiteralExpression configGroupsWrapper : configGroupsWrappers) {
             final PsiElement[] configGroups = configGroupsWrapper.getChildren();
@@ -96,6 +99,10 @@ public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
                         configGroup,
                         JSObjectLiteralExpression.class
                 );
+
+                if (mappingWrapper == null) {
+                    continue;
+                }
                 final JSProperty[] allConfigs = mappingWrapper.getProperties();
 
                 for (final JSProperty mapping : allConfigs) {
@@ -123,6 +130,10 @@ public class RequireJsIndex extends FileBasedIndexExtension<String, String> {
         }
         final JSObjectLiteralExpression[] pathGroupsWrappers = PsiTreeUtil
                 .getChildrenOfType(pathsMap, JSObjectLiteralExpression.class);
+
+        if (pathGroupsWrappers == null) {
+            return;
+        }
 
         for (final JSObjectLiteralExpression pathGroupsWrapper : pathGroupsWrappers) {
             final JSProperty[] allConfigs = pathGroupsWrapper.getProperties();


### PR DESCRIPTION
**Description** (*)

Fixed failed to build requirejs-config.js files index.

**Bug was reproduced before fixing:**

<img width="1421" alt="Screenshot 2021-11-30 at 13 49 49" src="https://user-images.githubusercontent.com/31848341/144056514-987d5746-e6c7-48f3-b63f-9b0da40bbc5f.png">

**The result of fixing it:**

<img width="850" alt="Screenshot 2021-11-30 at 14 28 06" src="https://user-images.githubusercontent.com/31848341/144056529-f5c4d323-a02b-4fcd-af81-a601578b5a20.png">

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#645

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
