### PR TITLE
900: Changed realization for function checkDelete using of CheckUtil.

### DIFF
--- a/src/com/magento/idea/magento2plugin/linemarker/xml/LineMarkerXmlTagDecorator.java
+++ b/src/com/magento/idea/magento2plugin/linemarker/xml/LineMarkerXmlTagDecorator.java
@@ -501,7 +501,10 @@ public abstract class LineMarkerXmlTagDecorator implements XmlTag {
 
     @Override
     public void checkDelete() throws IncorrectOperationException {
-        xmlTag.checkDelete();
+        if (xmlTag instanceof XmlTagImpl) {
+            ((XmlTagImpl) xmlTag).checkDelete();
+        }
+        throw new IncorrectOperationException(getClass().getName());
     }
 
     @Override


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description** (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
I think we have two variants. We should set this method how deprecated and never use xmlTag.checkDelete() or create another realisation for it. I found service CheckUtil which has realisation checkWritable (similar checkDelete) for PsiElement. 

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes Eliminate LineMarkerXmlTagDecorator#checkDelete usage #900


**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
