### PR TITLE
698: Add "module" prefix to module name in composer.json

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModuleDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModuleDialog.java
@@ -264,9 +264,9 @@ public class NewModuleDialog extends AbstractDialog implements ListSelectionList
      * @return String
      */
     private String removeSubstringFormString(
-            @NotNull String target, @NotNull String replacement
+            final @NotNull String target, final @NotNull String replacement
     ) {
-        String moduleRegex = "(?i)" + target;
+        final String moduleRegex = "(?i)" + target;
         return replacement.replaceAll(moduleRegex, "");
     }
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModuleDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModuleDialog.java
@@ -53,6 +53,8 @@ public class NewModuleDialog extends AbstractDialog implements ListSelectionList
     private static final String MODULE_VERSION = "module version";
     private static final String MODULE_NAME = "module name";
     private static final String PACKAGE_NAME = "package name";
+    private static final String MAGENTO_BEFORE_DECLARATIVE_SCHEMA_VERSION = "2.2.11";
+    private static final String DEFAULT_MODULE_PREFIX = "module";
 
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
             message = {NotEmptyRule.MESSAGE, PACKAGE_NAME})
@@ -106,8 +108,6 @@ public class NewModuleDialog extends AbstractDialog implements ListSelectionList
     private String detectedPackageName;
     private final ModuleIndex moduleIndex;
     private final CamelCaseToHyphen camelCaseToHyphen;
-    private static final String MAGENTO_BEFORE_DECLARATIVE_SCHEMA_VERSION = "2.2.11";
-    private static final String DEFAULT_MODULE_PREFIX = "module";
 
     /**
      * Constructor.
@@ -252,22 +252,7 @@ public class NewModuleDialog extends AbstractDialog implements ListSelectionList
      * @return String
      */
     public String getModuleName() {
-        return this.removeSubstringFormString(
-                DEFAULT_MODULE_PREFIX, this.moduleName.getText().trim()
-        );
-    }
-
-    /**
-     * Remove substring from string.
-     * @param target String
-     * @param replacement String
-     * @return String
-     */
-    private String removeSubstringFormString(
-            final @NotNull String target, final @NotNull String replacement
-    ) {
-        final String moduleRegex = "(?i)" + target;
-        return replacement.replaceAll(moduleRegex, "");
+        return this.moduleName.getText().trim();
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModuleDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModuleDialog.java
@@ -246,17 +246,26 @@ public class NewModuleDialog extends AbstractDialog implements ListSelectionList
         return this.packageName.getText().trim();
     }
 
+    /**
+     * Getter for Module Name.
+     *
+     * @return String
+     */
     public String getModuleName() {
-        return this.removeSubstringFormString(DEFAULT_MODULE_PREFIX, this.moduleName.getText().trim());
+        return this.removeSubstringFormString(
+                DEFAULT_MODULE_PREFIX, this.moduleName.getText().trim()
+        );
     }
 
     /**
-     *
+     * Remove substring from string.
      * @param target String
      * @param replacement String
      * @return String
      */
