### PR TITLE
838: Fixed java.lang.NoClassDefFoundError for com.intellij.lang.jsgraphql.GraphQLIcons

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ intellij {
             'properties',
             'CSS',
             'JavaScriptLanguage',
-            'com.intellij.lang.jsgraphql:3.0.0',
+            'com.intellij.lang.jsgraphql:3.1.2',
             'platform-images',
             'copyright'
     ]
@@ -69,7 +69,7 @@ sourceSets {
 publishPlugin {
     token = System.getenv("MAGENTO_PHPSTORM_intellijPublishToken")
     if (Boolean.valueOf(System.getenv("MAGENTO_PHPSTORM_isAlpha"))) {
-        channels 'alpha'
+        channels = ['alpha']
         version = version + "-alpha-" + getDate()
     }
 }

--- a/src/com/magento/idea/magento2plugin/linemarker/php/GraphQlResolverUsageLineMarkerProvider.java
+++ b/src/com/magento/idea/magento2plugin/linemarker/php/GraphQlResolverUsageLineMarkerProvider.java
@@ -2,50 +2,51 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 package com.magento.idea.magento2plugin.linemarker.php;
 
 import com.intellij.codeInsight.daemon.LineMarkerInfo;
 import com.intellij.codeInsight.daemon.LineMarkerProvider;
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder;
-import com.intellij.lang.jsgraphql.GraphQLIcons;
+import com.intellij.lang.jsgraphql.icons.GraphQLIcons;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.magento.idea.magento2plugin.project.Settings;
 import com.magento.idea.magento2plugin.util.magento.graphql.GraphQlUsagesCollector;
 import com.magento.idea.magento2plugin.util.magento.graphql.GraphQlUtil;
+import java.util.Collection;
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
-import java.util.List;
-
 public class GraphQlResolverUsageLineMarkerProvider implements LineMarkerProvider {
-    @Nullable
+
     @Override
-    public LineMarkerInfo getLineMarkerInfo(@NotNull PsiElement psiElement) {
+    public @Nullable LineMarkerInfo<?> getLineMarkerInfo(final @NotNull PsiElement psiElement) {
         return null;
     }
 
     @Override
-    public void collectSlowLineMarkers(@NotNull List<? extends PsiElement> psiElements, @NotNull Collection<? super LineMarkerInfo<?>> collection) {
-        if (psiElements.size() > 0) {
-            if (!Settings.isEnabled(psiElements.get(0).getProject())) {
-                return;
-            }
+    public void collectSlowLineMarkers(
+            final @NotNull List<? extends PsiElement> psiElements,
+            final @NotNull Collection<? super LineMarkerInfo<?>> collection
+    ) {
+        if (!psiElements.isEmpty() && !Settings.isEnabled(psiElements.get(0).getProject())) {
+            return;
         }
 
-        for (PsiElement psiElement : psiElements) {
+        for (final PsiElement psiElement : psiElements) {
             if (psiElement instanceof PhpClass) {
-                List<? extends PsiElement> results;
-
                 if (!GraphQlUtil.isResolver((PhpClass) psiElement)) {
                     return;
                 }
-                GraphQlUsagesCollector collector = new GraphQlUsagesCollector();
-                results = collector.getGraphQLUsages((PhpClass) psiElement);
+                final GraphQlUsagesCollector collector = new GraphQlUsagesCollector();//NOPMD
+                final List<? extends PsiElement> results = collector.getGraphQLUsages(
+                        (PhpClass) psiElement
+                );
 
-                if (results.size() > 0 ) {
+                if (!results.isEmpty()) {
                     collection.add(NavigationGutterIconBuilder
                             .create(GraphQLIcons.FILE)
                             .setTargets(results)


### PR DESCRIPTION
**Description** (*)

Fixed java.lang.NoClassDefFoundError for com.intellij.lang.jsgraphql.GraphQLIcons.

**Successfully reproduced:**

<img width="1013" alt="Screenshot 2021-12-15 at 15 42 50" src="https://user-images.githubusercontent.com/31848341/146201385-19fa3bb8-bce7-4230-9026-63bed1162429.png">

**Result:**

<img width="1013" alt="Screenshot 2021-12-15 at 16 01 11" src="https://user-images.githubusercontent.com/31848341/146201429-1dc0f287-294a-47a7-a934-50a35e7354f2.png">

**Fixed Issues (if relevant)**

1. Fixes magento/magento2-phpstorm-plugin#838

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
