### PR TITLE
932: Fixed general exception while accessing phpIndex.getAnyByFQN(classFQN)

### DIFF
--- a/src/com/magento/idea/magento2plugin/reference/provider/PhpClassReferenceProvider.java
+++ b/src/com/magento/idea/magento2plugin/reference/provider/PhpClassReferenceProvider.java
@@ -74,16 +74,20 @@ public class PhpClassReferenceProvider extends PsiReferenceProvider {
                 psiReferences.add(new PolyVariantReferenceBase(element, range, references));
             }
         }
-
         final String className = classFQN.substring(classFQN.lastIndexOf(92) + 1);
-        final Collection<PhpClass> classes = phpIndex.getAnyByFQN(classFQN);
 
-        if (!classes.isEmpty()) {
-            final TextRange range = new TextRange(
-                    origValue.lastIndexOf(92) + 1,
-                    origValue.lastIndexOf(92) + 1 + className.length()
-            );
-            psiReferences.add(new PolyVariantReferenceBase(element, range, classes));
+        try {
+            final Collection<PhpClass> classes = phpIndex.getAnyByFQN(classFQN);
+
+            if (!classes.isEmpty()) {
+                final TextRange range = new TextRange(
+                        origValue.lastIndexOf(92) + 1,
+                        origValue.lastIndexOf(92) + 1 + className.length()
+                );
+                psiReferences.add(new PolyVariantReferenceBase(element, range, classes));
+            }
+        } catch (Exception exception) { //NOPMD
+            return psiReferences.toArray(new PsiReference[0]);
         }
 
         return psiReferences.toArray(new PsiReference[0]);


### PR DESCRIPTION
**Description** (*):

Fixed general Exception in the PhpClassReferenceProvider while accessing phpIndex.getAnyByFQN(classFQN).

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#932

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
