### PR TITLE
825: null pointer exception new cronjob dialog suggest cronjob name

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCronjobDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCronjobDialog.java
@@ -263,15 +263,19 @@ public class NewCronjobDialog extends AbstractDialog {
      * @return String
      */
     private String suggestCronjobName(final String cronjobClassname) {
+        if (moduleName == null) {
+            return "";
+        }
+
         if (cronjobClassname == null || cronjobClassname.isEmpty()) {
-            return this.moduleName.toLowerCase(new java.util.Locale("en","EN"));
+            return moduleName.toLowerCase(new java.util.Locale("en","EN"));
         }
 
         final String cronjobClassnameToSnakeCase = this.camelCaseToSnakeCase.convert(
                 cronjobClassname
         );
 
-        return this.moduleName.toLowerCase(new java.util.Locale("en","EN"))
+        return moduleName.toLowerCase(new java.util.Locale("en","EN"))
                 + "_"
                 + cronjobClassnameToSnakeCase;
     }

--- a/src/com/magento/idea/magento2plugin/util/magento/GetModuleNameByDirectoryUtil.java
+++ b/src/com/magento/idea/magento2plugin/util/magento/GetModuleNameByDirectoryUtil.java
@@ -16,6 +16,7 @@ import com.magento.idea.magento2plugin.magento.files.RegistrationPhp;
 import com.magento.idea.magento2plugin.util.RegExUtil;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class GetModuleNameByDirectoryUtil {
@@ -27,18 +28,21 @@ public final class GetModuleNameByDirectoryUtil {
      *
      * @param psiDirectory PsiDirectory
      * @param project Project
+     *
      * @return String
      */
-    public static String execute(
-            final PsiDirectory psiDirectory,
-            final Project project
+    public static @Nullable String execute(
+            final @NotNull PsiDirectory psiDirectory,
+            final @NotNull Project project
     ) {
         // Check if directory is theme directory and return module name from directory path if yes
         final String path = psiDirectory.getVirtualFile().getPath();
         final Pattern pattern = Pattern.compile(RegExUtil.CustomTheme.MODULE_NAME);
         final Matcher matcher = pattern.matcher(path);
+
         while (matcher.find()) {
             final String moduleNamePath =  matcher.group(0);
+
             if (!moduleNamePath.isEmpty()) {
                 return moduleNamePath.split("/")[5];
             }
@@ -48,13 +52,16 @@ public final class GetModuleNameByDirectoryUtil {
                 psiDirectory,
                 project
         );
+
         if (registrationPhp == null) {
             return null;
         }
         final PsiElement[] childElements = registrationPhp.getChildren();
+
         if (childElements.length == 0) {
             return null;
         }
+
         return getModuleName(childElements);
     }
 
@@ -66,14 +73,17 @@ public final class GetModuleNameByDirectoryUtil {
                 element,
                 MethodReference.class
             );
+
             if (methods == null) {
                 final PsiElement[] children = element.getChildren();
                 methods = parseRegistrationPhpElements(children);
             }
+
             if (methods != null) {
                 return methods;
             }
         }
+
         return null;
     }
 
@@ -99,25 +109,30 @@ public final class GetModuleNameByDirectoryUtil {
 
     private static String getModuleName(final PsiElement... childElements) {
         final MethodReference[] methods = parseRegistrationPhpElements(childElements);
+
         if (methods == null) {
             return null;
         }
+
         for (final MethodReference method: methods) {
             if (!method.getName().equals(RegistrationPhp.REGISTER_METHOD_NAME)) {
                 continue;
             }
             final PsiElement[] parameters =  method.getParameters();
+
             for (final PsiElement parameter: parameters) {
                 if (!(parameter instanceof StringLiteralExpression)) {
                     continue;
                 }
                 final String moduleName = ((StringLiteralExpression) parameter)
                         .getContents();
+
                 if (moduleName.matches(RegExUtil.Magento.MODULE_NAME)) {
                     return moduleName;
                 }
             }
         }
+
         return null;
     }
 
@@ -131,11 +146,13 @@ public final class GetModuleNameByDirectoryUtil {
                     continue;
                 }
                 final String filename = ((PhpFile) containingFile).getName();
+
                 if (filename.equals(RegistrationPhp.FILE_NAME)) {
                     return (PhpFile) containingFile;
                 }
             }
         }
+
         return null;
     }
 }

--- a/src/com/magento/idea/magento2plugin/util/magento/GetModuleNameByDirectoryUtil.java
+++ b/src/com/magento/idea/magento2plugin/util/magento/GetModuleNameByDirectoryUtil.java
@@ -65,10 +65,10 @@ public final class GetModuleNameByDirectoryUtil {
         return getModuleName(childElements);
     }
 
-    private static MethodReference[] parseRegistrationPhpElements(//NOPMD
+    private static MethodReference[] parseRegistrationPhpElements(
             final PsiElement... elements
     ) {
-        for (final PsiElement element: elements) {
+        for (final PsiElement element : elements) {
             MethodReference[] methods = PsiTreeUtil.getChildrenOfType(
                 element,
                 MethodReference.class
@@ -79,12 +79,12 @@ public final class GetModuleNameByDirectoryUtil {
                 methods = parseRegistrationPhpElements(children);
             }
 
-            if (methods != null) {
+            if (methods.length > 0) {
                 return methods;
             }
         }
 
-        return null;
+        return new MethodReference[0];
     }
 
     private static PhpFile getRegistrationPhpRecursively(
@@ -110,12 +110,12 @@ public final class GetModuleNameByDirectoryUtil {
     private static String getModuleName(final PsiElement... childElements) {
         final MethodReference[] methods = parseRegistrationPhpElements(childElements);
 
-        if (methods == null) {
+        if (methods.length == 0) {
             return null;
         }
 
         for (final MethodReference method: methods) {
-            if (!method.getName().equals(RegistrationPhp.REGISTER_METHOD_NAME)) {
+            if (!RegistrationPhp.REGISTER_METHOD_NAME.equals(method.getName())) {
                 continue;
             }
             final PsiElement[] parameters =  method.getParameters();
@@ -147,7 +147,7 @@ public final class GetModuleNameByDirectoryUtil {
                 }
                 final String filename = ((PhpFile) containingFile).getName();
 
-                if (filename.equals(RegistrationPhp.FILE_NAME)) {
+                if (RegistrationPhp.FILE_NAME.equals(filename)) {
                     return (PhpFile) containingFile;
                 }
             }


### PR DESCRIPTION
**Description** (*)

Fixed java.lang.NullPointerException when opening new cron job dialog for an invalid Magento 2 module.

**The bug was reproduced before fixing it:**

<img width="803" alt="Screenshot 2021-12-17 at 16 23 15" src="https://user-images.githubusercontent.com/31848341/146558581-8190eb19-1d5f-40da-ad5e-fae2ff4b8725.png">

**Behaviour after bug fixing (for an invalid module structure):**

<img width="827" alt="Screenshot 2021-12-17 at 16 20 10" src="https://user-images.githubusercontent.com/31848341/146558740-018f8e49-5184-40a3-8b11-7b4a9b6d6651.png">

The cron job name is not auto-populated as it cannot be resolved without valid module structure.

**Behaviour after bug fixing (for a valid module structure):**

<img width="827" alt="Screenshot 2021-12-17 at 16 20 41" src="https://user-images.githubusercontent.com/31848341/146558911-b135dead-4a62-47c6-bb00-efaf6bf5d2da.png">

The cron job name is auto-populated.

**Fixed Issues (if relevant)**

1. Fixes magento/magento2-phpstorm-plugin#825

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
