### PR TITLE
878: enhanced new UI grid dialog UX

### DIFF
--- a/resources/magento2/validation.properties
+++ b/resources/magento2/validation.properties
@@ -1,6 +1,7 @@
 validator.notEmpty=The {0} field must not be empty
 validator.box.notEmpty=The {0} field must contain a valid selection from the dropdown
 validator.package.validPath=Please specify a valid Magento 2 installation path
+validator.properties.notEmpty=The properties must not be empty
 validator.alphaNumericCharacters=The {0} field must contain letters and numbers only
 validator.alphaNumericAndUnderscoreCharacters={0} must contain letters, numbers and underscores only
 validator.alphaAndPeriodCharacters=The {0} field must contain alphabets and periods only

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewDataModelAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewDataModelAction.java
@@ -18,6 +18,7 @@ import com.magento.idea.magento2plugin.actions.generation.dialog.NewDataModelDia
 import org.jetbrains.annotations.NotNull;
 
 public class NewDataModelAction extends AnAction {
+
     public static final String ACTION_NAME = "Magento 2 Data Model";
     public static final String ACTION_DESCRIPTION = "Create a new Magento 2 Data Model";
 
@@ -29,24 +30,23 @@ public class NewDataModelAction extends AnAction {
     }
 
     @Override
-    public void actionPerformed(@NotNull final AnActionEvent event) {
+    public void actionPerformed(final @NotNull AnActionEvent event) {
         final DataContext dataContext = event.getDataContext();
-
         final IdeView view = LangDataKeys.IDE_VIEW.getData(dataContext);
+
         if (view == null) {
             return;
         }
-
         final Project project = CommonDataKeys.PROJECT.getData(dataContext);
+
         if (project == null) {
             return;
         }
-
         final PsiDirectory directory = view.getOrChooseDirectory();
+
         if (directory == null) {
             return;
         }
-
         NewDataModelDialog.open(project, directory);
     }
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewDbSchemaAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewDbSchemaAction.java
@@ -18,6 +18,7 @@ import com.magento.idea.magento2plugin.actions.generation.dialog.NewDbSchemaDial
 import org.jetbrains.annotations.NotNull;
 
 public class NewDbSchemaAction extends AnAction {
+
     public static final String ACTION_NAME = "Magento 2 Declarative Schema XML";
     public static final String ACTION_DESCRIPTION = "Create a new declarative schema XML";
 
@@ -32,16 +33,17 @@ public class NewDbSchemaAction extends AnAction {
     public void actionPerformed(final @NotNull AnActionEvent event) {
         final DataContext dataContext = event.getDataContext();
         final IdeView view = LangDataKeys.IDE_VIEW.getData(dataContext);
+
         if (view == null) {
             return;
         }
-
         final Project project = CommonDataKeys.PROJECT.getData(dataContext);
+
         if (project == null) {
             return;
         }
-
         final PsiDirectory directory = view.getOrChooseDirectory();
+
         if (directory == null) {
             return;
         }

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewEmailTemplateAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewEmailTemplateAction.java
@@ -16,8 +16,8 @@ import com.intellij.psi.PsiDirectory;
 import com.magento.idea.magento2plugin.MagentoIcons;
 import com.magento.idea.magento2plugin.actions.generation.dialog.NewEmailTemplateDialog;
 
-@SuppressWarnings({"PMD.OnlyOneReturn", "PMD.FieldNamingConventions"})
 public class NewEmailTemplateAction extends AnAction {
+
     public static final String ACTION_NAME = "Magento 2 Email Template";
     public static final String ACTION_DESCRIPTION = "Create a new Magento 2 email template";
 
@@ -36,17 +36,16 @@ public class NewEmailTemplateAction extends AnAction {
         if (view == null) {
             return;
         }
-
         final Project project = CommonDataKeys.PROJECT.getData(dataContext);
+
         if (project == null) {
             return;
         }
-
         final PsiDirectory directory = view.getOrChooseDirectory();
+
         if (directory == null) {
             return;
         }
-
         NewEmailTemplateDialog.open(project, directory);
     }
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewMessageQueueAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewMessageQueueAction.java
@@ -18,6 +18,7 @@ import com.magento.idea.magento2plugin.actions.generation.dialog.NewMessageQueue
 import org.jetbrains.annotations.NotNull;
 
 public class NewMessageQueueAction extends AnAction {
+
     public static final String ACTION_NAME = "Magento 2 Message Queue";
     public static final String ACTION_DESCRIPTION = "Create a new Magento 2 Message Queue";
 
@@ -29,24 +30,23 @@ public class NewMessageQueueAction extends AnAction {
     }
 
     @Override
-    public void actionPerformed(@NotNull final AnActionEvent event) {
+    public void actionPerformed(final @NotNull AnActionEvent event) {
         final DataContext dataContext = event.getDataContext();
-
         final IdeView view = LangDataKeys.IDE_VIEW.getData(dataContext);
+
         if (view == null) {
             return;
         }
-
         final Project project = CommonDataKeys.PROJECT.getData(dataContext);
+
         if (project == null) {
             return;
         }
-
         final PsiDirectory directory = view.getOrChooseDirectory();
+
         if (directory == null) {
             return;
         }
-
         NewMessageQueueDialog.open(project, directory);
     }
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewModelsAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewModelsAction.java
@@ -17,6 +17,7 @@ import com.magento.idea.magento2plugin.MagentoIcons;
 import com.magento.idea.magento2plugin.actions.generation.dialog.NewModelsDialog;
 
 public class NewModelsAction extends AnAction {
+
     public static final String ACTION_NAME = "Magento 2 Models";
     public static final String ACTION_DESCRIPTION = "Create a new Magento 2 models";
 
@@ -35,17 +36,16 @@ public class NewModelsAction extends AnAction {
         if (view == null) {
             return;
         }
-
         final Project project = CommonDataKeys.PROJECT.getData(dataContext);
+
         if (project == null) {
             return;
         }
-
         final PsiDirectory directory = view.getOrChooseDirectory();
+
         if (directory == null) {
             return;
         }
-
         NewModelsDialog.open(project, directory);
     }
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewUiComponentGridAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewUiComponentGridAction.java
@@ -16,8 +16,8 @@ import com.intellij.psi.PsiDirectory;
 import com.magento.idea.magento2plugin.MagentoIcons;
 import com.magento.idea.magento2plugin.actions.generation.dialog.NewUiComponentGridDialog;
 
-@SuppressWarnings({"PMD.OnlyOneReturn"})
 public class NewUiComponentGridAction extends AnAction {
+
     public static final String ACTION_NAME = "Magento 2 UI Component Grid";
     public static final String ACTION_DESCRIPTION = "Create a new Magento 2 UI Component Grid";
 
@@ -41,18 +41,16 @@ public class NewUiComponentGridAction extends AnAction {
         if (view == null) {
             return;
         }
-
         final Project project = CommonDataKeys.PROJECT.getData(dataContext);
+
         if (project == null) {
             return;
         }
-
         final PsiDirectory directory = view.getOrChooseDirectory();
 
         if (directory == null) {
             return;
         }
-
         NewUiComponentGridDialog.open(project, directory);
     }
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDataModelDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDataModelDialog.form
@@ -10,7 +10,7 @@
     </properties>
     <border type="none"/>
     <children>
-      <grid id="e3588" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="e3588" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -31,6 +31,14 @@
               <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="8fecc" class="javax.swing.JLabel" binding="modelNameErrorMessage">
+            <constraints>
+              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value=""/>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDataModelDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDataModelDialog.java
@@ -47,23 +47,24 @@ import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableColumn;
+import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings({
         "PMD.ExcessiveImports"
 })
 public class NewDataModelDialog extends AbstractDialog {
 
-    private final Project project;
-    private final String moduleName;
-    private final ValidatorBundle validatorBundle;
-    private final CommonBundle commonBundle;
-    private final List<String> properties;
-
     private static final String MODEL_NAME = "Model Name";
     private static final String PROPERTY_NAME = "Name";
     private static final String PROPERTY_TYPE = "Type";
     private static final String PROPERTY_ACTION = "Action";
     private static final String PROPERTY_DELETE = "Delete";
+
+    private final Project project;
+    private final String moduleName;
+    private final ValidatorBundle validatorBundle;
+    private final CommonBundle commonBundle;
+    private final List<String> properties;
 
     private JPanel contentPanel;
     private JButton buttonOK;
@@ -72,16 +73,17 @@ public class NewDataModelDialog extends AbstractDialog {
     private JButton addProperty;
     private JCheckBox createInterface;
 
-    @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
-            message = {NotEmptyRule.MESSAGE, MODEL_NAME})
-    @FieldValidation(rule = RuleRegistry.PHP_CLASS,
-            message = {PhpClassRule.MESSAGE, MODEL_NAME})
+    @FieldValidation(rule = RuleRegistry.NOT_EMPTY, message = {NotEmptyRule.MESSAGE, MODEL_NAME})
+    @FieldValidation(rule = RuleRegistry.PHP_CLASS, message = {PhpClassRule.MESSAGE, MODEL_NAME})
     private JTextField modelName;
 
     /**
      * Constructor.
      */
-    public NewDataModelDialog(final Project project, final PsiDirectory directory) {
+    public NewDataModelDialog(
+            final @NotNull Project project,
+            final @NotNull PsiDirectory directory
+    ) {
         super();
 
         this.project = project;
@@ -122,7 +124,10 @@ public class NewDataModelDialog extends AbstractDialog {
     /**
      * Opens the dialog window.
      */
-    public static void open(final Project project, final PsiDirectory directory) {
+    public static void open(
+            final @NotNull Project project,
+            final @NotNull PsiDirectory directory
+    ) {
         final NewDataModelDialog dialog = new NewDataModelDialog(project, directory);
         dialog.pack();
         dialog.centerDialog(dialog);
@@ -145,8 +150,8 @@ public class NewDataModelDialog extends AbstractDialog {
                 generateDataModelInterfaceFile();
                 generatePreferenceForInterface();
             }
+            exit();
         }
-        exit();
     }
 
     @Override
@@ -188,11 +193,6 @@ public class NewDataModelDialog extends AbstractDialog {
         }
 
         return valid;
-    }
-
-    @Override
-    public void onCancel() {
-        dispose();
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDataModelDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDataModelDialog.java
@@ -40,6 +40,7 @@ import java.util.List;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
+import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTable;
@@ -76,6 +77,8 @@ public class NewDataModelDialog extends AbstractDialog {
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY, message = {NotEmptyRule.MESSAGE, MODEL_NAME})
     @FieldValidation(rule = RuleRegistry.PHP_CLASS, message = {PhpClassRule.MESSAGE, MODEL_NAME})
     private JTextField modelName;
+
+    private JLabel modelNameErrorMessage;//NOPMD
 
     /**
      * Constructor.
@@ -162,6 +165,17 @@ public class NewDataModelDialog extends AbstractDialog {
             valid = true;
             final String errorTitle = commonBundle.message("common.error");
             final int column = 0;
+
+            if (propertyTable.getRowCount() == 0) {
+                valid = false;
+                JOptionPane.showMessageDialog(
+                        null,
+                        validatorBundle.message("validator.properties.notEmpty"),
+                        errorTitle,
+                        JOptionPane.ERROR_MESSAGE
+                );
+            }
+
             for (int row = 0; row < propertyTable.getRowCount(); row++) {
                 final String propertyName = ((String) propertyTable.getValueAt(row, column)).trim();
                 if (propertyName.isEmpty()) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDbSchemaDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDbSchemaDialog.form
@@ -56,7 +56,7 @@
         <properties/>
         <border type="none"/>
         <children>
-          <grid id="40126" layout-manager="GridLayoutManager" row-count="2" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="40126" layout-manager="GridLayoutManager" row-count="3" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -92,7 +92,7 @@
               </component>
               <component id="a42c4" class="javax.swing.JLabel" binding="tableEngineLabel">
                 <constraints>
-                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <labelFor value="21a4a"/>
@@ -101,7 +101,7 @@
               </component>
               <component id="d636e" class="javax.swing.JLabel" binding="tableCommentLabel">
                 <constraints>
-                  <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <labelFor value="dd0b9"/>
@@ -110,7 +110,7 @@
               </component>
               <component id="dd0b9" class="javax.swing.JTextField" binding="tableComment">
                 <constraints>
-                  <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                  <grid row="2" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                     <preferred-size width="150" height="-1"/>
                   </grid>
                 </constraints>
@@ -118,7 +118,7 @@
               </component>
               <component id="21a4a" class="javax.swing.JComboBox" binding="tableEngine">
                 <constraints>
-                  <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties/>
               </component>
@@ -127,6 +127,14 @@
                   <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties/>
+              </component>
+              <component id="e5139" class="javax.swing.JLabel" binding="tableNameErrorMessage">
+                <constraints>
+                  <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value=""/>
+                </properties>
               </component>
             </children>
           </grid>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDbSchemaDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDbSchemaDialog.java
@@ -150,8 +150,8 @@ public class NewDbSchemaDialog extends AbstractDialog {
                 return;
             }
             generateWhitelistJsonFile(dbSchemaXmlData);
+            exit();
         }
-        exit();
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDbSchemaDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewDbSchemaDialog.java
@@ -46,6 +46,7 @@ import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings({"PMD.TooManyFields", "PMD.ExcessiveImports"})
 public class NewDbSchemaDialog extends AbstractDialog {
+
     private static final String TABLE_NAME = "Table Name";
 
     private final Project project;
@@ -85,6 +86,7 @@ public class NewDbSchemaDialog extends AbstractDialog {
     private JLabel tableResourceLabel;//NOPMD
     private JLabel tableCommentLabel;//NOPMD
     private JLabel tableColumnsLabel;//NOPMD
+    private JLabel tableNameErrorMessage;//NOPMD
 
     /**
      * Constructor.

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEmailTemplateDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEmailTemplateDialog.form
@@ -3,9 +3,11 @@
   <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
-      <xy x="48" y="54" width="436" height="297"/>
+      <xy x="48" y="54" width="436" height="351"/>
     </constraints>
-    <properties/>
+    <properties>
+      <preferredSize width="450" height="325"/>
+    </properties>
     <border type="none"/>
     <children>
       <grid id="94766" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
@@ -49,7 +51,7 @@
           </grid>
         </children>
       </grid>
-      <grid id="e3588" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="e3588" layout-manager="GridLayoutManager" row-count="9" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -75,7 +77,7 @@
           </component>
           <component id="c7eac" class="javax.swing.JLabel">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="magento2/common" key="common.template.label"/>
@@ -83,7 +85,7 @@
           </component>
           <component id="35e0c" class="javax.swing.JTextField" binding="label">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -91,7 +93,7 @@
           </component>
           <component id="65e98" class="javax.swing.JLabel">
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="magento2/common" key="common.template.filename"/>
@@ -99,7 +101,7 @@
           </component>
           <component id="f244b" class="javax.swing.JLabel">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="magento2/common" key="common.template.type"/>
@@ -107,7 +109,7 @@
           </component>
           <component id="33fd6" class="javax.swing.JLabel">
             <constraints>
-              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="magento2/common" key="common.area.target"/>
@@ -115,7 +117,7 @@
           </component>
           <component id="617b5" class="javax.swing.JTextField" binding="fileName">
             <constraints>
-              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -123,7 +125,7 @@
           </component>
           <component id="bfac1" class="com.magento.idea.magento2plugin.ui.FilteredComboBox" binding="area" custom-create="true">
             <constraints>
-              <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <toolTipText value=""/>
@@ -134,7 +136,7 @@
           </component>
           <component id="c5b33" class="com.magento.idea.magento2plugin.ui.FilteredComboBox" binding="templateType" custom-create="true">
             <constraints>
-              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <toolTipText value=""/>
@@ -145,7 +147,7 @@
           </component>
           <component id="285c1" class="javax.swing.JLabel">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="magento2/common" key="common.template.subject"/>
@@ -153,11 +155,35 @@
           </component>
           <component id="56e46" class="javax.swing.JTextField" binding="subject">
             <constraints>
-              <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
             <properties/>
+          </component>
+          <component id="fd5e" class="javax.swing.JLabel" binding="identifierErrorMessage">
+            <constraints>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="69f30" class="javax.swing.JLabel" binding="labelErrorMessage">
+            <constraints>
+              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="e3d5a" class="javax.swing.JLabel" binding="fileNameErrorMessage">
+            <constraints>
+              <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
           </component>
         </children>
       </grid>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEmailTemplateDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEmailTemplateDialog.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.List;
 import javax.swing.JButton;
 import javax.swing.JComponent;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
@@ -51,9 +52,11 @@ public class NewEmailTemplateDialog extends AbstractDialog {
     @FieldValidation(rule = RuleRegistry.IDENTIFIER,
             message = {IdentifierRule.MESSAGE, EMAIL_TEMPLATE_ID})
     private JTextField identifier;
+
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
             message = {NotEmptyRule.MESSAGE, LABEL})
     private JTextField label;
+
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
             message = {NotEmptyRule.MESSAGE, FILENAME})
     @FieldValidation(rule = RuleRegistry.IDENTIFIER,
@@ -63,6 +66,10 @@ public class NewEmailTemplateDialog extends AbstractDialog {
     private FilteredComboBox area;
     private FilteredComboBox templateType;
     private JTextField subject;
+
+    private JLabel identifierErrorMessage;//NOPMD
+    private JLabel labelErrorMessage;//NOPMD
+    private JLabel fileNameErrorMessage;//NOPMD
 
     /**
      * New email template dialog.
@@ -208,11 +215,9 @@ public class NewEmailTemplateDialog extends AbstractDialog {
         final boolean emailTemplateCanBeDeclared = !this.validator.validate(this);
 
         if (!validateFormFields() || emailTemplateCanBeDeclared) {
-            exit();
             return;
         }
         generateFile();
-
         exit();
     }
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEmailTemplateDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewEmailTemplateDialog.java
@@ -21,8 +21,6 @@ import com.magento.idea.magento2plugin.magento.files.EmailTemplateHtml;
 import com.magento.idea.magento2plugin.magento.packages.Areas;
 import com.magento.idea.magento2plugin.ui.FilteredComboBox;
 import com.magento.idea.magento2plugin.util.magento.GetModuleNameByDirectoryUtil;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
@@ -36,15 +34,18 @@ import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 
 public class NewEmailTemplateDialog extends AbstractDialog {
-    private final String moduleName;
-    private final Project project;
-    private final NewEmailTemplateDialogValidator validator;
+
     private static final String EMAIL_TEMPLATE_ID = "id";
     private static final String LABEL = "label";
     private static final String FILENAME = "file name";
+
+    private final String moduleName;
+    private final Project project;
+    private final NewEmailTemplateDialogValidator validator;
     private JPanel contentPane;
     private JButton buttonOK;
     private JButton buttonCancel;
+
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
             message = {NotEmptyRule.MESSAGE, EMAIL_TEMPLATE_ID})
     @FieldValidation(rule = RuleRegistry.IDENTIFIER,
@@ -58,6 +59,7 @@ public class NewEmailTemplateDialog extends AbstractDialog {
     @FieldValidation(rule = RuleRegistry.IDENTIFIER,
             message = {IdentifierRule.MESSAGE, FILENAME})
     private JTextField fileName;
+
     private FilteredComboBox area;
     private FilteredComboBox templateType;
     private JTextField subject;
@@ -83,6 +85,8 @@ public class NewEmailTemplateDialog extends AbstractDialog {
         // call onCancel() when cross is clicked
         setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
         addWindowListener(new WindowAdapter() {
+
+            @Override
             public void windowClosing(final WindowEvent windowEvent) {
                 onCancel();
             }
@@ -90,11 +94,7 @@ public class NewEmailTemplateDialog extends AbstractDialog {
 
         // call onCancel() on ESCAPE
         contentPane.registerKeyboardAction(
-                new ActionListener() {
-                    public void actionPerformed(final ActionEvent actionEvent) {
-                        onCancel();
-                    }
-                },
+                actionEvent -> onCancel(),
                 KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
                 JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT
         );
@@ -228,11 +228,6 @@ public class NewEmailTemplateDialog extends AbstractDialog {
                 project
         );
         xmlGenerator.generate(NewEmailTemplateAction.ACTION_NAME, true);
-    }
-
-    protected void onCancel() {
-        // add your code here if necessary
-        dispose();
     }
 
     @SuppressWarnings({"PMD.UnusedPrivateMethod"})

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewMessageQueueDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewMessageQueueDialog.form
@@ -7,11 +7,12 @@
     </constraints>
     <properties>
       <opaque value="true"/>
+      <preferredSize width="750" height="425"/>
       <requestFocusEnabled value="true"/>
     </properties>
     <border type="none"/>
     <children>
-      <grid id="90a70" layout-manager="GridLayoutManager" row-count="8" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="90a70" layout-manager="GridLayoutManager" row-count="16" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -21,7 +22,7 @@
         <children>
           <component id="29a9d" class="javax.swing.JTextField" binding="handlerName">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -32,7 +33,7 @@
           </component>
           <component id="b5004" class="javax.swing.JLabel">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <labelFor value="fdc52"/>
@@ -44,7 +45,7 @@
           </component>
           <component id="c2a5" class="javax.swing.JLabel" binding="handlerClassLabel">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Handler Class"/>
@@ -53,7 +54,7 @@
           </component>
           <component id="ddec2" class="javax.swing.JTextField" binding="handlerClass">
             <constraints>
-              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -63,7 +64,7 @@
           </component>
           <component id="8bd7e" class="javax.swing.JLabel" binding="handlerDirectoryLabel">
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Handler Directory"/>
@@ -71,7 +72,7 @@
           </component>
           <component id="4cc1b" class="javax.swing.JTextField" binding="handlerDirectory">
             <constraints>
-              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -103,7 +104,7 @@
           </component>
           <component id="1c424" class="javax.swing.JTextField" binding="bindingId">
             <constraints>
-              <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="10" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -113,7 +114,7 @@
           </component>
           <component id="5dbf2" class="javax.swing.JLabel">
             <constraints>
-              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Binding ID"/>
@@ -121,7 +122,7 @@
           </component>
           <component id="ebf0" class="javax.swing.JLabel">
             <constraints>
-              <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="14" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Exchange Name"/>
@@ -129,7 +130,7 @@
           </component>
           <component id="debf6" class="javax.swing.JTextField" binding="exchangeName">
             <constraints>
-              <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="14" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -139,7 +140,7 @@
           </component>
           <component id="e89fb" class="javax.swing.JTextField" binding="queueName">
             <constraints>
-              <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -147,7 +148,7 @@
           </component>
           <component id="bbe6" class="javax.swing.JLabel">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Queue Name"/>
@@ -155,7 +156,7 @@
           </component>
           <component id="2e48e" class="javax.swing.JLabel" binding="bindingTopicLabel">
             <constraints>
-              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Binding Topic"/>
@@ -163,11 +164,75 @@
           </component>
           <component id="68452" class="javax.swing.JTextField" binding="bindingTopic">
             <constraints>
-              <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="12" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
             <properties/>
+          </component>
+          <component id="1236" class="javax.swing.JLabel" binding="topicNameErrorMessage">
+            <constraints>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="d7b24" class="javax.swing.JLabel" binding="handlerNameErrorMessage">
+            <constraints>
+              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="fa50b" class="javax.swing.JLabel" binding="handlerClassErrorMessage">
+            <constraints>
+              <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="cdea9" class="javax.swing.JLabel" binding="queueNameErrorMessage">
+            <constraints>
+              <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="b60d" class="javax.swing.JLabel" binding="exchangeNameErrorMessage">
+            <constraints>
+              <grid row="15" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="be8fe" class="javax.swing.JLabel" binding="bindingIdErrorMessage">
+            <constraints>
+              <grid row="11" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="bec3" class="javax.swing.JLabel" binding="bindingTopicErrorMessage">
+            <constraints>
+              <grid row="13" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="d5d5e" class="javax.swing.JLabel" binding="handlerDirectoryErrorMessage">
+            <constraints>
+              <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
           </component>
         </children>
       </grid>
@@ -212,7 +277,7 @@
           </grid>
         </children>
       </grid>
-      <grid id="e8701" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="e8701" layout-manager="GridLayoutManager" row-count="10" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -222,7 +287,7 @@
         <children>
           <component id="2351b" class="javax.swing.JTextField" binding="maxMessages">
             <constraints>
-              <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -232,7 +297,7 @@
           </component>
           <component id="ee88a" class="javax.swing.JLabel" binding="maxMessagesLabel">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Max Messages"/>
@@ -240,7 +305,7 @@
           </component>
           <vspacer id="37a05">
             <constraints>
-              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+              <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
             </constraints>
           </vspacer>
           <component id="f214a" class="javax.swing.JLabel" binding="consumerNameLabel">
@@ -253,7 +318,7 @@
           </component>
           <component id="39cf" class="javax.swing.JLabel" binding="consumerClassLabel">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Consumer Class"/>
@@ -270,7 +335,7 @@
           </component>
           <component id="e126b" class="javax.swing.JTextField" binding="consumerClass">
             <constraints>
-              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -280,7 +345,7 @@
           </component>
           <component id="4f7be" class="javax.swing.JLabel" binding="consumerDirectoryLabel">
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Consumer Directory"/>
@@ -288,7 +353,7 @@
           </component>
           <component id="22658" class="javax.swing.JTextField" binding="consumerDirectory">
             <constraints>
-              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -311,6 +376,38 @@
               </grid>
             </constraints>
             <properties/>
+          </component>
+          <component id="f9c30" class="javax.swing.JLabel" binding="consumerNameErrorMessage">
+            <constraints>
+              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="766b1" class="javax.swing.JLabel" binding="consumerClassErrorMessage">
+            <constraints>
+              <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="d6841" class="javax.swing.JLabel" binding="maxMessagesErrorMessage">
+            <constraints>
+              <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="2dfbc" class="javax.swing.JLabel" binding="consumerDirectoryErrorMessage">
+            <constraints>
+              <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
           </component>
         </children>
       </grid>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewMessageQueueDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewMessageQueueDialog.java
@@ -19,6 +19,7 @@ import com.magento.idea.magento2plugin.actions.generation.dialog.validator.annot
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.AlphaWithDashRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.AlphaWithPeriodRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.AlphanumericWithUnderscoreRule;
+import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.DirectoryRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.Lowercase;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.NotEmptyRule;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.NumericRule;
@@ -55,10 +56,12 @@ public class NewMessageQueueDialog extends AbstractDialog {
 
     private static final String TOPIC_NAME = "Topic Name";
     private static final String HANDLER_NAME = "Handler Name";
-    private static final String HANDLER_TYPE = "Handler Type";
+    private static final String HANDLER_TYPE = "Handler Class";
+    private static final String HANDLER_DIR = "Handler Directory";
     private static final String CONSUMER_NAME = "Consumer Name";
     private static final String QUEUE_NAME = "Queue Name";
-    private static final String CONSUMER_TYPE = "Consumer Type";
+    private static final String CONSUMER_TYPE = "Consumer Class";
+    private static final String CONSUMER_DIR = "Consumer Directory";
     private static final String MAX_MESSAGES = "Maximum Messages";
     private static final String EXCHANGE_NAME = "Exchange Name";
     private static final String BINDING_ID = "Binding ID";
@@ -69,22 +72,18 @@ public class NewMessageQueueDialog extends AbstractDialog {
     private final String moduleName;
 
     /* TODO: Improve validation */
-    @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
-            message = {NotEmptyRule.MESSAGE, TOPIC_NAME})
+    @FieldValidation(rule = RuleRegistry.NOT_EMPTY, message = {NotEmptyRule.MESSAGE, TOPIC_NAME})
     @FieldValidation(rule = RuleRegistry.ALPHA_WITH_PERIOD,
             message = {AlphaWithPeriodRule.MESSAGE, TOPIC_NAME})
-    @FieldValidation(rule = RuleRegistry.LOWERCASE,
-            message = {Lowercase.MESSAGE, TOPIC_NAME})
+    @FieldValidation(rule = RuleRegistry.LOWERCASE, message = {Lowercase.MESSAGE, TOPIC_NAME})
     private JTextField topicName;
 
-    @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
-            message = {NotEmptyRule.MESSAGE, HANDLER_NAME})
+    @FieldValidation(rule = RuleRegistry.NOT_EMPTY, message = {NotEmptyRule.MESSAGE, HANDLER_NAME})
     @FieldValidation(rule = RuleRegistry.ALPHA_WITH_PERIOD,
             message = {AlphanumericWithUnderscoreRule.MESSAGE, HANDLER_NAME})
     private JTextField handlerName;
 
-    @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
-            message = {NotEmptyRule.MESSAGE, HANDLER_TYPE})
+    @FieldValidation(rule = RuleRegistry.NOT_EMPTY, message = {NotEmptyRule.MESSAGE, HANDLER_TYPE})
     @FieldValidation(rule = RuleRegistry.PHP_CLASS,
             message = {PhpClassFqnRule.MESSAGE, HANDLER_TYPE})
     private JTextField handlerClass;
@@ -93,16 +92,13 @@ public class NewMessageQueueDialog extends AbstractDialog {
             message = {NotEmptyRule.MESSAGE, CONSUMER_NAME})
     @FieldValidation(rule = RuleRegistry.ALPHA_WITH_PERIOD,
             message = {AlphaWithPeriodRule.MESSAGE, CONSUMER_NAME})
-    @FieldValidation(rule = RuleRegistry.LOWERCASE,
-            message = {Lowercase.MESSAGE, CONSUMER_NAME})
+    @FieldValidation(rule = RuleRegistry.LOWERCASE, message = {Lowercase.MESSAGE, CONSUMER_NAME})
     private JTextField consumerName;
 
-    @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
-            message = {NotEmptyRule.MESSAGE, QUEUE_NAME})
+    @FieldValidation(rule = RuleRegistry.NOT_EMPTY, message = {NotEmptyRule.MESSAGE, QUEUE_NAME})
     @FieldValidation(rule = RuleRegistry.ALPHA_WITH_PERIOD,
             message = {AlphaWithPeriodRule.MESSAGE, QUEUE_NAME})
-    @FieldValidation(rule = RuleRegistry.LOWERCASE,
-            message = {Lowercase.MESSAGE, QUEUE_NAME})
+    @FieldValidation(rule = RuleRegistry.LOWERCASE, message = {Lowercase.MESSAGE, QUEUE_NAME})
     private JTextField queueName;
 
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
@@ -111,10 +107,8 @@ public class NewMessageQueueDialog extends AbstractDialog {
             message = {PhpClassFqnRule.MESSAGE, CONSUMER_TYPE})
     private JTextField consumerClass;
 
-    @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
-            message = {NotEmptyRule.MESSAGE, MAX_MESSAGES})
-    @FieldValidation(rule = RuleRegistry.NUMERIC,
-            message = {NumericRule.MESSAGE, MAX_MESSAGES})
+    @FieldValidation(rule = RuleRegistry.NOT_EMPTY, message = {NotEmptyRule.MESSAGE, MAX_MESSAGES})
+    @FieldValidation(rule = RuleRegistry.NUMERIC, message = {NumericRule.MESSAGE, MAX_MESSAGES})
     private JTextField maxMessages;
 
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
@@ -123,8 +117,7 @@ public class NewMessageQueueDialog extends AbstractDialog {
             message = {AlphaWithDashRule.MESSAGE, EXCHANGE_NAME})
     private JTextField exchangeName;
 
-    @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
-            message = {NotEmptyRule.MESSAGE, BINDING_ID})
+    @FieldValidation(rule = RuleRegistry.NOT_EMPTY, message = {NotEmptyRule.MESSAGE, BINDING_ID})
     @FieldValidation(rule = RuleRegistry.ALPHANUMERIC_WITH_UNDERSCORE,
             message = {AlphaWithDashRule.MESSAGE, BINDING_ID})
     private JTextField bindingId;
@@ -135,7 +128,12 @@ public class NewMessageQueueDialog extends AbstractDialog {
             message = {AlphanumericWithUnderscoreRule.MESSAGE, BINDING_TOPIC})
     private JTextField bindingTopic;
 
+    @FieldValidation(rule = RuleRegistry.NOT_EMPTY, message = {NotEmptyRule.MESSAGE, CONSUMER_DIR})
+    @FieldValidation(rule = RuleRegistry.DIRECTORY, message = {DirectoryRule.MESSAGE, CONSUMER_DIR})
     private JTextField consumerDirectory;
+
+    @FieldValidation(rule = RuleRegistry.NOT_EMPTY, message = {NotEmptyRule.MESSAGE, HANDLER_DIR})
+    @FieldValidation(rule = RuleRegistry.DIRECTORY, message = {DirectoryRule.MESSAGE, HANDLER_DIR})
     private JTextField handlerDirectory;
 
     private JPanel contentPanel;
@@ -148,6 +146,19 @@ public class NewMessageQueueDialog extends AbstractDialog {
     private JLabel handlerClassLabel;//NOPMD
     private JLabel consumerNameLabel;//NOPMD
     private JLabel handlerDirectoryLabel;//NOPMD
+
+    private JLabel topicNameErrorMessage;//NOPMD
+    private JLabel handlerNameErrorMessage;//NOPMD
+    private JLabel handlerClassErrorMessage;//NOPMD
+    private JLabel consumerNameErrorMessage;//NOPMD
+    private JLabel queueNameErrorMessage;//NOPMD
+    private JLabel consumerClassErrorMessage;//NOPMD
+    private JLabel maxMessagesErrorMessage;//NOPMD
+    private JLabel exchangeNameErrorMessage;//NOPMD
+    private JLabel bindingIdErrorMessage;//NOPMD
+    private JLabel bindingTopicErrorMessage;//NOPMD
+    private JLabel consumerDirectoryErrorMessage;//NOPMD
+    private JLabel handlerDirectoryErrorMessage;//NOPMD
 
     /**
      * Constructor.

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewMessageQueueDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewMessageQueueDialog.java
@@ -52,6 +52,7 @@ import org.jetbrains.annotations.NotNull;
         "PMD.ExcessiveImports",
 })
 public class NewMessageQueueDialog extends AbstractDialog {
+
     private static final String TOPIC_NAME = "Topic Name";
     private static final String HANDLER_NAME = "Handler Name";
     private static final String HANDLER_TYPE = "Handler Type";
@@ -64,6 +65,8 @@ public class NewMessageQueueDialog extends AbstractDialog {
     private static final String BINDING_TOPIC = "Binding Topic";
 
     private JComboBox connectionName;
+    private final Project project;
+    private final String moduleName;
 
     /* TODO: Improve validation */
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
@@ -146,13 +149,16 @@ public class NewMessageQueueDialog extends AbstractDialog {
     private JLabel consumerNameLabel;//NOPMD
     private JLabel handlerDirectoryLabel;//NOPMD
 
-    private final Project project;
-    private final String moduleName;
-
     /**
      * Constructor.
+     *
+     * @param project Project
+     * @param directory PsiDirectory
      */
-    public NewMessageQueueDialog(final Project project, final PsiDirectory directory) {
+    public NewMessageQueueDialog(
+            final @NotNull Project project,
+            final @NotNull PsiDirectory directory
+    ) {
         super();
 
         this.project = project;
@@ -224,17 +230,18 @@ public class NewMessageQueueDialog extends AbstractDialog {
 
     /**
      * Opens the dialog window.
+     *
+     * @param project Project
+     * @param directory PsiDirectory
      */
-    public static void open(final Project project, final PsiDirectory directory) {
+    public static void open(
+            final @NotNull Project project,
+            final @NotNull PsiDirectory directory
+    ) {
         final NewMessageQueueDialog dialog = new NewMessageQueueDialog(project, directory);
         dialog.pack();
         dialog.centerDialog(dialog);
         dialog.setVisible(true);
-    }
-
-    @Override
-    public void onCancel() {
-        dispose();
     }
 
     private void onOK() {
@@ -248,8 +255,8 @@ public class NewMessageQueueDialog extends AbstractDialog {
             if (getConnectionName().equals(MessageQueueConnections.DB.getType())) {
                 generateConsumerClass();
             }
+            exit();
         }
-        exit();
     }
 
     private void generateCommunication() {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModelsDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModelsDialog.form
@@ -3,10 +3,10 @@
   <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
-      <xy x="48" y="54" width="454" height="423"/>
+      <xy x="48" y="54" width="454" height="426"/>
     </constraints>
     <properties>
-      <preferredSize width="450" height="300"/>
+      <preferredSize width="450" height="360"/>
     </properties>
     <border type="none"/>
     <children>
@@ -51,7 +51,7 @@
           </grid>
         </children>
       </grid>
-      <grid id="e3588" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="e3588" layout-manager="GridLayoutManager" row-count="12" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -77,7 +77,7 @@
           </component>
           <component id="c77c5" class="javax.swing.JTextField" binding="dbTableName">
             <constraints>
-              <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -85,7 +85,7 @@
           </component>
           <component id="4081c" class="javax.swing.JLabel" binding="dbTableNameLabel">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="DB Table Name"/>
@@ -93,7 +93,7 @@
           </component>
           <component id="80b3c" class="javax.swing.JLabel" binding="resourceModelLabel">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Resource Model Name"/>
@@ -101,7 +101,7 @@
           </component>
           <component id="53105" class="javax.swing.JTextField" binding="resourceModelName">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -109,7 +109,7 @@
           </component>
           <component id="4f1ae" class="javax.swing.JTextField" binding="entityIdColumn">
             <constraints>
-              <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="10" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -119,7 +119,7 @@
           </component>
           <component id="cb7cf" class="javax.swing.JLabel" binding="entityIdColumnLabel">
             <constraints>
-              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Entity ID Column"/>
@@ -127,7 +127,7 @@
           </component>
           <component id="a4d4e" class="javax.swing.JTextField" binding="collectionName">
             <constraints>
-              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -137,7 +137,7 @@
           </component>
           <component id="2763d" class="javax.swing.JLabel" binding="collectionNameLabel">
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Collection Name"/>
@@ -145,7 +145,7 @@
           </component>
           <component id="2c62a" class="javax.swing.JTextField" binding="collectionDirectory">
             <constraints>
-              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -155,10 +155,58 @@
           </component>
           <component id="ec37" class="javax.swing.JLabel" binding="collectionDirectoryLabel">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Collection Directory"/>
+            </properties>
+          </component>
+          <component id="81d78" class="javax.swing.JLabel" binding="modelNameErrorMessage">
+            <constraints>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="37560" class="javax.swing.JLabel" binding="resourceModelNameErrorMessage">
+            <constraints>
+              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="a162b" class="javax.swing.JLabel" binding="dbTableNameErrorMessage">
+            <constraints>
+              <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="53623" class="javax.swing.JLabel" binding="entityIdColumnErrorMessage">
+            <constraints>
+              <grid row="11" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="6d038" class="javax.swing.JLabel" binding="collectionDirectoryErrorMessage">
+            <constraints>
+              <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+          <component id="ab299" class="javax.swing.JLabel" binding="collectionNameErrorMessage">
+            <constraints>
+              <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value=""/>
             </properties>
           </component>
         </children>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModelsDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModelsDialog.java
@@ -92,6 +92,12 @@ public class NewModelsDialog extends AbstractDialog {
     private JLabel entityIdColumnLabel;//NOPMD
     private JLabel collectionDirectoryLabel;//NOPMD
     private JLabel collectionNameLabel;//NOPMD
+    private JLabel modelNameErrorMessage;//NOPMD
+    private JLabel resourceModelNameErrorMessage;//NOPMD
+    private JLabel dbTableNameErrorMessage;//NOPMD
+    private JLabel entityIdColumnErrorMessage;//NOPMD
+    private JLabel collectionDirectoryErrorMessage;//NOPMD
+    private JLabel collectionNameErrorMessage;//NOPMD
 
     /**
      * Open new dialog for adding new controller.

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModelsDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewModelsDialog.java
@@ -35,6 +35,7 @@ import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("PMD.TooManyFields")
 public class NewModelsDialog extends AbstractDialog {
+
     private final String moduleName;
     private final Project project;
     private JPanel contentPane;
@@ -160,11 +161,6 @@ public class NewModelsDialog extends AbstractDialog {
         dialog.setVisible(true);
     }
 
-    @Override
-    protected void onCancel() {
-        dispose();
-    }
-
     /**
      * Process generation.
      */
@@ -173,8 +169,8 @@ public class NewModelsDialog extends AbstractDialog {
             generateModelFile();
             generateResourceModelFile();
             generateCollectionFile();
+            exit();
         }
-        exit();
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewUiComponentGridDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewUiComponentGridDialog.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="contentPanel" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
-      <xy x="20" y="14" width="636" height="825"/>
+      <xy x="20" y="14" width="636" height="1050"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -65,7 +65,7 @@
             <properties/>
             <border type="none"/>
             <children>
-              <grid id="6f89d" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="6f89d" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -75,7 +75,7 @@
                 <children>
                   <component id="30ea0" class="javax.swing.JTextField" binding="idField">
                     <constraints>
-                      <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                      <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                         <preferred-size width="150" height="-1"/>
                       </grid>
                     </constraints>
@@ -85,7 +85,7 @@
                   </component>
                   <component id="89d9c" class="javax.swing.JLabel">
                     <constraints>
-                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text resource-bundle="magento2/common" key="common.entityIdField"/>
@@ -93,7 +93,7 @@
                   </component>
                   <component id="1b13f" class="com.magento.idea.magento2plugin.ui.FilteredComboBox" binding="areaSelect" custom-create="true">
                     <constraints>
-                      <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <toolTipText value=""/>
@@ -104,7 +104,7 @@
                   </component>
                   <component id="c6e" class="javax.swing.JLabel">
                     <constraints>
-                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text resource-bundle="magento2/common" key="common.area.target"/>
@@ -135,9 +135,25 @@
                       <text value="General Information"/>
                     </properties>
                   </component>
+                  <component id="60e80" class="javax.swing.JLabel" binding="uiComponentNameErrorMessage">
+                    <constraints>
+                      <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
+                  <component id="2be9a" class="javax.swing.JLabel" binding="idFieldErrorMessage">
+                    <constraints>
+                      <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
                 </children>
               </grid>
-              <grid id="3036c" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="3036c" layout-manager="GridLayoutManager" row-count="9" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -155,7 +171,7 @@
                   </component>
                   <component id="4d93" class="javax.swing.JLabel" binding="sortOrderLabel">
                     <constraints>
-                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text value="Sort Order"/>
@@ -163,7 +179,7 @@
                   </component>
                   <component id="40a2b" class="javax.swing.JLabel" binding="menuIdentifierLabel">
                     <constraints>
-                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text value="Identifier"/>
@@ -171,7 +187,7 @@
                   </component>
                   <component id="ec0f7" class="javax.swing.JTextField" binding="sortOrder">
                     <constraints>
-                      <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                      <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                         <preferred-size width="150" height="-1"/>
                       </grid>
                     </constraints>
@@ -179,7 +195,7 @@
                   </component>
                   <component id="1264b" class="javax.swing.JTextField" binding="menuIdentifier">
                     <constraints>
-                      <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                      <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                         <preferred-size width="150" height="-1"/>
                       </grid>
                     </constraints>
@@ -187,7 +203,7 @@
                   </component>
                   <component id="4e6de" class="javax.swing.JLabel" binding="menuTitleLabel">
                     <constraints>
-                      <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text value="Title"/>
@@ -195,7 +211,7 @@
                   </component>
                   <component id="9a0c1" class="javax.swing.JTextField" binding="menuTitle" default-binding="true">
                     <constraints>
-                      <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                      <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                         <preferred-size width="150" height="-1"/>
                       </grid>
                     </constraints>
@@ -216,9 +232,41 @@
                       <text value="Menu"/>
                     </properties>
                   </component>
+                  <component id="54789" class="javax.swing.JLabel" binding="sortOrderErrorMessage">
+                    <constraints>
+                      <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
+                  <component id="8175e" class="javax.swing.JLabel" binding="menuIdentifierErrorMessage">
+                    <constraints>
+                      <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
+                  <component id="ac609" class="javax.swing.JLabel" binding="menuTitleErrorMessage">
+                    <constraints>
+                      <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
+                  <component id="c9304" class="javax.swing.JLabel" binding="parentMenuErrorMessage">
+                    <constraints>
+                      <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
                 </children>
               </grid>
-              <grid id="43bd9" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="43bd9" layout-manager="GridLayoutManager" row-count="8" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -266,7 +314,7 @@
                   </component>
                   <component id="d07c7" class="javax.swing.JLabel" binding="dataProviderParentDirectoryLabel">
                     <constraints>
-                      <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text resource-bundle="magento2/common" key="common.parentDirectory"/>
@@ -274,7 +322,7 @@
                   </component>
                   <component id="6da57" class="javax.swing.JTextField" binding="dataProviderParentDirectory">
                     <constraints>
-                      <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                      <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                         <preferred-size width="150" height="-1"/>
                       </grid>
                     </constraints>
@@ -291,13 +339,13 @@
                   </component>
                   <component id="77176" class="com.magento.idea.magento2plugin.ui.FilteredComboBox" binding="collection" custom-create="true">
                     <constraints>
-                      <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties/>
                   </component>
                   <component id="d22c7" class="javax.swing.JLabel" binding="collectionLabel">
                     <constraints>
-                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text value="Collection"/>
@@ -305,7 +353,7 @@
                   </component>
                   <component id="218a2" class="javax.swing.JLabel" binding="tableNameLabel">
                     <constraints>
-                      <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text value="Table Name"/>
@@ -314,15 +362,31 @@
                   </component>
                   <component id="13c5a" class="javax.swing.JTextField" binding="tableName">
                     <constraints>
-                      <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                      <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                         <preferred-size width="150" height="-1"/>
                       </grid>
                     </constraints>
                     <properties/>
                   </component>
+                  <component id="fc26f" class="javax.swing.JLabel" binding="providerClassNameErrorMessage">
+                    <constraints>
+                      <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
+                  <component id="5a429" class="javax.swing.JLabel" binding="dataProviderParentDirectoryErrorMessage">
+                    <constraints>
+                      <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
                 </children>
               </grid>
-              <grid id="17b2a" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="17b2a" layout-manager="GridLayoutManager" row-count="7" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -340,7 +404,7 @@
                   </component>
                   <component id="e550" class="javax.swing.JLabel" binding="actionLabel">
                     <constraints>
-                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text value="Action"/>
@@ -348,7 +412,7 @@
                   </component>
                   <component id="2ec13" class="javax.swing.JLabel" binding="controllerLabel">
                     <constraints>
-                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text value="Controller"/>
@@ -364,7 +428,7 @@
                   </component>
                   <component id="2b2ed" class="javax.swing.JTextField" binding="controllerName">
                     <constraints>
-                      <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                      <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                         <preferred-size width="150" height="-1"/>
                       </grid>
                     </constraints>
@@ -372,7 +436,7 @@
                   </component>
                   <component id="d08e6" class="javax.swing.JTextField" binding="actionName">
                     <constraints>
-                      <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                      <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                         <preferred-size width="150" height="-1"/>
                       </grid>
                     </constraints>
@@ -387,9 +451,33 @@
                       <text value="Controller"/>
                     </properties>
                   </component>
+                  <component id="46ac2" class="javax.swing.JLabel" binding="routeErrorMessage">
+                    <constraints>
+                      <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
+                  <component id="7e72a" class="javax.swing.JLabel" binding="controllerNameErrorMessage">
+                    <constraints>
+                      <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
+                  <component id="542f3" class="javax.swing.JLabel" binding="actionNameErrorMessage">
+                    <constraints>
+                      <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
                 </children>
               </grid>
-              <grid id="ef801" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="ef801" layout-manager="GridLayoutManager" row-count="7" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -415,7 +503,7 @@
                   </component>
                   <component id="22346" class="javax.swing.JLabel" binding="parentAclID">
                     <constraints>
-                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text value="Parent ACL ID"/>
@@ -423,13 +511,13 @@
                   </component>
                   <component id="faef5" class="com.magento.idea.magento2plugin.ui.FilteredComboBox" binding="parentAcl" custom-create="true">
                     <constraints>
-                      <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties/>
                   </component>
                   <component id="d883f" class="javax.swing.JLabel" binding="aclTitleLabel">
                     <constraints>
-                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                      <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
                       <text value="Title"/>
@@ -437,7 +525,7 @@
                   </component>
                   <component id="69f6d" class="javax.swing.JTextField" binding="aclTitle">
                     <constraints>
-                      <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                      <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                         <preferred-size width="150" height="-1"/>
                       </grid>
                     </constraints>
@@ -450,6 +538,30 @@
                     <properties>
                       <font style="1"/>
                       <text value="ACL"/>
+                    </properties>
+                  </component>
+                  <component id="37cf3" class="javax.swing.JLabel" binding="aclErrorMessage">
+                    <constraints>
+                      <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
+                  <component id="c144a" class="javax.swing.JLabel" binding="parentAclErrorMessage">
+                    <constraints>
+                      <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
+                  <component id="61e69" class="javax.swing.JLabel" binding="aclTitleErrorMessage">
+                    <constraints>
+                      <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
                     </properties>
                   </component>
                 </children>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewUiComponentGridDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewUiComponentGridDialog.java
@@ -168,6 +168,8 @@ public class NewUiComponentGridDialog extends AbstractDialog {
             message = {NotEmptyRule.MESSAGE, "Parent Menu"})
     private FilteredComboBox parentMenu;
 
+    private JTextField tableName;
+
     private JLabel aclLabel;
     private JLabel routeLabel;//NOPMD
     private JLabel controllerLabel;//NOPMD
@@ -186,7 +188,20 @@ public class NewUiComponentGridDialog extends AbstractDialog {
     private JLabel collectionLabel;//NOPMD
     private JLabel dataProviderParentDirectoryLabel;
     private JLabel tableNameLabel;
-    private JTextField tableName;
+    private JLabel uiComponentNameErrorMessage;//NOPMD
+    private JLabel idFieldErrorMessage;//NOPMD
+    private JLabel providerClassNameErrorMessage;//NOPMD
+    private JLabel dataProviderParentDirectoryErrorMessage;//NOPMD
+    private JLabel aclErrorMessage;//NOPMD
+    private JLabel parentAclErrorMessage;//NOPMD
+    private JLabel aclTitleErrorMessage;//NOPMD
+    private JLabel routeErrorMessage;//NOPMD
+    private JLabel controllerNameErrorMessage;//NOPMD
+    private JLabel actionNameErrorMessage;//NOPMD
+    private JLabel sortOrderErrorMessage;//NOPMD
+    private JLabel menuIdentifierErrorMessage;//NOPMD
+    private JLabel menuTitleErrorMessage;//NOPMD
+    private JLabel parentMenuErrorMessage;//NOPMD
 
     /**
      * New UI component grid dialog constructor.

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewUiComponentGridDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewUiComponentGridDialog.java
@@ -79,6 +79,7 @@ import org.jetbrains.annotations.NotNull;
         "PMD.GodClass"
 })
 public class NewUiComponentGridDialog extends AbstractDialog {
+
     private static final String ACTION_NAME = "Action Name";
     private static final String DATA_PROVIDER_CLASS_NAME = "Data Provider Class Name";
     private static final String DATA_PROVIDER_DIRECTORY = "Data Provider Directory";
@@ -91,6 +92,16 @@ public class NewUiComponentGridDialog extends AbstractDialog {
     private JButton buttonOK;
     private JButton buttonCancel;
 
+    private JCheckBox addToolBar;
+    private JCheckBox addBookmarksCheckBox;
+    private JCheckBox addColumnsControlCheckBox;
+    private JCheckBox addFullTextSearchCheckBox;
+    private JCheckBox addListingFiltersCheckBox;
+    private JCheckBox addListingPagingCheckBox;
+    private FilteredComboBox collection;
+    private FilteredComboBox dataProviderType;
+    private FilteredComboBox areaSelect;
+
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY, message = {NotEmptyRule.MESSAGE, NAME})
     @FieldValidation(rule = RuleRegistry.IDENTIFIER, message = {IdentifierRule.MESSAGE, NAME})
     private JTextField uiComponentName;
@@ -98,17 +109,6 @@ public class NewUiComponentGridDialog extends AbstractDialog {
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY, message = {NotEmptyRule.MESSAGE, NAME})
     @FieldValidation(rule = RuleRegistry.IDENTIFIER, message = {IdentifierRule.MESSAGE, NAME})
     private JTextField idField;
-
-    private JCheckBox addToolBar;
-    private JCheckBox addBookmarksCheckBox;
-    private JCheckBox addColumnsControlCheckBox;
-    private JCheckBox addFullTextSearchCheckBox;
-    private JCheckBox addListingFiltersCheckBox;
-    private JCheckBox addListingPagingCheckBox;
-
-    private FilteredComboBox collection;
-    private FilteredComboBox dataProviderType;
-    private FilteredComboBox areaSelect;
 
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
             message = {NotEmptyRule.MESSAGE, DATA_PROVIDER_CLASS_NAME})
@@ -194,7 +194,10 @@ public class NewUiComponentGridDialog extends AbstractDialog {
      * @param project Project
      * @param directory PsiDirectory
      */
-    public NewUiComponentGridDialog(final Project project, final PsiDirectory directory) {
+    public NewUiComponentGridDialog(
+            final @NotNull Project project,
+            final @NotNull PsiDirectory directory
+    ) {
         super();
         this.project = project;
         this.moduleName = GetModuleNameByDirectoryUtil.execute(directory, project);
@@ -244,7 +247,10 @@ public class NewUiComponentGridDialog extends AbstractDialog {
      * @param project Project
      * @param directory PsiDirectory
      */
-    public static void open(final Project project, final PsiDirectory directory) {
+    public static void open(
+            final @NotNull Project project,
+            final @NotNull PsiDirectory directory
+    ) {
         final NewUiComponentGridDialog dialog = new NewUiComponentGridDialog(project, directory);
         dialog.pack();
         dialog.centerDialog(dialog);
@@ -312,8 +318,8 @@ public class NewUiComponentGridDialog extends AbstractDialog {
             generateDataProviderClass();
             generateDataProviderDeclaration();
             generateUiComponentFile();
+            exit();
         }
-        exit();
     }
 
     private void setDefaultValues() {
@@ -352,7 +358,7 @@ public class NewUiComponentGridDialog extends AbstractDialog {
      * Generate data provider class.
      */
     private void generateDataProviderClass() {
-        if (getDataProviderType().equals(UiComponentDataProviderFile.CUSTOM_TYPE)) {
+        if (UiComponentDataProviderFile.CUSTOM_TYPE.equals(getDataProviderType())) {
             final UiComponentDataProviderGenerator dataProviderGenerator;
             dataProviderGenerator = new UiComponentDataProviderGenerator(
                 getGridDataProviderData(),
@@ -367,7 +373,7 @@ public class NewUiComponentGridDialog extends AbstractDialog {
      * Generate data provider declaration.
      */
     private void generateDataProviderDeclaration() {
-        if (getDataProviderType().equals(UiComponentDataProviderFile.COLLECTION_TYPE)) {
+        if (UiComponentDataProviderFile.COLLECTION_TYPE.equals(getDataProviderType())) {
             final DataProviderDeclarationGenerator dataProviderGenerator;
             dataProviderGenerator = new DataProviderDeclarationGenerator(
                 new DataProviderDeclarationData(
@@ -463,8 +469,8 @@ public class NewUiComponentGridDialog extends AbstractDialog {
     }
 
     private void onDataProviderTypeChange() {
-        final boolean visible = getDataProviderType().equals(
-                UiComponentDataProviderFile.COLLECTION_TYPE
+        final boolean visible = UiComponentDataProviderFile.COLLECTION_TYPE.equals(
+                getDataProviderType()
         );
 
         collection.setVisible(visible);
@@ -554,7 +560,7 @@ public class NewUiComponentGridDialog extends AbstractDialog {
     }
 
     private String getDataProviderClassFqn() {
-        if (!getDataProviderType().equals(UiComponentDataProviderFile.CUSTOM_TYPE)) {
+        if (!UiComponentDataProviderFile.CUSTOM_TYPE.equals(getDataProviderType())) {
             return UiComponentDataProviderFile.DEFAULT_DATA_PROVIDER;
         }
         return String.format(


### PR DESCRIPTION
**Description** (*)

Enhanced error outputting for the new Magento 2 UI Grid generation.

<img width="1398" alt="Screenshot 2021-12-23 at 09 51 39" src="https://user-images.githubusercontent.com/31848341/147207428-492cbf04-807c-496f-bd87-4899d74610b7.png">
<img width="1398" alt="Screenshot 2021-12-23 at 09 51 42" src="https://user-images.githubusercontent.com/31848341/147207425-d6c00bbc-d6c4-4308-85a9-b8e6d3e3d949.png">
<img width="1398" alt="Screenshot 2021-12-23 at 09 53 21" src="https://user-images.githubusercontent.com/31848341/147207407-5529c371-4651-4559-870e-67a4b36e2134.png">


**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#878

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
