### PR TITLE
833: Added Open In Find Tool Window action to the Navigate to plugins linemarker

### DIFF
--- a/src/com/magento/idea/magento2plugin/linemarker/SearchGutterIconNavigationHandler.java
+++ b/src/com/magento/idea/magento2plugin/linemarker/SearchGutterIconNavigationHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.linemarker;
+
+import com.intellij.codeInsight.daemon.GutterIconNavigationHandler;
+import com.intellij.codeInsight.daemon.impl.PsiElementListNavigator;
+import com.intellij.ide.util.DefaultPsiElementCellRenderer;
+import com.intellij.psi.NavigatablePsiElement;
+import com.intellij.psi.PsiElement;
+import java.awt.event.MouseEvent;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
+
+public class SearchGutterIconNavigationHandler<T extends PsiElement>
+        implements GutterIconNavigationHandler<T> {
+
+    private final Collection<? extends NavigatablePsiElement> myReferences;
+    private final @NotNull String popupTitle;
+
+    /**
+     * Search gutter icon navigation handler constructor.
+     *
+     * @param references Collection
+     * @param popupTitle String
+     */
+    public SearchGutterIconNavigationHandler(
+            final Collection<? extends NavigatablePsiElement> references,
+            final @NotNull String popupTitle
+    ) {
+        this.popupTitle = popupTitle;
+        myReferences = references;
+    }
+
+    @Override
+    public void navigate(final MouseEvent event, final T elt) {
+        PsiElementListNavigator.openTargets(
+                event,
+                myReferences.toArray(NavigatablePsiElement.EMPTY_NAVIGATABLE_ELEMENT_ARRAY),
+                popupTitle,
+                "Open in Find Tool Window",// Ignored
+                new DefaultPsiElementCellRenderer()
+        );
+    }
+}

--- a/src/com/magento/idea/magento2plugin/linemarker/php/PluginLineMarkerProvider.java
+++ b/src/com/magento/idea/magento2plugin/linemarker/php/PluginLineMarkerProvider.java
@@ -5,10 +5,12 @@
 
 package com.magento.idea.magento2plugin.linemarker.php;
 
+import com.intellij.codeInsight.daemon.GutterIconNavigationHandler;
 import com.intellij.codeInsight.daemon.LineMarkerInfo;
 import com.intellij.codeInsight.daemon.LineMarkerProvider;
 import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder;
 import com.intellij.icons.AllIcons;
+import com.intellij.psi.NavigatablePsiElement;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -16,6 +18,7 @@ import com.intellij.util.indexing.FileBasedIndex;
 import com.jetbrains.php.PhpIndex;
 import com.jetbrains.php.lang.psi.elements.Method;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
+import com.magento.idea.magento2plugin.linemarker.SearchGutterIconNavigationHandler;
 import com.magento.idea.magento2plugin.project.Settings;
 import com.magento.idea.magento2plugin.stubs.indexes.PluginIndex;
 import java.util.ArrayList;
@@ -39,6 +42,7 @@ public class PluginLineMarkerProvider implements LineMarkerProvider {
     }
 
     @Override
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     public void collectSlowLineMarkers(
             final @NotNull List<? extends PsiElement> psiElements,
             final @NotNull Collection<? super LineMarkerInfo<?>> collection
@@ -69,12 +73,21 @@ public class PluginLineMarkerProvider implements LineMarkerProvider {
                 }
 
                 if (!results.isEmpty()) {
+                    final GutterIconNavigationHandler<PsiElement> navigationHandler =
+                            new SearchGutterIconNavigationHandler<>(
+                                    (Collection<? extends NavigatablePsiElement>) results,
+                                    TOOLTIP_TEXT
+                            );
+
                     collection.add(
                             NavigationGutterIconBuilder
                                     .create(AllIcons.Nodes.Plugin)
                                     .setTargets(results)
                                     .setTooltipText(TOOLTIP_TEXT)
-                                    .createLineMarkerInfo(PsiTreeUtil.getDeepestFirst(psiElement))
+                                    .createLineMarkerInfo(
+                                            PsiTreeUtil.getDeepestFirst(psiElement),
+                                            navigationHandler
+                                    )
                     );
                 }
             }


### PR DESCRIPTION
**Description** (*)

Added **"Open In Find Tool Window"** action to the **"Navigate to plugins"** linemarker.

<img width="1408" alt="Screenshot 2022-01-22 at 23 18 18" src="https://user-images.githubusercontent.com/31848341/150655949-62feb653-101a-4221-ba67-88c88db71f9c.png">

<img width="1754" alt="Screenshot 2022-01-22 at 23 18 36" src="https://user-images.githubusercontent.com/31848341/150655944-ceef8eca-bf71-4f96-97b9-faff883623ff.png">

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#833

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
