### PR TITLE
Bugfix-739: Fixed empty psi elements in the plugin inspections

### DIFF
--- a/src/com/magento/idea/magento2plugin/inspections/php/PluginInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/php/PluginInspection.java
@@ -187,6 +187,9 @@ public class PluginInspection extends PhpInspection {
 
                 int index = 0;
                 for (final Parameter pluginMethodParameter : pluginMethodParameters) {
+                    if (pluginMethodParameter.getName().isEmpty()) {
+                        continue;
+                    }
                     index++;
                     String declaredType = pluginMethodParameter.getDeclaredType().toString();
 

--- a/src/com/magento/idea/magento2plugin/inspections/php/PluginInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/php/PluginInspection.java
@@ -30,14 +30,13 @@ import com.magento.idea.magento2plugin.util.magento.plugin.GetTargetClassNamesBy
 import java.util.ArrayList;
 import org.jetbrains.annotations.NotNull;
 
-@SuppressWarnings({"PMD.ExcessiveMethodLength", "PMD.NPathComplexity"})
+@SuppressWarnings({"PMD.ExcessiveMethodLength", "PMD.NPathComplexity", "PMD.CognitiveComplexity"})
 public class PluginInspection extends PhpInspection {
 
     private static final String WRONG_PARAM_TYPE = "inspection.wrong_param_type";
 
-    @NotNull
     @Override
-    public PsiElementVisitor buildVisitor(
+    public @NotNull PsiElementVisitor buildVisitor(
             final @NotNull ProblemsHolder problemsHolder,
             final boolean isOnTheFly
     ) {
@@ -146,7 +145,7 @@ public class PluginInspection extends PhpInspection {
                     final String targetClassMethodName,
                     final Method targetMethod
             ) {
-                if (targetClassMethodName.equals(MagentoPhpClass.CONSTRUCT_METHOD_NAME)) {
+                if (MagentoPhpClass.CONSTRUCT_METHOD_NAME.equals(targetClassMethodName)) {
                     problemsHolder.registerProblem(
                             pluginMethod.getNameIdentifier(),
                             inspectionBundle.message("inspection.plugin.error.constructMethod"),
@@ -167,7 +166,7 @@ public class PluginInspection extends PhpInspection {
                             ProblemHighlightType.ERROR
                     );
                 }
-                if (!targetMethod.getAccess().toString().equals(AbstractPhpFile.PUBLIC_ACCESS)) {
+                if (!AbstractPhpFile.PUBLIC_ACCESS.equals(targetMethod.getAccess().toString())) {
                     problemsHolder.registerProblem(
                             pluginMethod.getNameIdentifier(),
                             inspectionBundle.message("inspection.plugin.error.nonPublicMethod"),
@@ -279,7 +278,7 @@ public class PluginInspection extends PhpInspection {
                         if (declaredType.isEmpty()) {
                             continue;
                         }
-                        if (!declaredType.equals(MagentoPhpClass.PHP_NULL)) {
+                        if (!MagentoPhpClass.PHP_NULL.equals(declaredType)) {
                             problemsHolder.registerProblem(
                                     pluginMethodParameter,
                                     PhpBundle.message(


### PR DESCRIPTION
**Description** (*)

Fixed empty psi elements in the plugin inspections.

**The bug is reproduced before fixing it:**

<img width="1448" alt="Screenshot 2021-11-30 at 15 29 18" src="https://user-images.githubusercontent.com/31848341/144068570-afbf1737-c94f-44ca-b991-4076ed74030a.png">

**The result of fixing:**

<img width="1293" alt="Screenshot 2021-11-30 at 15 47 04" src="https://user-images.githubusercontent.com/31848341/144069050-42c93685-cf45-4c95-bea9-409d1c3e4ab3.png">

**The same issue is found for the PHPStorm inspection:**

<img width="1409" alt="Screenshot 2021-11-30 at 15 32 02" src="https://user-images.githubusercontent.com/31848341/144068766-36b60280-7a2c-4408-8db4-942bcabb46a2.png">

**For clean testing it is should be disabled before testing bugfix:**

<img width="1098" alt="Screenshot 2021-11-30 at 15 31 29" src="https://user-images.githubusercontent.com/31848341/144068849-9d08a0cf-e39b-4bd9-b4b4-59bd1d0ee61d.png">

**I've opened an issue in the PHPStorm regarding mentioned PHPStorm inspection:**

https://youtrack.jetbrains.com/issue/WI-64186

**Fixed Issues (if relevant)**

1. Fixes magento/magento2-phpstorm-plugin#739

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
