### PR TITLE
857: fixed error when class already exists

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleControllerClassGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/ModuleControllerClassGenerator.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.swing.JOptionPane;
 
 public class ModuleControllerClassGenerator extends FileGenerator {
@@ -73,6 +74,8 @@ public class ModuleControllerClassGenerator extends FileGenerator {
     @Override
     public PsiFile generate(final String actionName) {
         final PsiFile[] controllerFiles = new PsiFile[1];
+        final AtomicBoolean isControllerExists = new AtomicBoolean(false);
+        final AtomicBoolean isControllerCanNotBeCreated = new AtomicBoolean(false);
 
         WriteCommandAction.runWriteCommandAction(project, () -> {
             PhpClass controller = GetPhpClassByFQN.getInstance(project).execute(
@@ -80,39 +83,39 @@ public class ModuleControllerClassGenerator extends FileGenerator {
             );
 
             if (controller != null) {
-                final String errorMessage = this.validatorBundle.message(
-                        "validator.file.alreadyExists",
-                        "Controller Class"
-                );
-                JOptionPane.showMessageDialog(
-                        null,
-                        errorMessage,
-                        commonBundle.message("common.error"),
-                        JOptionPane.ERROR_MESSAGE
-                );
-
+                isControllerExists.set(true);
                 return;
             }
-
             controller = createControllerClass(actionName);
 
             if (controller == null) {
-                final String errorMessage = this.validatorBundle.message(
-                        "validator.file.cantBeCreated",
-                        "Controller Class"
-                );
-                JOptionPane.showMessageDialog(
-                        null,
-                        errorMessage,
-                        commonBundle.message("common.error"),
-                        JOptionPane.ERROR_MESSAGE
-                );
-
+                isControllerCanNotBeCreated.set(true);
                 return;
             }
-
             controllerFiles[0] = controller.getContainingFile();
         });
+
+        if (isControllerExists.get()) {
+            JOptionPane.showMessageDialog(
+                    null,
+                    validatorBundle.message(
+                            "validator.file.alreadyExists",
+                            "Controller Class"
+                    ),
+                    commonBundle.message("common.error"),
+                    JOptionPane.ERROR_MESSAGE
+            );
+        } else if (isControllerCanNotBeCreated.get()) {
+            JOptionPane.showMessageDialog(
+                    null,
+                    validatorBundle.message(
+                            "validator.file.cantBeCreated",
+                            "Controller Class"
+                    ),
+                    commonBundle.message("common.error"),
+                    JOptionPane.ERROR_MESSAGE
+            );
+        }
 
         return controllerFiles[0];
     }


### PR DESCRIPTION
1. Fixes magento/magento2-phpstorm-plugin#857

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
