### PR TITLE
619: Overriding layouts and templates allows to select an incompatibl…

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideInThemeDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideInThemeDialog.java
@@ -131,9 +131,13 @@ public class OverrideInThemeDialog extends AbstractDialog {
     }
 
     private void fillThemeOptions() {
+        final String area = psiFile.getVirtualFile().getPath().split("view/")[1].split("/")[0];
         final List<String> themeNames = new ModuleIndex(project).getEditableThemeNames();
-        for (final String themeName: themeNames) {
-            theme.addItem(themeName);
+        final String baseArea = "base";
+        for (final String themeName : themeNames) {
+            if (baseArea.equals(area) || themeName.split("/")[0].equals(area)) {
+                theme.addItem(themeName);
+            }
         }
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideInThemeDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideInThemeDialog.java
@@ -13,6 +13,7 @@ import com.magento.idea.magento2plugin.actions.generation.dialog.validator.annot
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.NotEmptyRule;
 import com.magento.idea.magento2plugin.actions.generation.generator.OverrideInThemeGenerator;
 import com.magento.idea.magento2plugin.indexes.ModuleIndex;
+import com.magento.idea.magento2plugin.magento.packages.Areas;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
@@ -133,9 +134,9 @@ public class OverrideInThemeDialog extends AbstractDialog {
     private void fillThemeOptions() {
         final String area = psiFile.getVirtualFile().getPath().split("view/")[1].split("/")[0];
         final List<String> themeNames = new ModuleIndex(project).getEditableThemeNames();
-        final String baseArea = "base";
+
         for (final String themeName : themeNames) {
-            if (baseArea.equals(area) || themeName.split("/")[0].equals(area)) {
+            if (Areas.base.toString().equals(area) || themeName.split("/")[0].equals(area)) {
                 theme.addItem(themeName);
             }
         }


### PR DESCRIPTION
**Description** (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

**Fixed Issues (if relevant)**
Added logic that in the theme selector shows only themes in which this file can be overridden

1. Fixes magento/magento2-phpstorm-plugin#604


**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
