### PR TITLE
276: Added uiComponent registration syntax highlighting as JSON

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -564,6 +564,8 @@
 
         <testSourcesFilter implementation="com.magento.idea.magento2plugin.lang.roots.MagentoTestSourceFilter"/>
         <searchScopesProvider implementation="com.magento.idea.magento2plugin.lang.psi.search.MagentoSearchScopesProvider"/>
+
+        <multiHostInjector implementation="com.magento.idea.magento2plugin.lang.injection.UiComponentSyntaxInjector"/>
     </extensions>
 
     <extensions defaultExtensionNs="com.jetbrains.php">

--- a/src/com/magento/idea/magento2plugin/lang/injection/UiComponentSyntaxInjector.java
+++ b/src/com/magento/idea/magento2plugin/lang/injection/UiComponentSyntaxInjector.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.lang.injection;
+
+import com.intellij.json.JsonLanguage;
+import com.intellij.lang.injection.MultiHostInjector;
+import com.intellij.lang.injection.MultiHostRegistrar;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLanguageInjectionHost;
+import com.intellij.psi.html.HtmlTag;
+import com.intellij.psi.templateLanguages.OuterLanguageElement;
+import com.intellij.psi.xml.XmlText;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+public class UiComponentSyntaxInjector implements MultiHostInjector {
+
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
+    @Override
+    public void getLanguagesToInject(
+            final @NotNull MultiHostRegistrar registrar,
+            final @NotNull PsiElement host
+    ) {
+        if (!isUiComponentTag(host)) {
+            return;
+        }
+        PsiElement targetXmlText = null;
+
+        for (final PsiElement element : host.getChildren()) {
+            if (element instanceof XmlText) {
+                targetXmlText = element;
+                break;
+            }
+        }
+
+        if (targetXmlText == null) {
+            return;
+        }
+        registrar.startInjecting(JsonLanguage.INSTANCE);
+        int startPosition = 0;
+
+        for (final PsiElement element : targetXmlText.getChildren()) {
+            if (!(element instanceof OuterLanguageElement)) {
+                final int endPosition = Math.min(
+                        startPosition + element.getTextLength(),
+                        targetXmlText.getTextLength()
+                );
+
+                if (startPosition > element.getStartOffsetInParent()) {
+                    startPosition = element.getStartOffsetInParent();
+                }
+                registrar.addPlace(
+                        null,
+                        null,
+                        (PsiLanguageInjectionHost) targetXmlText,
+                        new TextRange(startPosition, endPosition)
+                );
+            }
+            startPosition += element.getTextLength();
+        }
+        registrar.doneInjecting();
+    }
+
+    @Override
+    public @NotNull List<? extends Class<? extends PsiElement>> elementsToInjectIn() {
+        return List.of(HtmlTag.class);
+    }
+
+    private boolean isUiComponentTag(final @NotNull PsiElement host) {
+        if (!(host instanceof HtmlTag)) {
+            return false;
+        }
+        final HtmlTag tag = (HtmlTag) host;
+        final String typeAttributeValue = tag.getAttributeValue("type");
+
+        return typeAttributeValue != null && typeAttributeValue.equals("text/x-magento-init");
+    }
+}


### PR DESCRIPTION
**Description** (*)

Provided uiComponent registration syntax highlighting inside `<script type="x-magento-init">` tags.

<img width="770" alt="Screenshot 2022-01-24 at 23 55 13" src="https://user-images.githubusercontent.com/31848341/150871460-e5d5a9fb-ed12-44ff-9208-1c3d9acf3495.png">

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#276

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
