### PR TITLE
[Bugfix:685] Fixed empty psi element in module xml inspection

### DIFF
--- a/src/com/magento/idea/magento2plugin/inspections/xml/ModuleDeclarationInModuleXmlInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/xml/ModuleDeclarationInModuleXmlInspection.java
@@ -28,20 +28,22 @@ import org.jetbrains.annotations.NotNull;
 
 public class ModuleDeclarationInModuleXmlInspection extends XmlSuppressableInspectionTool {
 
-    @NotNull
     @Override
-    public PsiElementVisitor buildVisitor(
+    public @NotNull PsiElementVisitor buildVisitor(
             final @NotNull ProblemsHolder problemsHolder,
             final boolean isOnTheFly
     ) {
         return new XmlElementVisitor() {
+
             @Override
             public void visitXmlAttributeValue(final XmlAttributeValue value) {
                 final PsiFile file = value.getContainingFile();
                 final String filename = file.getName();
-                if (!filename.equals(ModuleXml.FILE_NAME)) {
+
+                if (!ModuleXml.FILE_NAME.equals(filename)) {
                     return;
                 }
+
                 if (!IsFileInEditableModuleUtil.execute(file)) {
                     return;
                 }
@@ -49,21 +51,23 @@ public class ModuleDeclarationInModuleXmlInspection extends XmlSuppressableInspe
                 if (isSubTag(value, (XmlFile) file)) {
                     return;
                 }
-
                 final PsiDirectory etcDirectory = file.getParent();
+
                 if (etcDirectory == null) {
                     return;
                 }
-
                 final String attributeName = XmlAttributeValuePattern.getLocalName(value);
+
                 if (attributeName != null && attributeName.equals(ModuleXml.MODULE_ATTR_NAME)) {
                     final String expectedName
                             = GetEditableModuleNameByRootFileUtil.execute(etcDirectory);
                     final String actualName = value.getValue();
+
                     if (actualName.equals(expectedName)) {
                         return;
                     }
                     final InspectionBundle inspectionBundle = new InspectionBundle();
+
                     problemsHolder.registerProblem(
                             value,
                             inspectionBundle.message(
@@ -81,26 +85,27 @@ public class ModuleDeclarationInModuleXmlInspection extends XmlSuppressableInspe
 
     protected boolean isSubTag(final XmlAttributeValue value, final XmlFile file) {
         final XmlAttribute xmlAttribute = PsiTreeUtil.getParentOfType(value, XmlAttribute.class);
+
         if (xmlAttribute == null) {
             return true;
         }
-
         final XmlTag xmlTag = PsiTreeUtil.getParentOfType(xmlAttribute, XmlTag.class);
+
         if (xmlTag == null) {
             return true;
         }
-
         final XmlDocument xmlDocument = file.getDocument();
+
         if (xmlDocument == null) {
             return true;
         }
-
         final XmlTag xmlRootTag = xmlDocument.getRootTag();
+
         if (xmlRootTag == null) {
             return true;
         }
-
         final XmlTag rootTag = PsiTreeUtil.getParentOfType(xmlTag, XmlTag.class);
+
         return rootTag == null || !(rootTag.getName().equals(xmlRootTag.getName()));
     }
 }

--- a/src/com/magento/idea/magento2plugin/inspections/xml/ModuleDeclarationInModuleXmlInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/xml/ModuleDeclarationInModuleXmlInspection.java
@@ -63,7 +63,7 @@ public class ModuleDeclarationInModuleXmlInspection extends XmlSuppressableInspe
                             = GetEditableModuleNameByRootFileUtil.execute(etcDirectory);
                     final String actualName = value.getValue();
 
-                    if (actualName.equals(expectedName)) {
+                    if (actualName.equals(expectedName) || actualName.trim().isEmpty()) {
                         return;
                     }
                     final InspectionBundle inspectionBundle = new InspectionBundle();


### PR DESCRIPTION
**Description** (*)

Fixed empty PSI elements must not be passed to createDescriptor for the ModuleDeclarationInModuleXmlInspection inspection.

**The bug was reproduced before fixing it:**

<img width="1262" alt="Screenshot 2021-11-30 at 16 59 51" src="https://user-images.githubusercontent.com/31848341/144084038-a77d8796-1655-4791-88fa-e0f32e9c32d5.png">

**The result after the bug fixing:**

<img width="868" alt="Screenshot 2021-11-30 at 17 06 09" src="https://user-images.githubusercontent.com/31848341/144084095-3fe94d2f-7ecc-4508-b967-0f03fba51e51.png">

**Fixed Issues (if relevant)**

1. Fixes magento/magento2-phpstorm-plugin#685

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
