### PR TITLE
598: Added placeholder to dialog window

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/AbstractDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/AbstractDialog.java
@@ -6,6 +6,7 @@
 package com.magento.idea.magento2plugin.actions.generation.dialog;
 
 import com.intellij.openapi.util.Pair;
+import com.magento.idea.magento2plugin.actions.generation.dialog.prompt.PlaceholderInitializerUtil;
 import com.magento.idea.magento2plugin.actions.generation.dialog.reflection.ExtractComponentFromFieldUtil;
 import com.magento.idea.magento2plugin.actions.generation.dialog.util.DialogFieldErrorUtil;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.annotation.TypeFieldsRulesParser;
@@ -248,6 +249,12 @@ public abstract class AbstractDialog extends JDialog {
         }
 
         return getParentTabPaneForComponent(parent);
+    }
+
+    @Override
+    public void setVisible(boolean b) {
+        new PlaceholderInitializerUtil(this).initialize();
+        super.setVisible(b);
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/AbstractDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/AbstractDialog.java
@@ -252,9 +252,9 @@ public abstract class AbstractDialog extends JDialog {
     }
 
     @Override
-    public void setVisible(boolean b) {
+    public void setVisible(final boolean status) {
         new PlaceholderInitializerUtil(this).initialize();
-        super.setVisible(b);
+        super.setVisible(status);
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/prompt/PlaceholderInitializerUtil.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/prompt/PlaceholderInitializerUtil.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.actions.generation.dialog.prompt;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import javax.swing.text.JTextComponent;
+import org.jdesktop.swingx.prompt.PromptSupport;
+import org.jetbrains.annotations.NotNull;
+
+public final class PlaceholderInitializerUtil {
+
+    private static final String PLACEHOLDER_CLIENT_PROPERTY = "promptText";
+
+    private final Class<?> type;
+    private final Object object;
+
+    /**
+     * PlaceholderInitializerUtil constructor.
+     *
+     * @param object Object
+     */
+    public PlaceholderInitializerUtil(final @NotNull Object object) {
+        this.object = object;
+        type = object.getClass();
+    }
+
+    /**
+     * Initialize placeholders for supported field types if specified promptText client property.
+     */
+    public void initialize() {
+        for (final Field field : type.getDeclaredFields()) {
+            final JTextComponent target = getTarget(field);
+
+            if (target == null) {
+                continue;
+            }
+            final Object promptProperty = target.getClientProperty(
+                    PLACEHOLDER_CLIENT_PROPERTY
+            );
+
+            if (promptProperty == null) {
+                continue;
+            }
+            PromptSupport.setPrompt((String) promptProperty, target);
+        }
+    }
+
+    private JTextComponent getTarget(final Field field) {
+        if (Modifier.isStatic(field.getModifiers())) {
+            return null;
+        }
+        final boolean isAccessible = field.canAccess(object);
+        field.setAccessible(true);
+
+        try {
+            final Object value = field.get(object);
+
+            return value instanceof JTextComponent ? (JTextComponent) value : null;
+        } catch (IllegalAccessException exception) {
+            return null;
+        } finally {
+            field.setAccessible(isAccessible);
+        }
+    }
+}


### PR DESCRIPTION
**Description** (*)

Developed flexible way to add placeholders to a dialog window fields that inherited from the JTextComponent.

1. Fixes magento/magento2-phpstorm-plugin#598

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