-    private String removeSubstringFormString(@NotNull String target, @NotNull String replacement) {
+    private String removeSubstringFormString(
+            @NotNull String target, @NotNull String replacement
+    ) {
         String moduleRegex = "(?i)" + target;
         return replacement.replaceAll(moduleRegex, "");
     }

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModuleDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModuleDialog.java
@@ -107,6 +107,7 @@ public class NewModuleDialog extends AbstractDialog implements ListSelectionList
     private final ModuleIndex moduleIndex;
     private final CamelCaseToHyphen camelCaseToHyphen;
     private static final String MAGENTO_BEFORE_DECLARATIVE_SCHEMA_VERSION = "2.2.11";
+    private static final String DEFAULT_MODULE_PREFIX = "module";
 
     /**
      * Constructor.
@@ -246,7 +247,18 @@ public class NewModuleDialog extends AbstractDialog implements ListSelectionList
     }
 
     public String getModuleName() {
-        return this.moduleName.getText().trim();
+        return this.removeSubstringFormString(DEFAULT_MODULE_PREFIX, this.moduleName.getText().trim());
+    }
+
+    /**
+     *
+     * @param target String
+     * @param replacement String
+     * @return String
+     */
+    private String removeSubstringFormString(@NotNull String target, @NotNull String replacement) {
+        String moduleRegex = "(?i)" + target;
+        return replacement.replaceAll(moduleRegex, "");
     }
 
     /**
@@ -332,6 +344,7 @@ public class NewModuleDialog extends AbstractDialog implements ListSelectionList
     private String getComposerPackageName() {
         return camelCaseToHyphen.convert(getPackageName())
                 .concat("/")
+                .concat(DEFAULT_MODULE_PREFIX + "-")
                 .concat(camelCaseToHyphen.convert(getModuleName()));
     }
 

--- a/testData/actions/generation/generator/ModuleComposerJsonGenerator/generateFileInRoot/composer.json
+++ b/testData/actions/generation/generator/ModuleComposerJsonGenerator/generateFileInRoot/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "test/module",
+  "name": "test/module-test",
   "version": "1.0.0-dev",
   "description": "test-description",
   "type": "magento2-module",
@@ -17,7 +17,7 @@
       "registration.php"
     ],
     "psr-4": {
-      "TestWithDependencies\\Module\\": ""
+      "TestWithDependencies\\Test\\": ""
     }
   }
 }

--- a/testData/actions/generation/generator/ModuleComposerJsonGenerator/generateModuleFile/composer.json
+++ b/testData/actions/generation/generator/ModuleComposerJsonGenerator/generateModuleFile/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "test/module",
+  "name": "test/module-test",
   "version": "1.0.0-dev",
   "description": "test-description",
   "type": "magento2-module",
@@ -17,7 +17,7 @@
       "registration.php"
     ],
     "psr-4": {
-      "TestWithDependencies\\Module\\": ""
+      "TestWithDependencies\\Test\\": ""
     }
   }
 }

--- a/testData/actions/generation/generator/ModuleComposerJsonGenerator/generateModuleFileWithoutDependencies/composer.json
+++ b/testData/actions/generation/generator/ModuleComposerJsonGenerator/generateModuleFileWithoutDependencies/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "test/module",
+  "name": "test/module-test",
   "version": "1.0.0-dev",
   "description": "test-description",
   "type": "magento2-module",
@@ -15,7 +15,7 @@
       "registration.php"
     ],
     "psr-4": {
-      "TestWithoutDependencies\\Module\\": ""
+      "TestWithoutDependencies\\Test\\": ""
     }
   }
 }

--- a/tests/com/magento/idea/magento2plugin/actions/generation/generator/ModuleComposerJsonGeneratorTest.java
+++ b/tests/com/magento/idea/magento2plugin/actions/generation/generator/ModuleComposerJsonGeneratorTest.java
@@ -102,10 +102,10 @@ public class ModuleComposerJsonGeneratorTest extends BaseGeneratorTestCase {
         );
         final ModuleComposerJsonData composerJsonData = new ModuleComposerJsonData(
                 packageName,
-                "Module",
+                "Test",
                 projectDir,
                 "test-description",
-                "test/module",
+                "test/module-test",
                 "1.0.0-dev",
                 licenses,
                 dependencies,

--- a/tests/com/magento/idea/magento2plugin/actions/generation/generator/ModuleComposerJsonGeneratorTest.java
+++ b/tests/com/magento/idea/magento2plugin/actions/generation/generator/ModuleComposerJsonGeneratorTest.java
@@ -25,7 +25,7 @@ public class ModuleComposerJsonGeneratorTest extends BaseGeneratorTestCase {
         final PsiDirectory projectDir = getProjectDirectory();
 
         final String expectedDirectory =
-                projectDir.getVirtualFile().getPath() + "/TestWithDependencies/Module";
+                projectDir.getVirtualFile().getPath() + "/TestWithDependencies/Test";
         final PsiFile composerJson = generateComposerJson(
                 true,
                 projectDir,
@@ -65,7 +65,7 @@ public class ModuleComposerJsonGeneratorTest extends BaseGeneratorTestCase {
         final PsiFile expectedFile = myFixture.configureByFile(filePath);
         final PsiDirectory projectDir = getProjectDirectory();
         final String expectedDirectory = projectDir.getVirtualFile().getPath()
-                + "/TestWithoutDependencies/Module";
+                + "/TestWithoutDependencies/Test";
         final PsiFile composerJson = generateComposerJson(
                 true,
                 projectDir,


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description** (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
According to [Magento Devdocs](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/build/composer-integration.html#package-name) each module should be named with a module prefix in the composer.json. Added logic which adding prefix the module to package-name in composer.json

Issue was reproduced before fixing it:
When we create a new module and set Vendor_Test, it will be named vendor/test.
<img width="761" alt="Screenshot 2021-12-15 at 10 48 36" src="https://user-images.githubusercontent.com/30173454/146154819-c877be0f-1090-46d6-9d1e-68a160067c23.png">

The result after fixing it:
<img width="677" alt="Screenshot 2021-12-15 at 10 53 32" src="https://user-images.githubusercontent.com/30173454/146154858-ea624f2c-4dde-4c40-9157-c6f912033569.png">


**Fixed Issues (if relevant)**

1. Fixed [Add "module" prefix to module name in composer.json](https://github.com/magento/magento2-phpstorm-plugin/issues/698) #<698>


**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
