### PR TITLE
834: module name declaration inspection flags valid code

### DIFF
--- a/src/com/magento/idea/magento2plugin/inspections/php/ModuleDeclarationInRegistrationPhpInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/php/ModuleDeclarationInRegistrationPhpInspection.java
@@ -21,9 +21,8 @@ import org.jetbrains.annotations.NotNull;
 
 public class ModuleDeclarationInRegistrationPhpInspection extends PhpInspection {
 
-    @NotNull
     @Override
-    public PsiElementVisitor buildVisitor(
+    public @NotNull PsiElementVisitor buildVisitor(
             final @NotNull ProblemsHolder problemsHolder,
             final boolean isOnTheFly
     ) {
@@ -33,19 +32,22 @@ public class ModuleDeclarationInRegistrationPhpInspection extends PhpInspection 
             public void visitPhpStringLiteralExpression(final StringLiteralExpression expression) {
                 final PsiFile file =  expression.getContainingFile();
                 final String filename = file.getName();
-                if (!filename.equals(RegistrationPhp.FILE_NAME)) {
+
+                if (!RegistrationPhp.FILE_NAME.equals(filename)) {
                         return;
                 }
+
                 if (!IsFileInEditableModuleUtil.execute(file)) {
                         return;
                 }
                 final String expectedName = GetEditableModuleNameByRootFileUtil.execute(file);
                 final String actualName = expression.getContents();
+
                 if (actualName.equals(expectedName)) {
                         return;
                 }
-
                 final InspectionBundle inspectionBundle = new InspectionBundle();
+
                 problemsHolder.registerProblem(
                         expression,
                         inspectionBundle.message(

--- a/src/com/magento/idea/magento2plugin/inspections/php/ModuleDeclarationInRegistrationPhpInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/php/ModuleDeclarationInRegistrationPhpInspection.java
@@ -7,15 +7,21 @@ package com.magento.idea.magento2plugin.inspections.php;
 
 import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.PsiTreeUtil;
 import com.jetbrains.php.lang.inspections.PhpInspection;
+import com.jetbrains.php.lang.psi.elements.Method;
+import com.jetbrains.php.lang.psi.elements.MethodReference;
+import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
 import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor;
 import com.magento.idea.magento2plugin.bundles.InspectionBundle;
 import com.magento.idea.magento2plugin.inspections.php.fix.PhpModuleNameQuickFix;
 import com.magento.idea.magento2plugin.inspections.util.GetEditableModuleNameByRootFileUtil;
 import com.magento.idea.magento2plugin.magento.files.RegistrationPhp;
+import com.magento.idea.magento2plugin.magento.packages.code.FrameworkLibraryType;
 import com.magento.idea.magento2plugin.util.magento.IsFileInEditableModuleUtil;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,17 +40,38 @@ public class ModuleDeclarationInRegistrationPhpInspection extends PhpInspection 
                 final String filename = file.getName();
 
                 if (!RegistrationPhp.FILE_NAME.equals(filename)) {
-                        return;
+                    return;
+                }
+                final MethodReference callerReference = PsiTreeUtil.getParentOfType(
+                        expression,
+                        MethodReference.class
+                );
+
+                if (callerReference == null) {
+                    return;
+                }
+                final PsiElement caller = callerReference.resolve();
+
+                if (!(caller instanceof Method)) {
+                    return;
+                }
+                final PhpClass callerOwner = ((Method) caller).getContainingClass();
+
+                if (callerOwner == null
+                        || !FrameworkLibraryType.COMPONENT_REGISTRAR.getType().equals(
+                                callerOwner.getPresentableFQN()
+                )) {
+                    return;
                 }
 
                 if (!IsFileInEditableModuleUtil.execute(file)) {
-                        return;
+                    return;
                 }
                 final String expectedName = GetEditableModuleNameByRootFileUtil.execute(file);
                 final String actualName = expression.getContents();
 
                 if (actualName.equals(expectedName)) {
-                        return;
+                    return;
                 }
                 final InspectionBundle inspectionBundle = new InspectionBundle();
 

--- a/src/com/magento/idea/magento2plugin/magento/packages/code/FrameworkLibraryType.java
+++ b/src/com/magento/idea/magento2plugin/magento/packages/code/FrameworkLibraryType.java
@@ -13,6 +13,7 @@ public enum FrameworkLibraryType {
     ABSTRACT_COLLECTION(
             "Magento\\Framework\\Model\\ResourceModel\\Db\\Collection\\AbstractCollection"
     ),
+    COMPONENT_REGISTRAR("Magento\\Framework\\Component\\ComponentRegistrar"),
     COLLECTION_PROCESSOR("Magento\\Framework\\Api\\SearchCriteria\\CollectionProcessorInterface"),
     DATA_PERSISTOR("Magento\\Framework\\App\\Request\\DataPersistorInterface"),
     DATA_OBJECT("Magento\\Framework\\DataObject"),

--- a/testData/project/magento2/vendor/magento/framework/Component/ComponentRegistrar.php
+++ b/testData/project/magento2/vendor/magento/framework/Component/ComponentRegistrar.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Component;
+
+/**
+ * Provides ability to statically register components.
+ *
+ * @api
+ * @since 100.0.2
+ */
+class ComponentRegistrar implements ComponentRegistrarInterface
+{
+    /**#@+
+     * Different types of components
+     */
+    const MODULE = 'module';
+    const LIBRARY = 'library';
+    const THEME = 'theme';
+    const LANGUAGE = 'language';
+    const SETUP = 'setup';
+    /**#@- */
+
+    /**#@- */
+    private static $paths = [
+        self::MODULE => [],
+        self::LIBRARY => [],
+        self::LANGUAGE => [],
+        self::THEME => [],
+        self::SETUP => []
+    ];
+
+    /**
+     * Sets the location of a component.
+     *
+     * @param string $type component type
+     * @param string $componentName Fully-qualified component name
+     * @param string $path Absolute file path to the component
+     * @throws \LogicException
+     * @return void
+     */
+    public static function register($type, $componentName, $path)
+    {
+        self::validateType($type);
+        if (isset(self::$paths[$type][$componentName])) {
+            throw new \LogicException(
+                ucfirst($type) . ' \'' . $componentName . '\' from \'' . $path . '\' '
+                . 'has been already defined in \'' . self::$paths[$type][$componentName] . '\'.'
+            );
+        }
+        self::$paths[$type][$componentName] = str_replace('\\', '/', $path);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPaths($type)
+    {
+        self::validateType($type);
+        return self::$paths[$type];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPath($type, $componentName)
+    {
+        self::validateType($type);
+        return self::$paths[$type][$componentName] ?? null;
+    }
+
+    /**
+     * Checks if type of component is valid
+     *
+     * @param string $type
+     * @return void
+     * @throws \LogicException
+     */
+    private static function validateType($type)
+    {
+        if (!isset(self::$paths[$type])) {
+            throw new \LogicException('\'' . $type . '\' is not a valid component type');
+        }
+    }
+}


### PR DESCRIPTION
**Description** (*)

Fixed module name declaration inspection flags valid code.

**Issue was reproduced before fixing it:**

<img width="1237" alt="Screenshot 2021-12-24 at 10 15 19" src="https://user-images.githubusercontent.com/31848341/147341546-e41295c3-73c1-41f8-8419-f57d09ae29d1.png">

**Result:**

<img width="1005" alt="Screenshot 2021-12-24 at 10 15 07" src="https://user-images.githubusercontent.com/31848341/147341556-fd9d7e9c-44a0-436b-af99-16f34c055ab8.png">

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#834

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
