### PR TITLE
866: IndexNotReadyException while opening a context menu

### DIFF
--- a/src/com/magento/idea/magento2plugin/indexes/ModuleIndex.java
+++ b/src/com/magento/idea/magento2plugin/indexes/ModuleIndex.java
@@ -119,12 +119,12 @@ public final class ModuleIndex {
      * @return PsiDirectory
      */
     public @Nullable PsiDirectory getModuleDirectoryByModuleName(final String moduleName) {
-        final FileBasedIndex index = FileBasedIndex
-                .getInstance();
-
         if (DumbService.getInstance(project).isDumb()) {
             return null;
         }
+        final FileBasedIndex index = FileBasedIndex
+                .getInstance();
+
         final Collection<VirtualFile> files = index.getContainingFiles(
                 ModuleNameIndex.KEY,
                 moduleName,

--- a/src/com/magento/idea/magento2plugin/indexes/ModuleIndex.java
+++ b/src/com/magento/idea/magento2plugin/indexes/ModuleIndex.java
@@ -5,6 +5,7 @@
 
 package com.magento.idea.magento2plugin.indexes;
 
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -120,6 +121,10 @@ public final class ModuleIndex {
     public @Nullable PsiDirectory getModuleDirectoryByModuleName(final String moduleName) {
         final FileBasedIndex index = FileBasedIndex
                 .getInstance();
+
+        if (DumbService.getInstance(project).isDumb()) {
+            return null;
+        }
         final Collection<VirtualFile> files = index.getContainingFiles(
                 ModuleNameIndex.KEY,
                 moduleName,


### PR DESCRIPTION
1. Fixes magento/magento2-phpstorm-plugin#866

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
