### PR TITLE
633: Fixed NoSuchElementException when creating new controller

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewControllerDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewControllerDialog.java
@@ -249,12 +249,13 @@ public class NewControllerDialog extends AbstractDialog {
         );
 
         return String.format(
-                "%s%s%s%s%s%s",
+                "%s%s%s%s%s%s%s",
                 parts[0],
                 Package.fqnSeparator,
                 parts[1],
                 Package.fqnSeparator,
                 directoryPart,
+                Package.fqnSeparator,
                 controllerPart
         );
     }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/CLICommandClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/CLICommandClassGenerator.java
@@ -18,6 +18,7 @@ import com.magento.idea.magento2plugin.indexes.ModuleIndex;
 import com.magento.idea.magento2plugin.magento.files.CLICommandTemplate;
 import java.util.Properties;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings({
         "PMD.AvoidUncheckedExceptionsInSignatures",
@@ -69,11 +70,17 @@ public class CLICommandClassGenerator extends FileGenerator {
         return cliCommandFile;
     }
 
-    private PhpFile createCLICommandClass(final String actionName) {
+    private @Nullable PhpFile createCLICommandClass(final String actionName) {
+        final PsiDirectory parentDirectory = getParentDirectory();
+
+        if (parentDirectory == null) {
+            return null;
+        }
+
         final PsiFile cliCommandFile = fileGenerator.generate(
                 this.getCLICommandTemplate(),
                 getAttributes(),
-                this.getParentDirectory(),
+                parentDirectory,
                 actionName
         );
 
@@ -82,9 +89,14 @@ public class CLICommandClassGenerator extends FileGenerator {
 
     private PsiDirectory getParentDirectory() {
         final String moduleName = this.phpClassData.getModuleName();
-        final String[] subDirectories = this.phpClassData.getParentDirectory().split("/");
         PsiDirectory parentDirectory = new ModuleIndex(project)
                 .getModuleDirectoryByModuleName(moduleName);
+
+        if (parentDirectory == null) {
+            return null;
+        }
+        final String[] subDirectories = this.phpClassData.getParentDirectory().split("/");
+
         for (final String subDirectory : subDirectories) {
             parentDirectory = dirGenerator.findOrCreateSubdirectory(parentDirectory, subDirectory);
         }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/CronjobClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/CronjobClassGenerator.java
@@ -89,11 +89,15 @@ public class CronjobClassGenerator extends FileGenerator {
      * @return PhpFile
      */
     private PhpFile createCronjobClass(final String actionName) {
-        final String cronjobClassName = this.cronjobClassData.getClassName();
         final String moduleName = this.cronjobClassData.getModuleName();
-        final String[] cronjobSubDirectories = this.cronjobClassData.getDirectory().split("/");
         PsiDirectory parentDirectory = new ModuleIndex(project)
                 .getModuleDirectoryByModuleName(moduleName);
+
+        if (parentDirectory == null) {
+            return null;
+        }
+        final String cronjobClassName = this.cronjobClassData.getClassName();
+        final String[] cronjobSubDirectories = this.cronjobClassData.getDirectory().split("/");
 
         for (final String cronjobSubDirectory: cronjobSubDirectories) {
             parentDirectory = directoryGenerator

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/MessageQueueClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/MessageQueueClassGenerator.java
@@ -114,6 +114,10 @@ public class MessageQueueClassGenerator extends FileGenerator {
     private PhpClass createHandlerClass(final String actionName) {
         PsiDirectory parentDirectory = new ModuleIndex(project)
                 .getModuleDirectoryByModuleName(this.moduleName);
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final PsiFile handlerFile;
         final String[] handlerDirectories = messageQueueClassDataName.getPath().split(
                 File.separator

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleBlockClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleBlockClassGenerator.java
@@ -58,6 +58,7 @@ public class ModuleBlockClassGenerator extends FileGenerator {
      * @param actionName String
      * @return PsiFile
      */
+    @Override
     public PsiFile generate(final String actionName) {
         final String errorTitle = commonBundle.message("common.error");
         final PhpClass block = GetPhpClassByFQN.getInstance(project).execute(getBlockFqn());
@@ -106,7 +107,12 @@ public class ModuleBlockClassGenerator extends FileGenerator {
     private PhpFile createBlockClass(final String actionName) {
         PsiDirectory parentDirectory = new ModuleIndex(project)
                 .getModuleDirectoryByModuleName(getBlockModule());
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final String[] blockDirectories = blockFileData.getBlockDirectory().split(File.separator);
+
         for (final String blockDirectory: blockDirectories) {
             parentDirectory = directoryGenerator.findOrCreateSubdirectory(
                 parentDirectory,
@@ -127,6 +133,7 @@ public class ModuleBlockClassGenerator extends FileGenerator {
         return (PhpFile) blockFile;
     }
 
+    @Override
     protected void fillAttributes(final Properties attributes) {
         final String blockClassName = blockFileData.getBlockClassName();
         attributes.setProperty("NAME", blockClassName);

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleComposerJsonGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleComposerJsonGenerator.java
@@ -10,6 +10,7 @@ import com.google.gson.JsonParser;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiFile;
 import com.magento.idea.magento2plugin.actions.generation.data.ModuleComposerJsonData;
 import com.magento.idea.magento2plugin.actions.generation.generator.data.ModuleDirectoriesData;
@@ -120,8 +121,8 @@ public class ModuleComposerJsonGenerator extends FileGenerator {
         final Object[] dependencies = dependenciesList.toArray();
         result = result.concat(ComposerJson.DEFAULT_DEPENDENCY);
         final boolean noDependency =
-                dependencies.length == 1 && dependencies[0].equals(
-                        ComposerJson.NO_DEPENDENCY_LABEL
+                dependencies.length == 1 && ComposerJson.NO_DEPENDENCY_LABEL.equals(
+                        dependencies[0]
                 );
         if (dependencies.length == 0 || noDependency) {
             result = result.concat("\n");
@@ -161,8 +162,12 @@ public class ModuleComposerJsonGenerator extends FileGenerator {
                 "_-", "/"
         );
         try {
-            final PsiFile virtualFile = moduleIndex.getModuleDirectoryByModuleName(dependency)
-                    .findFile(ComposerJson.FILE_NAME);
+            final PsiDirectory moduleDir = moduleIndex.getModuleDirectoryByModuleName(dependency);
+
+            if (moduleDir == null) {
+                return Pair.create("", "");
+            }
+            final PsiFile virtualFile = moduleDir.findFile(ComposerJson.FILE_NAME);
 
             if (virtualFile != null) { //NOPMD
                 final VirtualFile composerJsonFile = virtualFile.getVirtualFile();

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleControllerClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleControllerClassGenerator.java
@@ -148,6 +148,10 @@ public class ModuleControllerClassGenerator extends FileGenerator {
     private PhpClass createControllerClass(final String actionName) {
         PsiDirectory parentDirectory = new ModuleIndex(project)
                 .getModuleDirectoryByModuleName(getControllerModule());
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final PsiFile controllerFile;
         final String[] controllerDirectories = data.getActionDirectory().split(
                 File.separator

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleEmailTemplateHtmlGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleEmailTemplateHtmlGenerator.java
@@ -51,6 +51,7 @@ public class ModuleEmailTemplateHtmlGenerator extends FileGenerator {
      * @param actionName Action name
      * @return PsiFile
      */
+    @Override
     public PsiFile generate(final String actionName) {
         final PsiFile templateFile = FileBasedIndexUtil.findModuleViewFile(
                 this.emailTemplateData.getFileName(),
@@ -67,6 +68,10 @@ public class ModuleEmailTemplateHtmlGenerator extends FileGenerator {
         PsiDirectory parentDirectory = this.moduleIndex.getModuleDirectoryByModuleName(
                 this.emailTemplateData.getModule()
         );
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final ArrayList<String> fileDirectories = new ArrayList<>();
 
         fileDirectories.add(Package.moduleViewDir);
@@ -96,7 +101,7 @@ public class ModuleEmailTemplateHtmlGenerator extends FileGenerator {
         attributes.setProperty("SUBJECT", emailTemplateData.getSubject());
         attributes.setProperty("TYPE", emailTemplateData.getType());
 
-        if (emailTemplateData.getType().equals(EmailTemplateHtml.HTML_TYPE)) {
+        if (EmailTemplateHtml.HTML_TYPE.equals(emailTemplateData.getType())) {
             attributes.setProperty("HTML_TYPE", "true");
         }
     }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleGraphQlResolverClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleGraphQlResolverClassGenerator.java
@@ -117,7 +117,7 @@ public class ModuleGraphQlResolverClassGenerator extends FileGenerator {
                 LeafPsiElement.class
         );
         for (final LeafPsiElement leafPsiElement: leafElements) {
-            if (!leafPsiElement.getText().equals(MagentoPhpClass.CLOSING_TAG)) {
+            if (!MagentoPhpClass.CLOSING_TAG.equals(leafPsiElement.getText())) {
                 continue;
             }
             insertPos = leafPsiElement.getTextOffset();
@@ -128,6 +128,10 @@ public class ModuleGraphQlResolverClassGenerator extends FileGenerator {
     private PhpClass createGraphQlResolverClass(final String actionName) {
         PsiDirectory parentDirectory = new ModuleIndex(project)
                 .getModuleDirectoryByModuleName(graphQlResolverFileData.getGraphQlResolverModule());
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final String[] graphQlResolverDirectories = graphQlResolverFileData
                 .getGraphQlResolverDirectory().split(File.separator);
         for (final String graphQlResolverDirectory: graphQlResolverDirectories) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleViewModelClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleViewModelClassGenerator.java
@@ -58,6 +58,7 @@ public class ModuleViewModelClassGenerator extends FileGenerator {
      * @param actionName String
      * @return PsiFile
      */
+    @Override
     public PsiFile generate(final String actionName) {
         final PhpClass block = GetPhpClassByFQN.getInstance(project).execute(getViewModelFqn());
         final String errorTitle = commonBundle.message("common.error");
@@ -106,6 +107,10 @@ public class ModuleViewModelClassGenerator extends FileGenerator {
     private PhpFile createViewModelClass(final String actionName) {
         PsiDirectory parentDirectory = new ModuleIndex(project)
                 .getModuleDirectoryByModuleName(getViewModelModule());
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final String[] viewModelDirectories = viewModelFileData.getViewModelDirectory()
                 .split(File.separator);
         for (final String viewModelDirectory: viewModelDirectories) {
@@ -128,6 +133,7 @@ public class ModuleViewModelClassGenerator extends FileGenerator {
         return (PhpFile) viewModelFile;
     }
 
+    @Override
     protected void fillAttributes(final Properties attributes) {
         final String viewModelClassName = viewModelFileData.getViewModelClassName();
         attributes.setProperty("NAME", viewModelClassName);

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/NewEntityLayoutGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/NewEntityLayoutGenerator.java
@@ -88,6 +88,10 @@ public class NewEntityLayoutGenerator extends FileGenerator {
         final PsiDirectory moduleBaseDir = moduleIndex.getModuleDirectoryByModuleName(
                 data.getModuleName()
         );
+
+        if (moduleBaseDir == null) {
+            return null;
+        }
         final PsiDirectory layoutBaseDir = directoryGenerator.findOrCreateSubdirectories(
                 moduleBaseDir,
                 file.getDirectory()

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ObserverClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ObserverClassGenerator.java
@@ -122,7 +122,7 @@ public class ObserverClassGenerator extends FileGenerator {
                 LeafPsiElement.class
         );
         for (final LeafPsiElement leafPsiElement: leafElements) {
-            if (!leafPsiElement.getText().equals(MagentoPhpClass.CLOSING_TAG)) {
+            if (!MagentoPhpClass.CLOSING_TAG.equals(leafPsiElement.getText())) {
                 continue;
             }
             insertPos = leafPsiElement.getTextOffset();
@@ -133,6 +133,10 @@ public class ObserverClassGenerator extends FileGenerator {
     private PhpClass createObserverClass(final String actionName) {
         PsiDirectory parentDirectory = new ModuleIndex(project)
                 .getModuleDirectoryByModuleName(observerFileData.getObserverModule());
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final String[] observerDirectories = observerFileData.getObserverDirectory()
                 .split(File.separator);
         for (final String observerDirectory: observerDirectories) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/OverrideInThemeGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/OverrideInThemeGenerator.java
@@ -69,6 +69,10 @@ public class OverrideInThemeGenerator {
 
         final ModuleIndex moduleIndex = new ModuleIndex(project);
         PsiDirectory directory = moduleIndex.getModuleDirectoryByModuleName(themeName);
+
+        if (directory == null) {
+            return;
+        }
         directory = getTargetDirectory(directory, pathComponents);
 
         if (directory.findFile(baseFile.getName()) != null) {
@@ -134,11 +138,13 @@ public class OverrideInThemeGenerator {
             PsiDirectory directory, //NOPMD
             final List<String> pathComponents
     ) {
+        PsiDirectory result = directory;
         final DirectoryGenerator generator = DirectoryGenerator.getInstance();
+
         for (final String directoryName : pathComponents) {
-            directory = generator.findOrCreateSubdirectory(directory, directoryName);
+            result = generator.findOrCreateSubdirectory(directory, directoryName);
         }
 
-        return directory;
+        return result;
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/PhpFileGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/PhpFileGenerator.java
@@ -77,8 +77,16 @@ public abstract class PhpFileGenerator extends FileGenerator {
             return phpClass.getContainingFile();
         }
 
+        final PsiDirectory moduleDirectory = moduleIndex.getModuleDirectoryByModuleName(
+                file.getModuleName()
+        );
+
+        if (moduleDirectory == null) {
+            onFileGenerated(null, actionName);
+            return null;
+        }
         final PsiDirectory fileBaseDir = directoryGenerator.findOrCreateSubdirectories(
-                moduleIndex.getModuleDirectoryByModuleName(file.getModuleName()),
+                moduleDirectory,
                 file.getDirectory()
         );
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/PluginClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/PluginClassGenerator.java
@@ -88,6 +88,7 @@ public class PluginClassGenerator extends FileGenerator {
      *
      * @return PsiFile
      */
+    @SuppressWarnings("PMD.CognitiveComplexity")
     @Override
     public PsiFile generate(final String actionName) {
         final PsiFile[] pluginFile = {null};
@@ -206,6 +207,10 @@ public class PluginClassGenerator extends FileGenerator {
     private PhpClass createPluginClass(final String actionName) {
         PsiDirectory parentDirectory = new ModuleIndex(project)
                 .getModuleDirectoryByModuleName(getPluginModule());
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final String[] pluginDirectories = pluginFileData.getPluginDirectory()
                 .split(File.separator);
         for (final String pluginDirectory: pluginDirectories) {
@@ -262,7 +267,7 @@ public class PluginClassGenerator extends FileGenerator {
         }
 
         for (final LeafPsiElement leafPsiElement: leafElements) {
-            if (!leafPsiElement.getText().equals(MagentoPhpClass.CLOSING_TAG)) {
+            if (!MagentoPhpClass.CLOSING_TAG.equals(leafPsiElement.getText())) {
                 continue;
             }
             insertPos = leafPsiElement.getTextOffset();

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/PreferenceClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/PreferenceClassGenerator.java
@@ -82,6 +82,10 @@ public class PreferenceClassGenerator extends FileGenerator {
     private PhpClass createPluginClass(final String actionName) {
         PsiDirectory parentDirectory = new ModuleIndex(project)
                 .getModuleDirectoryByModuleName(getPreferenceModule());
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final String[] pluginDirectories = preferenceFileData.getPreferenceDirectory()
                 .split(File.separator);
         for (final String pluginDirectory: pluginDirectories) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/QueryGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/QueryGenerator.java
@@ -117,6 +117,10 @@ public class QueryGenerator extends FileGenerator {
     private PhpClass createDataProviderClass(final @NotNull String actionName) {
         final PsiDirectory parentDirectory = new ModuleIndex(project)
                 .getModuleDirectoryByModuleName(this.moduleName);
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final PsiDirectory dataProviderDirectory =
                 directoryGenerator.findOrCreateSubdirectories(parentDirectory, data.getPath());
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/UiComponentFormButtonBlockGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/UiComponentFormButtonBlockGenerator.java
@@ -123,6 +123,10 @@ public class UiComponentFormButtonBlockGenerator extends FileGenerator {
         final PsiDirectory moduleBaseDir = moduleIndex.getModuleDirectoryByModuleName(
                 buttonData.getButtonModule()
         );
+
+        if (moduleBaseDir == null) {
+            return null;
+        }
         final PsiDirectory baseDirectory = directoryGenerator.findOrCreateSubdirectories(
                 moduleBaseDir,
                 buttonData.getButtonDirectory()

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/UiComponentFormGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/UiComponentFormGenerator.java
@@ -92,14 +92,16 @@ public class UiComponentFormGenerator extends FileGenerator {
     protected PsiFile createForm(
             final String actionName
     ) {
-        final DirectoryGenerator directoryGenerator = DirectoryGenerator.getInstance();
-        final FileFromTemplateGenerator fileFromTemplateGenerator =
-                new FileFromTemplateGenerator(project);
-
         final String moduleName = data.getModuleName();
         final PsiDirectory parentDirectory = new ModuleIndex(project)
                 .getModuleDirectoryByModuleName(moduleName);
 
+        if (parentDirectory == null) {
+            return null;
+        }
+        final DirectoryGenerator directoryGenerator = DirectoryGenerator.getInstance();
+        final FileFromTemplateGenerator fileFromTemplateGenerator =
+                new FileFromTemplateGenerator(project);
         final ArrayList<String> fileDirectories = new ArrayList<>();
         fileDirectories.add(Package.moduleViewDir);
         final String area = data.getFormArea();

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/UiComponentGridXmlGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/UiComponentGridXmlGenerator.java
@@ -67,6 +67,9 @@ public class UiComponentGridXmlGenerator extends FileGenerator {
         final PsiDirectory parentDirectory = moduleIndex.getModuleDirectoryByModuleName(
                 moduleName
         );
+        if (parentDirectory == null) {
+            return null;
+        }
         final String subdirectory = String.format(
                 "%s/%s/%s",
                 Package.moduleViewDir,

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateAclXml.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateAclXml.java
@@ -31,12 +31,15 @@ public final class FindOrCreateAclXml {
      * @return PsiFile
      */
     public PsiFile execute(final String actionName, final String moduleName) {
+        PsiDirectory parentDirectory = new ModuleIndex(project)
+                .getModuleDirectoryByModuleName(moduleName);
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final DirectoryGenerator directoryGenerator = DirectoryGenerator.getInstance();
         final FileFromTemplateGenerator fileFromTemplateGenerator =
                 new FileFromTemplateGenerator(project);
-
-        PsiDirectory parentDirectory = new ModuleIndex(project)
-                .getModuleDirectoryByModuleName(moduleName);
         parentDirectory = directoryGenerator
                 .findOrCreateSubdirectory(parentDirectory, Package.moduleBaseAreaDir);
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateCronGroupXml.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateCronGroupXml.java
@@ -45,6 +45,10 @@ public class FindOrCreateCronGroupXml {
      */
     public PsiFile execute(final String actionName, final String moduleName) {
         PsiDirectory parentDirectory = this.moduleIndex.getModuleDirectoryByModuleName(moduleName);
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final ArrayList<String> fileDirectories = new ArrayList<>();
 
         fileDirectories.add(Package.moduleBaseAreaDir);

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateCrontabXml.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateCrontabXml.java
@@ -45,6 +45,10 @@ public class FindOrCreateCrontabXml {
      */
     public PsiFile execute(final String actionName, final String moduleName) {
         PsiDirectory parentDirectory = this.moduleIndex.getModuleDirectoryByModuleName(moduleName);
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final ArrayList<String> fileDirectories = new ArrayList<>();
 
         fileDirectories.add(Package.moduleBaseAreaDir);

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateDbSchemaWhitelistJson.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateDbSchemaWhitelistJson.java
@@ -54,6 +54,10 @@ public class FindOrCreateDbSchemaWhitelistJson {
         if (dbSchemaWhitelistJson == null) {
             PsiDirectory parentDirectory = new ModuleIndex(project)
                     .getModuleDirectoryByModuleName(moduleName);
+
+            if (parentDirectory == null) {
+                return null;
+            }
             parentDirectory = directoryGenerator
                     .findOrCreateSubdirectory(parentDirectory, Package.moduleBaseAreaDir);
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateDbSchemaXmlUtil.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateDbSchemaXmlUtil.java
@@ -31,12 +31,15 @@ public final class FindOrCreateDbSchemaXmlUtil {
      * @return PsiFile
      */
     public PsiFile execute(final String actionName, final String moduleName) {
+        PsiDirectory parentDirectory = new ModuleIndex(project)
+                .getModuleDirectoryByModuleName(moduleName);
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final DirectoryGenerator directoryGenerator = DirectoryGenerator.getInstance();
         final FileFromTemplateGenerator fileFromTemplateGenerator =
                 new FileFromTemplateGenerator(project);
-
-        PsiDirectory parentDirectory = new ModuleIndex(project)
-                .getModuleDirectoryByModuleName(moduleName);
         parentDirectory = directoryGenerator
                 .findOrCreateSubdirectory(parentDirectory, Package.moduleBaseAreaDir);
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateDiXml.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateDiXml.java
@@ -32,12 +32,15 @@ public final class FindOrCreateDiXml {
      * @return PsiFile
      */
     public PsiFile execute(final String actionName, final String moduleName, final String area) {
+        PsiDirectory parentDirectory = new ModuleIndex(project)
+                .getModuleDirectoryByModuleName(moduleName);
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final DirectoryGenerator directoryGenerator = DirectoryGenerator.getInstance();
         final FileFromTemplateGenerator fileFromTemplateGenerator =
                 new FileFromTemplateGenerator(project);
-
-        PsiDirectory parentDirectory = new ModuleIndex(project)
-                .getModuleDirectoryByModuleName(moduleName);
         final ArrayList<String> fileDirectories = new ArrayList<>();
         fileDirectories.add(Package.moduleBaseAreaDir);
         if (!getArea(area).equals(Areas.base)) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateEmailTemplatesXml.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateEmailTemplatesXml.java
@@ -45,6 +45,10 @@ public class FindOrCreateEmailTemplatesXml {
      */
     public PsiFile execute(final String actionName, final String moduleName) {
         PsiDirectory parentDirectory = this.moduleIndex.getModuleDirectoryByModuleName(moduleName);
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final ArrayList<String> fileDirectories = new ArrayList<>();
 
         fileDirectories.add(Package.moduleBaseAreaDir);

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateEventsXml.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateEventsXml.java
@@ -36,11 +36,15 @@ public class FindOrCreateEventsXml {
             final String moduleName,
             final String area
     ) {
+        PsiDirectory parentDirectory = new ModuleIndex(project)
+                .getModuleDirectoryByModuleName(moduleName);
+        if (parentDirectory == null) {
+            return null;
+        }
+
         final DirectoryGenerator directoryGenerator = DirectoryGenerator.getInstance();
         final FileFromTemplateGenerator fileFromTemplateGenerator =
                 new FileFromTemplateGenerator(project);
-        PsiDirectory parentDirectory = new ModuleIndex(project)
-                .getModuleDirectoryByModuleName(moduleName);
         final ArrayList<String> fileDirectories = new ArrayList<>();
         fileDirectories.add(Package.moduleBaseAreaDir);
         if (!getArea(area).equals(Areas.base)) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateLayoutXml.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateLayoutXml.java
@@ -43,12 +43,15 @@ public final class FindOrCreateLayoutXml {
             final String moduleName,
             final String area
     ) {
+        PsiDirectory parentDirectory = new ModuleIndex(project)
+                .getModuleDirectoryByModuleName(moduleName);
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final DirectoryGenerator directoryGenerator = DirectoryGenerator.getInstance();
         final FileFromTemplateGenerator fileFromTemplateGenerator =
                 new FileFromTemplateGenerator(project);
-
-        PsiDirectory parentDirectory = new ModuleIndex(project)
-                .getModuleDirectoryByModuleName(moduleName);
         final ArrayList<String> fileDirectories = new ArrayList<>();
         fileDirectories.add(Package.moduleViewDir);
         fileDirectories.add(getArea(area).toString());

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateMenuXml.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateMenuXml.java
@@ -31,12 +31,15 @@ public final class FindOrCreateMenuXml {
      * @return PsiFile
      */
     public PsiFile execute(final String actionName, final String moduleName) {
+        PsiDirectory parentDirectory = new ModuleIndex(project)
+                .getModuleDirectoryByModuleName(moduleName);
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final DirectoryGenerator directoryGenerator = DirectoryGenerator.getInstance();
         final FileFromTemplateGenerator fileFromTemplateGenerator =
                 new FileFromTemplateGenerator(project);
-
-        PsiDirectory parentDirectory = new ModuleIndex(project)
-                .getModuleDirectoryByModuleName(moduleName);
         final ArrayList<String> fileDirectories = new ArrayList<>();
         fileDirectories.add(Package.moduleBaseAreaDir);
         fileDirectories.add(Areas.adminhtml.toString());

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateQueueXml.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateQueueXml.java
@@ -38,6 +38,10 @@ public abstract class FindOrCreateQueueXml {
      */
     public PsiFile execute(final String actionName, final String moduleName) {
         PsiDirectory parentDirectory = this.moduleIndex.getModuleDirectoryByModuleName(moduleName);
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final ArrayList<String> fileDirectories = new ArrayList<>();
 
         fileDirectories.add(Package.moduleBaseAreaDir);

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateRoutesXml.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FindOrCreateRoutesXml.java
@@ -32,12 +32,15 @@ public final class FindOrCreateRoutesXml {
      * @return PsiFile
      */
     public PsiFile execute(final String actionName, final String moduleName, final String area) {
+        PsiDirectory parentDirectory = new ModuleIndex(project)
+                .getModuleDirectoryByModuleName(moduleName);
+
+        if (parentDirectory == null) {
+            return null;
+        }
         final DirectoryGenerator directoryGenerator = DirectoryGenerator.getInstance();
         final FileFromTemplateGenerator fileFromTemplateGenerator =
                 new FileFromTemplateGenerator(project);
-
-        PsiDirectory parentDirectory = new ModuleIndex(project)
-                .getModuleDirectoryByModuleName(moduleName);
         final ArrayList<String> fileDirectories = new ArrayList<>();
         fileDirectories.add(Package.moduleBaseAreaDir);
         fileDirectories.add(getArea(area).toString());

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/xml/WebApiDeclarationGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/xml/WebApiDeclarationGenerator.java
@@ -75,6 +75,19 @@ public final class WebApiDeclarationGenerator extends FileGenerator {
     public PsiFile generate(final @NotNull String actionName) {
         final PsiDirectory moduleDirectory =
                 new ModuleIndex(project).getModuleDirectoryByModuleName(data.getModuleName());
+
+        if (moduleDirectory == null) {
+            JOptionPane.showMessageDialog(
+                    null,
+                    validatorBundle.message(
+                            "validator.file.cantBeCreated",
+                            "Web API XML file"
+                    ),
+                    commonBundle.message("common.error"),
+                    JOptionPane.ERROR_MESSAGE
+            );
+            return null;
+        }
         final PsiDirectory fileDirectory =
                 directoryGenerator.findOrCreateSubdirectory(
                         moduleDirectory,

--- a/src/com/magento/idea/magento2plugin/actions/groups/NewModuleFileGroup.java
+++ b/src/com/magento/idea/magento2plugin/actions/groups/NewModuleFileGroup.java
@@ -14,6 +14,7 @@ import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiElement;
 import com.magento.idea.magento2plugin.MagentoIcons;
 import com.magento.idea.magento2plugin.actions.generation.util.IsClickedDirectoryInsideProject;
+import com.magento.idea.magento2plugin.indexes.ModuleIndex;
 import com.magento.idea.magento2plugin.project.Settings;
 import com.magento.idea.magento2plugin.util.magento.GetModuleNameByDirectoryUtil;
 import javax.swing.Icon;
@@ -45,7 +46,10 @@ public class NewModuleFileGroup extends NonTrivialActionGroup {
         }
 
         final Project project = event.getData(PlatformDataKeys.PROJECT);
-        if (!IsClickedDirectoryInsideProject.getInstance()
+
+        if (project == null
+                || !Settings.isEnabled(project)
+                || !IsClickedDirectoryInsideProject.getInstance()
                 .execute(project, (PsiDirectory) psiElement)) {
             event.getPresentation().setVisible(false);
             return;
@@ -53,10 +57,17 @@ public class NewModuleFileGroup extends NonTrivialActionGroup {
 
         final String moduleName = GetModuleNameByDirectoryUtil
                 .execute((PsiDirectory) psiElement, project);
-        if (Settings.isEnabled(project) && moduleName != null) {
-            event.getPresentation().setVisible(true);
-            return;
+
+        if (moduleName != null) {
+            final PsiDirectory moduleDirectory = new ModuleIndex(project)
+                    .getModuleDirectoryByModuleName(moduleName);
+
+            if (moduleDirectory != null) {
+                event.getPresentation().setVisible(true);
+                return;
+            }
         }
+
         event.getPresentation().setVisible(false);
     }
 }

--- a/src/com/magento/idea/magento2plugin/indexes/ModuleIndex.java
+++ b/src/com/magento/idea/magento2plugin/indexes/ModuleIndex.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.jetbrains.annotations.Nullable;
 
 public final class ModuleIndex {
 
@@ -116,7 +117,7 @@ public final class ModuleIndex {
      * @param moduleName String
      * @return PsiDirectory
      */
-    public PsiDirectory getModuleDirectoryByModuleName(final String moduleName) {
+    public @Nullable PsiDirectory getModuleDirectoryByModuleName(final String moduleName) {
         final FileBasedIndex index = FileBasedIndex
                 .getInstance();
         final Collection<VirtualFile> files = index.getContainingFiles(
@@ -126,6 +127,10 @@ public final class ModuleIndex {
                     GlobalSearchScope.allScope(project),
                     PhpFileType.INSTANCE
             ));
+
+        if (files.isEmpty()) {
+            return null;
+        }
         final VirtualFile virtualFile = files.iterator().next();
 
         return PsiManager.getInstance(project).findDirectory(virtualFile.getParent());


### PR DESCRIPTION
**Description** (*)
Reproduced:
![image](https://user-images.githubusercontent.com/33068778/145852281-3018994a-9fa5-4b64-8756-f60137f89ff6.png)
**steps to reproduce:**
You need to specify the wrong type of module (the correct type is ComponentRegistrar::MODULE)
![image](https://user-images.githubusercontent.com/33068778/145852819-c8e99c89-5f3e-4c96-aea6-49dc4fd938d1.png)


**Fixed Issues (if relevant)**
the error has been fixed. If the module is not in the index, we do not show the dialog  window

1. Fixes magento/magento2-phpstorm-plugin#633

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
