### PR TITLE
651: slow operations are prohibited on EDT

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/CreateAPluginAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/CreateAPluginAction.java
@@ -25,6 +25,7 @@ import com.magento.idea.magento2plugin.util.magento.plugin.IsPluginAllowedForMet
 import org.jetbrains.annotations.NotNull;
 
 public class CreateAPluginAction extends DumbAwareAction {
+
     public static final String ACTION_NAME = "Create a new Plugin for this method";
     public static final String ACTION_DESCRIPTION = "Create a new Magento 2 Plugin";
     private final GetFirstClassOfFile getFirstClassOfFile;
@@ -47,10 +48,12 @@ public class CreateAPluginAction extends DumbAwareAction {
         targetClass = null;// NOPMD
         targetMethod = null;// NOPMD
         final Project project = event.getData(PlatformDataKeys.PROJECT);
-        if (Settings.isEnabled(project)) {
+
+        if (project != null && Settings.isEnabled(project)) {
             final Pair<PsiFile, PhpClass> pair = this.findPhpClass(event);
             final PsiFile psiFile = pair.getFirst();
             final PhpClass phpClass = pair.getSecond();
+
             if (phpClass == null
                     || !(psiFile instanceof PhpFile)
                     || phpClass.isFinal()
@@ -74,8 +77,13 @@ public class CreateAPluginAction extends DumbAwareAction {
     }
 
     @Override
-    public void actionPerformed(@NotNull final AnActionEvent event) {
-        CreateAPluginDialog.open(event.getProject(), this.targetMethod, this.targetClass);
+    public void actionPerformed(final @NotNull AnActionEvent event) {
+        final Project project = event.getProject();
+
+        if (project == null) {
+            return;
+        }
+        CreateAPluginDialog.open(project, this.targetMethod, this.targetClass);
     }
 
     @Override
@@ -83,7 +91,7 @@ public class CreateAPluginAction extends DumbAwareAction {
         return false;
     }
 
-    private Pair<PsiFile, PhpClass> findPhpClass(@NotNull final AnActionEvent event) {
+    private Pair<PsiFile, PhpClass> findPhpClass(final @NotNull AnActionEvent event) {
         final PsiFile psiFile = event.getData(PlatformDataKeys.PSI_FILE);
 
         PhpClass phpClass = null;
@@ -96,27 +104,31 @@ public class CreateAPluginAction extends DumbAwareAction {
     }
 
     private void fetchTargetMethod(
-            @NotNull final AnActionEvent event,
+            final @NotNull AnActionEvent event,
             final PsiFile psiFile,
             final PhpClass phpClass
     ) {
         final Caret caret = event.getData(PlatformDataKeys.CARET);
+
         if (caret == null) {
             return;
         }
         final int offset = caret.getOffset();
         final PsiElement element = psiFile.findElementAt(offset);
+
         if (element == null) {
             return;
         }
-        if (element instanceof Method && element.getParent()
-                == phpClass && IsPluginAllowedForMethodUtil.check((Method) element)) {
+
+        if (element instanceof Method && element.getParent().equals(phpClass)
+                && IsPluginAllowedForMethodUtil.check((Method) element)) {
             this.targetMethod = (Method) element;
             return;
         }
         final PsiElement parent = element.getParent();
-        if (parent instanceof Method && parent.getParent()
-                == phpClass && IsPluginAllowedForMethodUtil.check((Method) parent)) {
+
+        if (parent instanceof Method && parent.getParent().equals(phpClass)
+                && IsPluginAllowedForMethodUtil.check((Method) parent)) {
             this.targetMethod = (Method) parent;
         }
     }

--- a/src/com/magento/idea/magento2plugin/inspections/php/util/PhpClassImplementsNoninterceptableInterfaceUtil.java
+++ b/src/com/magento/idea/magento2plugin/inspections/php/util/PhpClassImplementsNoninterceptableInterfaceUtil.java
@@ -5,6 +5,7 @@
 
 package com.magento.idea.magento2plugin.inspections.php.util;
 
+import com.intellij.util.SlowOperations;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.magento.idea.magento2plugin.magento.files.Plugin;
 import org.jetbrains.annotations.NotNull;
@@ -17,13 +18,18 @@ public final class PhpClassImplementsNoninterceptableInterfaceUtil {
      * Check whether class implements NoninterceptableInterface.
      *
      * @param phpClass PhpClass
+     *
      * @return bool
      */
     public static boolean execute(final @NotNull PhpClass phpClass) {
-        final PhpClass[] interfaces = phpClass.getImplementedInterfaces();
+        final PhpClass[] interfaces = SlowOperations.allowSlowOperations(
+                phpClass::getImplementedInterfaces
+        );
+
         if (interfaces.length == 0) {
             return false;
         }
+
         for (final PhpClass targetInterfaceClass: interfaces) {
             if (targetInterfaceClass.getFQN().equals(Plugin.NON_INTERCEPTABLE_FQN)) {
                 return true;

--- a/src/com/magento/idea/magento2plugin/inspections/php/util/PhpClassImplementsNoninterceptableInterfaceUtil.java
+++ b/src/com/magento/idea/magento2plugin/inspections/php/util/PhpClassImplementsNoninterceptableInterfaceUtil.java
@@ -31,7 +31,7 @@ public final class PhpClassImplementsNoninterceptableInterfaceUtil {
         }
 
         for (final PhpClass targetInterfaceClass: interfaces) {
-            if (targetInterfaceClass.getFQN().equals(Plugin.NON_INTERCEPTABLE_FQN)) {
+            if (Plugin.NON_INTERCEPTABLE_FQN.equals(targetInterfaceClass.getFQN())) {
                 return true;
             }
         }


### PR DESCRIPTION
**Description** (*)

Fixed slow operations are prohibited on EDT when calling update method on the CreateAPluginAction.

**This issue was reproduced before fixing it:**

<img width="1254" alt="Screenshot 2021-12-20 at 11 45 54" src="https://user-images.githubusercontent.com/31848341/146761736-f794da06-f2be-48ca-abbc-a1efe9b63fbd.png">

This exception was throwing while accessing context menu under a php class method name during reindexing process.

**Fixed Issues (if relevant)**

1. Fixes magento/magento2-phpstorm-plugin#651

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
