### PR TITLE
760: fixed throwable when io exception is thrown during plugin generation

### DIFF
--- a/resources/magento2/validation.properties
+++ b/resources/magento2/validation.properties
@@ -22,6 +22,7 @@ validator.command.isNotValid=The {0} field does not contain a valid Magento 2 CL
 validator.module.noSuchModule=No such module {0}
 validator.file.alreadyExists={0} already exists
 validator.file.cantBeCreated={0} can't be created
+validator.file.cantBeCreatedWithException=The ''{0}'' cannot be created. Original message was: ''{1}''
 validator.file.isNotWritable=%s file is binary or has no document associations
 validator.file.noDocumentAssociations={0} file is binary or has no document associations
 validator.class.alreadyDeclared={0} already declared in the target module

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/PluginClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/PluginClassGenerator.java
@@ -5,6 +5,7 @@
 
 package com.magento.idea.magento2plugin.actions.generation.generator;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.project.Project;
@@ -88,7 +89,7 @@ public class PluginClassGenerator extends FileGenerator {
      *
      * @return PsiFile
      */
-    @SuppressWarnings("PMD.CognitiveComplexity")
+    @SuppressWarnings({"PMD.CognitiveComplexity", "PMD.ExcessiveMethodLength"})
     @Override
     public PsiFile generate(final String actionName) {
         final PsiFile[] pluginFile = {null};
@@ -100,15 +101,27 @@ public class PluginClassGenerator extends FileGenerator {
                 pluginClass = createPluginClass(actionName);
             }
             if (pluginClass == null) {
-                final String errorMessage = validatorBundle.message(
-                        "validator.file.cantBeCreated",
-                        "Plugin Class"
-                );
-                JOptionPane.showMessageDialog(
-                        null,
-                        errorMessage,
-                        errorTitle,
-                        JOptionPane.ERROR_MESSAGE
+                String errorMessage;
+
+                if (fileFromTemplateGenerator.getLastExceptionMessage() == null) {
+                    errorMessage = validatorBundle.message(
+                            "validator.file.cantBeCreated",
+                            "Plugin Class"
+                    );
+                } else {
+                    errorMessage = validatorBundle.message(
+                            "validator.file.cantBeCreatedWithException",
+                            "Plugin Class",
+                            fileFromTemplateGenerator.getLastExceptionMessage()
+                    );
+                }
+                ApplicationManager.getApplication().invokeLater(
+                        () -> JOptionPane.showMessageDialog(
+                                null,
+                                errorMessage,
+                                errorTitle,
+                                JOptionPane.ERROR_MESSAGE
+                        )
                 );
 
                 return;
@@ -132,11 +145,13 @@ public class PluginClassGenerator extends FileGenerator {
                                 "validator.file.alreadyExists",
                                 "Plugin Class"
                         );
-                JOptionPane.showMessageDialog(
-                        null,
-                        errorMessage,
-                        errorTitle,
-                        JOptionPane.ERROR_MESSAGE
+                ApplicationManager.getApplication().invokeLater(
+                        () -> JOptionPane.showMessageDialog(
+                                null,
+                                errorMessage,
+                                errorTitle,
+                                JOptionPane.ERROR_MESSAGE
+                        )
                 );
 
                 return;

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FileFromTemplateGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FileFromTemplateGenerator.java
@@ -56,7 +56,7 @@ public class FileFromTemplateGenerator {
     ) {
         final Ref<PsiFile> fileRef = new Ref<>(null);
         final Ref<String> exceptionRef = new Ref<>(null);
-        exceptionMessage = null;
+        exceptionMessage = null;//NOPMD
         final String filePath = baseDir.getText().concat("/").concat(moduleFile.getFileName());
 
         CommandProcessor.getInstance().executeCommand(project, () -> {

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FileFromTemplateGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/util/FileFromTemplateGenerator.java
@@ -31,9 +31,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class FileFromTemplateGenerator {
-    private final Project project;
 
-    public FileFromTemplateGenerator(final Project project) {
+    private final @NotNull Project project;
+
+    public FileFromTemplateGenerator(final @NotNull Project project) {
         this.project = project;
     }
 
@@ -56,10 +57,12 @@ public class FileFromTemplateGenerator {
         final Ref<PsiFile> fileRef = new Ref<>(null);
         final Ref<String> exceptionRef = new Ref<>(null);
         final String filePath = baseDir.getText().concat("/").concat(moduleFile.getFileName());
+
         CommandProcessor.getInstance().executeCommand(project, () -> {
             final Runnable run = () -> {
                 try {
-                    PsiFile file = createFile(moduleFile, filePath, baseDir, attributes);
+                    final PsiFile file = createFile(moduleFile, filePath, baseDir, attributes);
+
                     if (file != null) {
                         fileRef.set(file);
                     }
@@ -89,13 +92,19 @@ public class FileFromTemplateGenerator {
         final String fileName = path.get(path.size() - 1);
         final PsiFile fileTemplate = createFileFromTemplate(
                 getTemplateManager(),
-                baseDir, moduleFile.getTemplate(), attributes, fileName, moduleFile.getLanguage());
+                baseDir,
+                moduleFile.getTemplate(),
+                attributes,
+                fileName,
+                moduleFile.getLanguage()
+        );
+
         if (fileTemplate == null) {
             throw new IncorrectOperationException("Template not found!");
         } else {
             PsiElement file;
-
             file = baseDir.add(fileTemplate);
+
             if (file instanceof PsiFile) {
                 return (PsiFile)file;
             } else {
@@ -125,6 +134,7 @@ public class FileFromTemplateGenerator {
             final @NotNull Language language
     ) throws IOException {
         FileTemplate fileTemplate;
+
         try {
             fileTemplate = templateManager.getInternalTemplate(templateName);
         } catch (IllegalStateException e) {
@@ -140,6 +150,7 @@ public class FileFromTemplateGenerator {
                 true,
                 false
         );
+
         if (fileTemplate.isReformatCode()) {
             CodeStyleManager.getInstance(project).reformat(file);
         }


### PR DESCRIPTION
**Description** (*)

Fixed java.lang.Throwable: when an IOException is thrown during new plugin generation.

**The bug was reproduced programmatically:**

<img width="1139" alt="Screenshot 2021-12-17 at 22 30 58" src="https://user-images.githubusercontent.com/31848341/146611106-0490c885-4704-4c2d-9835-8e103dd691fc.png">

**Obsolete popup with detailed message was eliminated:**

<img width="378" alt="Screenshot 2021-12-17 at 22 36 30" src="https://user-images.githubusercontent.com/31848341/146611207-78a9f8eb-88c5-4bb1-bb1a-1c4f0a1a3fcf.png">

**Main popup with an general error was updated with detailed message IF it is known in particular case:**

**before:**

<img width="317" alt="Screenshot 2021-12-17 at 22 36 39" src="https://user-images.githubusercontent.com/31848341/146611342-7b4f8589-62c8-4663-bec8-da3d9b10eab2.png">

**after:**

<img width="687" alt="Screenshot 2021-12-17 at 23 33 23" src="https://user-images.githubusercontent.com/31848341/146611428-37f5316b-a399-4608-8ba0-9b1705bf1371.png">

**Fixed Issues (if relevant)**

1. Fixes magento/magento2-phpstorm-plugin#760

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
