### PR TITLE
590: The plugin inspection does not work correctly

### DIFF
--- a/src/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/xml/PluginDeclarationInspection.java
@@ -119,8 +119,11 @@ public class PluginDeclarationInspection extends PhpInspection {
                                     pluginIndex,
                                     file
                         );
+                        final XmlAttribute pluginTypeAttribute =
+                                pluginTypeXmlTag.getAttribute(ModuleDiXml.TYPE_ATTR);
 
                         if (pluginTypeDisabledAttribute != null
+                                && pluginTypeAttribute == null
                                 && pluginTypeDisabledAttribute.getValue() != null
                                 && pluginTypeDisabledAttribute.getValue().equals("true")
                                 && !pluginTypeName.isEmpty()


### PR DESCRIPTION
 I fixed the current check.
Now if the type is specified for this plugin, the error will not be displayed
![image](https://user-images.githubusercontent.com/33068778/147366223-7795eae1-d1f4-4b4a-bf34-57596ac14c5b.png)
![image](https://user-images.githubusercontent.com/33068778/147366230-ad1be860-cf3b-413f-aecd-70166e98400b.png)


1. Fixes magento/magento2-phpstorm-plugin#590

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
