### PR TITLE
1012: Updating generating UI form Delete button

### DIFF
--- a/src/com/magento/idea/magento2plugin/magento/packages/UiFormButtonTypeSettings.java
+++ b/src/com/magento/idea/magento2plugin/magento/packages/UiFormButtonTypeSettings.java
@@ -14,15 +14,28 @@ public enum UiFormButtonTypeSettings {
     SAVE("Save", "save primary", "''", "[\n"
             + "                'mage-init' => ['button' => ['event' => 'save']],\n"
             + "                'form-role' => 'save'\n"
-            + "            ]", 10, "Save entity button."),
-    DELETE("Delete", "delete", "'deleteConfirm(\\''\n"
-            + "            . __('Are you sure you want to delete this $varName?')\n"
-            + "            . '\\', \\'' . $this->getUrl(\n'*/*/delete',\n[$varIdConst => "
-            + "$this->$varEntityIdAccessor]\n) . '\\')'", "[]", 20, "Delete entity button."),
+            + "            ]", 30, "Save entity button."),
+    DELETE(
+            "Delete",
+            "delete",
+            "sprintf(\"deleteConfirm('%s', '%s')\", \n" +
+                    "__('Are you sure you want to delete this $varName?'),\n" +
+                    "$this->getUrl(\n'*/*/delete',\n['$varIdConst' => " +
+                    "$this->$varEntityIdAccessor]\n)\n)",
+            "[]",
+            20,
+            "Delete entity button."),
     BACK("Back To Grid", "back",
             "sprintf(\"location.href = '%s';\", $this->getUrl('*/*/'))",
-            "[]", 30, "Back to list button."),
-    CUSTOM("Custom Button", "custom", "''", "[]", 0, "Custom button.");
+            "[]", 10, "Back to list button."),
+    CUSTOM(
+            "Custom Button",
+            "custom",
+            "''",
+            "[]",
+            0,
+            "Custom button."
+    );
 
     private final String label;
     private final String classes;

--- a/src/com/magento/idea/magento2plugin/magento/packages/UiFormButtonTypeSettings.java
+++ b/src/com/magento/idea/magento2plugin/magento/packages/UiFormButtonTypeSettings.java
@@ -18,10 +18,10 @@ public enum UiFormButtonTypeSettings {
     DELETE(
             "Delete",
             "delete",
-            "sprintf(\"deleteConfirm('%s', '%s')\", \n" +
-                    "__('Are you sure you want to delete this $varName?'),\n" +
-                    "$this->getUrl(\n'*/*/delete',\n['$varIdConst' => " +
-                    "$this->$varEntityIdAccessor]\n)\n)",
+            "sprintf(\"deleteConfirm('%s', '%s')\", \n"
+                    + "__('Are you sure you want to delete this $varName?'),\n"
+                    + "$this->getUrl(\n'*/*/delete',\n[$varIdConst => "
+                    + "$this->$varEntityIdAccessor]\n)\n)",
             "[]",
             20,
             "Delete entity button."),

--- a/testData/actions/generation/generator/FormButtonBlockGenerator/generateBackButtonBlock/MyBackButton.php
+++ b/testData/actions/generation/generator/FormButtonBlockGenerator/generateBackButtonBlock/MyBackButton.php
@@ -21,7 +21,7 @@ class MyBackButton extends GenericButton implements ButtonProviderInterface
             'back',
             sprintf("location.href = '%s';", $this->getUrl('*/*/')),
             [],
-            30
+            10
         );
     }
 }

--- a/testData/actions/generation/generator/FormButtonBlockGenerator/generateDeleteButtonBlock/DeleteBlock.php
+++ b/testData/actions/generation/generator/FormButtonBlockGenerator/generateDeleteButtonBlock/DeleteBlock.php
@@ -20,12 +20,13 @@ class DeleteBlock extends GenericButton implements ButtonProviderInterface
         return $this->wrapButtonSettings(
             'Delete',
             'delete',
-            'deleteConfirm(\''
-            . __('Are you sure you want to delete this book?')
-            . '\', \'' . $this->getUrl(
-                '*/*/delete',
-                [BookData::BOOK_ID => $this->getBookId()]
-            ) . '\')',
+            sprintf("deleteConfirm('%s', '%s')",
+                __('Are you sure you want to delete this book?'),
+                $this->getUrl(
+                    '*/*/delete',
+                    [BookData::BOOK_ID => $this->getBookId()]
+                )
+            ),
             [],
             20
         );

--- a/testData/actions/generation/generator/FormButtonBlockGenerator/generateSaveButtonBlock/SaveBlock.php
+++ b/testData/actions/generation/generator/FormButtonBlockGenerator/generateSaveButtonBlock/SaveBlock.php
@@ -24,7 +24,7 @@ class SaveBlock extends GenericButton implements ButtonProviderInterface
                 'mage-init' => ['button' => ['event' => 'save']],
                 'form-role' => 'save'
             ],
-            10
+            30
         );
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description** (*)

Updated generating of the "UI form Delete" button.

The sorting for buttons has been changed:

- Back button: 10 
- Delete button: 20
- Save button: 30 

Also, for the Delete button, the on click option changed to use the **sprintf** function instead of the concatenation.

<img width="623" alt="Screenshot 2022-02-23 at 15 28 45" src="https://user-images.githubusercontent.com/89141549/155330275-94e6d49b-b3b5-43fa-9f67-1cb47d3803bb.png">


**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#1012.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#1012

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
