### PR TITLE
[Bug] 626: Fixed Invalid column types provided exception during db_schema.xml file generation

### DIFF
--- a/resources/magento2/validation.properties
+++ b/resources/magento2/validation.properties
@@ -38,3 +38,4 @@ validator.db.invalidTableNameLength=Table name must contain up to 64 characters 
 validator.lowerSnakeCase=The {0} field must be of the lower snake case format
 validator.menuIdentifierInvalid=The menu identifier is invalid
 validator.someFieldsHaveErrors=Please, check the dialog. Some fields have errors
+validator.dbSchema.invalidColumnType=Invalid ''{0}'' column type specified

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDbSchemaDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDbSchemaDialog.java
@@ -7,6 +7,7 @@ package com.magento.idea.magento2plugin.actions.generation.dialog;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDirectory;
+import com.intellij.psi.PsiFile;
 import com.magento.idea.magento2plugin.actions.generation.NewDbSchemaAction;
 import com.magento.idea.magento2plugin.actions.generation.data.DbSchemaXmlData;
 import com.magento.idea.magento2plugin.actions.generation.data.ui.ComboBoxItemData;
@@ -143,7 +144,11 @@ public class NewDbSchemaDialog extends AbstractDialog {
                     getTableComment(),
                     getColumns()
             );
-            generateDbSchemaXmlFile(dbSchemaXmlData);
+            final PsiFile dbSchemaXmlFile = generateDbSchemaXmlFile(dbSchemaXmlData);
+
+            if (dbSchemaXmlFile == null) {
+                return;
+            }
             generateWhitelistJsonFile(dbSchemaXmlData);
         }
         exit();
@@ -170,8 +175,8 @@ public class NewDbSchemaDialog extends AbstractDialog {
      *
      * @param dbSchemaXmlData DbSchemaXmlData
      */
-    private void generateDbSchemaXmlFile(final @NotNull DbSchemaXmlData dbSchemaXmlData) {
-        new DbSchemaXmlGenerator(
+    private PsiFile generateDbSchemaXmlFile(final @NotNull DbSchemaXmlData dbSchemaXmlData) {
+        return new DbSchemaXmlGenerator(
                 dbSchemaXmlData,
                 project,
                 moduleName


### PR DESCRIPTION
**Description** (*)

Fixed Invalid column types provided exception during db_schema.xml file generation.

**Bug was successfully reproduced before fixing it:**

<img width="1009" alt="Screenshot 2021-11-30 at 21 05 45" src="https://user-images.githubusercontent.com/31848341/144123189-35f413da-699a-40f6-a3d9-8555ef314181.png">
<img width="1170" alt="Screenshot 2021-11-30 at 21 06 31" src="https://user-images.githubusercontent.com/31848341/144123145-baf6523c-3cc7-44cb-96a9-42b93914d932.png">

**The results after the bug fixing:**

![fixed-db-schema-xml-generation-min](https://user-images.githubusercontent.com/31848341/144123299-4bbd72e1-7532-4c08-acd5-6f14e245bca4.gif)

**Fixed Issues (if relevant)**

1. Fixes magento/magento2-phpstorm-plugin#626

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
