### PR TITLE
864: enhanced a new block dialog UX

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/NewBlockAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewBlockAction.java
@@ -18,6 +18,7 @@ import com.magento.idea.magento2plugin.actions.generation.dialog.NewBlockDialog;
 import org.jetbrains.annotations.NotNull;
 
 public class NewBlockAction extends AnAction {
+
     public static final String ACTION_NAME = "Magento 2 Block";
     public static final String ACTION_DESCRIPTION = "Create a new Magento 2 Block";
 
@@ -26,23 +27,24 @@ public class NewBlockAction extends AnAction {
     }
 
     @Override
-    public void actionPerformed(@NotNull final AnActionEvent event) {
+    public void actionPerformed(final @NotNull AnActionEvent event) {
         final DataContext dataContext = event.getDataContext();
         final IdeView view = LangDataKeys.IDE_VIEW.getData(dataContext);
+
         if (view == null) {
             return;
         }
 
         final Project project = CommonDataKeys.PROJECT.getData(dataContext);
+
         if (project == null) {
             return;
         }
-
         final PsiDirectory directory = view.getOrChooseDirectory();
+
         if (directory == null) {
             return;
         }
-
         NewBlockDialog.open(project, directory);
     }
 
@@ -51,4 +53,3 @@ public class NewBlockAction extends AnAction {
         return false;
     }
 }
-

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewBlockDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewBlockDialog.form
@@ -53,7 +53,7 @@
           </grid>
         </children>
       </grid>
-      <grid id="e3588" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="e3588" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -85,7 +85,7 @@
           </component>
           <component id="fdc52" class="javax.swing.JTextField" binding="blockParentDir">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -96,7 +96,7 @@
           </component>
           <component id="be25f" class="javax.swing.JLabel">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <labelFor value="fdc52"/>
@@ -105,6 +105,22 @@
             <clientProperties>
               <html.disable class="java.lang.Boolean" value="true"/>
             </clientProperties>
+          </component>
+          <component id="48e8" class="javax.swing.JLabel" binding="blockNameErrorMessage">
+            <constraints>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="340c3" class="javax.swing.JLabel" binding="blockParentDirErrorMessage">
+            <constraints>
+              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
           </component>
         </children>
       </grid>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewBlockDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewBlockDialog.java
@@ -7,7 +7,6 @@ package com.magento.idea.magento2plugin.actions.generation.dialog;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDirectory;
-import com.intellij.psi.PsiFile;
 import com.magento.idea.magento2plugin.actions.generation.NewBlockAction;
 import com.magento.idea.magento2plugin.actions.generation.data.BlockFileData;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.annotation.FieldValidation;
@@ -26,6 +25,7 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import javax.swing.JButton;
 import javax.swing.JComponent;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JTextField;
@@ -33,6 +33,7 @@ import javax.swing.JTextPane;
 import javax.swing.KeyStroke;
 
 public class NewBlockDialog extends AbstractDialog {
+
     private final PsiDirectory baseDir;
     private final String moduleName;
     private JPanel contentPanel;
@@ -44,17 +45,17 @@ public class NewBlockDialog extends AbstractDialog {
     private static final String NAME = "name";
     private static final String DIRECTORY = "directory";
 
-    @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
-            message = {NotEmptyRule.MESSAGE, NAME})
-    @FieldValidation(rule = RuleRegistry.PHP_CLASS,
-            message = {PhpClassRule.MESSAGE, NAME})
+    @FieldValidation(rule = RuleRegistry.NOT_EMPTY, message = {NotEmptyRule.MESSAGE, NAME})
+    @FieldValidation(rule = RuleRegistry.PHP_CLASS, message = {PhpClassRule.MESSAGE, NAME})
     private JTextField blockName;
 
-    @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
-            message = {NotEmptyRule.MESSAGE, DIRECTORY})
+    @FieldValidation(rule = RuleRegistry.NOT_EMPTY, message = {NotEmptyRule.MESSAGE, DIRECTORY})
     @FieldValidation(rule = RuleRegistry.PHP_DIRECTORY,
             message = {PhpDirectoryRule.MESSAGE, DIRECTORY})
     private JTextField blockParentDir;
+
+    private JLabel blockNameErrorMessage;//NOPMD
+    private JLabel blockParentDirErrorMessage;//NOPMD
 
     /**
      * Constructor.
@@ -113,8 +114,8 @@ public class NewBlockDialog extends AbstractDialog {
     protected void onOK() {
         if (validateFormFields()) {
             generateFile();
+            exit();
         }
-        exit();
     }
 
     private void generateFile() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewBlockDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewBlockDialog.java
@@ -117,8 +117,8 @@ public class NewBlockDialog extends AbstractDialog {
         exit();
     }
 
-    private PsiFile generateFile() {
-        return new ModuleBlockClassGenerator(new BlockFileData(
+    private void generateFile() {
+        new ModuleBlockClassGenerator(new BlockFileData(
                 getBlockDirectory(),
                 getBlockName(),
                 getModuleName(),
@@ -140,6 +140,7 @@ public class NewBlockDialog extends AbstractDialog {
 
     private void suggestBlockDirectory() {
         final String moduleIdentifierPath = getModuleIdentifierPath();
+
         if (moduleIdentifierPath == null) {
             blockParentDir.setText(BlockPhp.DEFAULT_DIR);
             return;
@@ -147,6 +148,7 @@ public class NewBlockDialog extends AbstractDialog {
         final String path = baseDir.getVirtualFile().getPath();
         final String[] pathParts = path.split(moduleIdentifierPath);
         final int minimumPathParts = 2;
+
         if (pathParts.length != minimumPathParts) {
             blockParentDir.setText(BlockPhp.DEFAULT_DIR);
             return;
@@ -161,14 +163,17 @@ public class NewBlockDialog extends AbstractDialog {
 
     private String getModuleIdentifierPath() {
         final String[]parts = moduleName.split(Package.vendorModuleNameSeparator);
+
         if (parts[0] == null || parts[1] == null || parts.length > 2) {
             return null;
         }
+
         return parts[0] + File.separator + parts[1];
     }
 
     private String getNamespace() {
         final String[]parts = moduleName.split(Package.vendorModuleNameSeparator);
+
         if (parts[0] == null || parts[1] == null || parts.length > 2) {
             return null;
         }
@@ -176,12 +181,7 @@ public class NewBlockDialog extends AbstractDialog {
                 File.separator,
                 Package.fqnSeparator
         );
-        return parts[0] + Package.fqnSeparator + parts[1] + Package.fqnSeparator + directoryPart;
-    }
 
-    @Override
-    public void onCancel() {
-        // add your code here if necessary
-        dispose();
+        return parts[0] + Package.fqnSeparator + parts[1] + Package.fqnSeparator + directoryPart;
     }
 }


### PR DESCRIPTION
**Description** (*)

Enhanced error outputting for the new Magento 2 Block generation.

<img width="454" alt="Screenshot 2021-12-20 at 23 31 29" src="https://user-images.githubusercontent.com/31848341/146836284-aa084b8d-d155-4279-98c1-7085007ad3c4.png">

<img width="454" alt="Screenshot 2021-12-20 at 23 33 33" src="https://user-images.githubusercontent.com/31848341/146836366-f76572d7-f401-4962-b2bf-a05a6ee2370d.png">

<img width="454" alt="Screenshot 2021-12-20 at 23 33 44" src="https://user-images.githubusercontent.com/31848341/146836341-49cdc9b9-a7e8-40e6-8dd1-b08c348a6113.png">

<img width="477" alt="Screenshot 2021-12-20 at 23 33 58" src="https://user-images.githubusercontent.com/31848341/146836305-d047b654-5c13-4ea3-a28c-385fc98ccf44.png">

**Fixed Issues (if relevant)**

1. Fixes magento/magento2-phpstorm-plugin#864

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
