### PR TITLE
620: Introduced custom search scope to exclude test files from search

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -561,6 +561,9 @@
         <errorHandler implementation="com.magento.idea.magento2plugin.project.diagnostic.DefaultErrorReportSubmitter"/>
 
         <configurationType implementation="com.magento.idea.magento2uct.execution.configurations.UctRunConfigurationType"/>
+
+        <testSourcesFilter implementation="com.magento.idea.magento2plugin.lang.roots.MagentoTestSourceFilter"/>
+        <searchScopesProvider implementation="com.magento.idea.magento2plugin.lang.psi.search.MagentoSearchScopesProvider"/>
     </extensions>
 
     <extensions defaultExtensionNs="com.jetbrains.php">

--- a/src/com/magento/idea/magento2plugin/lang/psi/search/AllFilesExceptTestsScope.java
+++ b/src/com/magento/idea/magento2plugin/lang/psi/search/AllFilesExceptTestsScope.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.lang.psi.search;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.magento.idea.magento2plugin.lang.roots.MagentoTestSourceFilter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class AllFilesExceptTestsScope extends GlobalSearchScope {
+
+    public static final String SCOPE_NAME = "All Files Except Tests";
+    private static AllFilesExceptTestsScope instance;
+    private final Project project;
+
+    /**
+     * Get search scope instance.
+     *
+     * @param project Project
+     *
+     * @return AllFilesExceptTestsScope
+     */
+    @SuppressWarnings("PMD.AvoidSynchronizedAtMethodLevel")
+    public static synchronized AllFilesExceptTestsScope getInstance(
+            final @Nullable Project project
+    ) {
+        if (instance == null) {
+            instance = new AllFilesExceptTestsScope(project);
+        }
+
+        return instance;
+    }
+
+    /**
+     * Magento search scope constructor.
+     *
+     * @param project Project
+     */
+    private AllFilesExceptTestsScope(final @Nullable Project project) {
+        super(project);
+        this.project = project;
+    }
+
+    @Override
+    public @NotNull String getDisplayName() {
+        return SCOPE_NAME;
+    }
+
+    @Override
+    public boolean contains(final @NotNull VirtualFile file) {
+        assert project != null;
+        return GlobalSearchScope.allScope(project).contains(file)
+                && !(new MagentoTestSourceFilter().isTestSource(file, project));
+    }
+
+    @Override
+    public boolean isSearchInModuleContent(final @NotNull Module module) {
+        return true;
+    }
+
+    @Override
+    public boolean isSearchInLibraries() {
+        return true;
+    }
+}

--- a/src/com/magento/idea/magento2plugin/lang/psi/search/MagentoSearchScopesProvider.java
+++ b/src/com/magento/idea/magento2plugin/lang/psi/search/MagentoSearchScopesProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.lang.psi.search;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.NlsContexts;
+import com.intellij.psi.search.SearchScope;
+import com.intellij.psi.search.SearchScopeProvider;
+import java.util.Collections;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class MagentoSearchScopesProvider implements SearchScopeProvider {
+
+    @Override
+    public @Nullable @NlsContexts.Separator String getDisplayName() {
+        return "Magento";
+    }
+
+    @Override
+    public @NotNull List<SearchScope> getSearchScopes(
+            final @NotNull Project project,
+            final @NotNull DataContext dataContext
+    ) {
+        return Collections.singletonList(AllFilesExceptTestsScope.getInstance(project));
+    }
+}

--- a/src/com/magento/idea/magento2plugin/lang/roots/MagentoTestSourceFilter.java
+++ b/src/com/magento/idea/magento2plugin/lang/roots/MagentoTestSourceFilter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.lang.roots;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.TestSourcesFilter;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.jetbrains.php.lang.PhpFileType;
+import org.jetbrains.annotations.NotNull;
+
+public class MagentoTestSourceFilter extends TestSourcesFilter {
+
+    private static final String TEST_CLASS_SUFFIX = "Test";
+
+    @Override
+    public boolean isTestSource(final @NotNull VirtualFile file, final @NotNull Project project) {
+        final String fileName = file.getNameWithoutExtension();
+        final int suffixIndex = fileName.length() - TEST_CLASS_SUFFIX.length();
+
+        if (suffixIndex < 0) {
+            return false;
+        }
+
+        return file.getFileType().equals(PhpFileType.INSTANCE)
+                && "Test".equals(fileName.substring(suffixIndex));
+    }
+}


### PR DESCRIPTION
**Description** (*)

Introduced new predefined search scope group (**Magento**) and search scope (**All Files Except Tests**).
It works as **All Places** search scope except ignoring php test classes.

<img width="1655" alt="Screenshot 2022-01-23 at 13 17 53" src="https://user-images.githubusercontent.com/31848341/150676311-e774e8d0-5207-4a76-bac2-2a318eb818bb.png">

<img width="1655" alt="Screenshot 2022-01-23 at 13 18 04" src="https://user-images.githubusercontent.com/31848341/150676313-755d1ffc-7936-4277-a599-cdee30c37e09.png">

<img width="983" alt="Screenshot 2022-01-23 at 13 14 41" src="https://user-images.githubusercontent.com/31848341/150676333-9cc23fe7-3b0c-44b1-8554-18b0d8f7e1e4.png">

**Fixed Issues (if relevant)**

1. Fixes magento/magento2-phpstorm-plugin#620

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
