### PR TITLE
1023: Added an additional path field for UCT configuration dialog (to cover theme folder scanning)

### DIFF
--- a/src/com/magento/idea/magento2uct/settings/UctSettingsService.java
+++ b/src/com/magento/idea/magento2uct/settings/UctSettingsService.java
@@ -42,6 +42,12 @@ public class UctSettingsService implements PersistentStateComponent<UctSettingsS
     @Property
     private Boolean ignoreCurrentVersion;
 
+    @Property
+    private Boolean hasAdditionalPath;
+
+    @Property
+    private String additionalPath;
+
     @SuppressWarnings("PMD.UncommentedEmptyConstructor")
     public UctSettingsService() {
     }
@@ -248,5 +254,41 @@ public class UctSettingsService implements PersistentStateComponent<UctSettingsS
      */
     public @Nullable Boolean shouldIgnoreCurrentVersion() {
         return ignoreCurrentVersion;
+    }
+
+    /**
+     * Set if show additional path
+     *
+     * @param hasAdditionalPath boolean
+     */
+    public void setHasAdditionalPath(final boolean hasAdditionalPath) {
+        this.hasAdditionalPath = hasAdditionalPath;
+    }
+
+    /**
+     * Check if show additional path
+     *
+     * @return boolean
+     */
+    public @Nullable Boolean getHasAdditionalPath() {
+        return hasAdditionalPath;
+    }
+
+    /**
+     * Set path to analyse.
+     *
+     * @param additionalPath String
+     */
+    public void setAdditionalPath(final @NotNull String additionalPath) {
+        this.additionalPath = additionalPath;
+    }
+
+    /**
+     * Get target module path (path to analyse).
+     *
+     * @return String
+     */
+    public @Nullable String getAdditionalPath() {
+        return additionalPath;
     }
 }

--- a/src/com/magento/idea/magento2uct/ui/ConfigurationDialog.form
+++ b/src/com/magento/idea/magento2uct/ui/ConfigurationDialog.form
@@ -3,14 +3,16 @@
   <grid id="27dc6" binding="contentPanel" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
-      <xy x="20" y="20" width="688" height="400"/>
+      <xy x="20" y="20" width="719" height="500"/>
     </constraints>
     <properties>
-      <preferredSize width="580" height="300"/>
+      <minimumSize width="559" height="300"/>
+      <preferredSize width="580" height="380"/>
+      <requestFocusEnabled value="true"/>
     </properties>
     <border type="none"/>
     <children>
-      <grid id="d41a9" layout-manager="GridLayoutManager" row-count="9" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="d41a9" layout-manager="GridLayoutManager" row-count="12" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -20,7 +22,7 @@
         <children>
           <component id="28e30" class="javax.swing.JCheckBox" binding="enable">
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Enable the built-in Upgrade Compatibility Tool"/>
@@ -28,7 +30,7 @@
           </component>
           <component id="dda21" class="javax.swing.JComboBox" binding="currentVersion" custom-create="true">
             <constraints>
-              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
@@ -43,7 +45,7 @@
           </component>
           <component id="dede1" class="javax.swing.JComboBox" binding="targetVersion" custom-create="true">
             <constraints>
-              <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="4" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
@@ -58,11 +60,13 @@
           </component>
           <component id="d5e0b" class="com.intellij.openapi.ui.LabeledComponent" binding="modulePath" custom-create="true">
             <constraints>
-              <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="5" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
-            <properties/>
+            <properties>
+              <enabled value="true"/>
+            </properties>
           </component>
           <component id="f4311" class="javax.swing.JLabel" binding="modulePathLabel">
             <constraints>
@@ -74,13 +78,13 @@
           </component>
           <component id="70b2b" class="javax.swing.JComboBox" binding="issueSeverityLevel" custom-create="true">
             <constraints>
-              <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="10" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
           <component id="bd4f" class="javax.swing.JLabel" binding="issueSeverityLevelLabel">
             <constraints>
-              <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <labelFor value="70b2b"/>
@@ -89,7 +93,7 @@
           </component>
           <component id="3c2d0" class="javax.swing.JCheckBox" binding="ignoreCurrentVersion">
             <constraints>
-              <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="11" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Ignore current version compatibility issues"/>
@@ -97,7 +101,7 @@
           </component>
           <component id="2d9d9" class="javax.swing.JLabel" binding="modulePathError">
             <constraints>
-              <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="6" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Label"/>
@@ -105,7 +109,7 @@
           </component>
           <component id="6f213" class="javax.swing.JLabel" binding="enableComment">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <enabled value="true"/>
@@ -116,12 +120,46 @@
           </component>
           <component id="1b278" class="javax.swing.JLabel" binding="enableCommentPath">
             <constraints>
-              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <enabled value="true"/>
               <font size="12"/>
               <text value="Preferences -&gt; Editor -&gt; Inspections -&gt; UCT"/>
+            </properties>
+          </component>
+          <component id="3b634" class="javax.swing.JLabel" binding="additionalPathLabel">
+            <constraints>
+              <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Path To Analyse"/>
+            </properties>
+          </component>
+          <component id="ab5bd" class="com.intellij.openapi.ui.LabeledComponent" binding="additionalPath" custom-create="true">
+            <constraints>
+              <grid row="8" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="-1"/>
+              </grid>
+            </constraints>
+            <properties>
+              <enabled value="true"/>
+            </properties>
+          </component>
+          <component id="c2187" class="javax.swing.JCheckBox" binding="hasAdditionalPath">
+            <constraints>
+              <grid row="7" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Add additional path to analyse"/>
+            </properties>
+          </component>
+          <component id="9ba03" class="javax.swing.JLabel" binding="additionalPathError">
+            <constraints>
+              <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Label"/>
             </properties>
           </component>
         </children>

--- a/src/com/magento/idea/magento2uct/ui/ConfigurationDialog.java
+++ b/src/com/magento/idea/magento2uct/ui/ConfigurationDialog.java
@@ -40,6 +40,7 @@ public class ConfigurationDialog extends AbstractDialog {
     private LabeledComponent<TextFieldWithBrowseButton> modulePath;
     private LabeledComponent<TextFieldWithBrowseButton> additionalPath;
     private JCheckBox ignoreCurrentVersion;
+    private JCheckBox hasAdditionalPath;
     private JComboBox<ComboBoxItemData> currentVersion;
     private JComboBox<ComboBoxItemData> targetVersion;
     private JComboBox<ComboBoxItemData> issueSeverityLevel;
@@ -54,7 +55,6 @@ public class ConfigurationDialog extends AbstractDialog {
     private JLabel modulePathError;//NOPMD
     private JLabel enableComment;//NOPMD
     private JLabel enableCommentPath;//NOPMD
-    private JCheckBox hasAdditionalPath;
     private JLabel additionalPathLabel;//NOPMD
     private JLabel additionalPathError;//NOPMD
 
@@ -103,6 +103,7 @@ public class ConfigurationDialog extends AbstractDialog {
         enableComment.setForeground(JBColor.blue);
         enableCommentPath.setForeground(JBColor.blue);
         setDefaultValues();
+        refreshAdditionalFields(hasAdditionalPath.isSelected());
     }
 
     /**
@@ -129,8 +130,9 @@ public class ConfigurationDialog extends AbstractDialog {
             modulePathError.setText("The `Path To Analyse` field is empty or invalid");
             return;
         }
-        if (additionalPath.getComponent().getText().isEmpty()
-                || !UctModulePathValidatorUtil.validate(additionalPath.getComponent().getText())) {
+        if (hasAdditionalPath.isSelected() && additionalPath.getComponent().getText().isEmpty()
+                || hasAdditionalPath.isSelected()
+                && !UctModulePathValidatorUtil.validate(additionalPath.getComponent().getText())) {
             additionalPathError.setText("The `Path To Analyse` field is empty or invalid");
             return;
         }
@@ -232,17 +234,11 @@ public class ConfigurationDialog extends AbstractDialog {
         ignoreCurrentVersion.setSelected(Objects.requireNonNullElse(shouldIgnore, false));
 
         final Boolean isShowAdditionalPath = settingsService.getHasAdditionalPath();
-        additionalPath.setEnabled(
+        hasAdditionalPath.setSelected(
                 Objects.requireNonNullElse(isShowAdditionalPath, false)
         );
 
-        if (settingsService.getAdditionalPath() == null) {
-            final String basePath = Settings.getMagentoPath(project);
-
-            if (basePath != null) {
-                additionalPath.getComponent().setText(basePath);
-            }
-        } else {
+        if (settingsService.getAdditionalPath() != null) {
             additionalPath.getComponent().setText(settingsService.getAdditionalPath());
         }
     }
@@ -307,5 +303,8 @@ public class ConfigurationDialog extends AbstractDialog {
 
     private void refreshAdditionalFields(final boolean isEnabled) {
         additionalPath.setEnabled(isEnabled);
+        additionalPath.setVisible(isEnabled);
+        additionalPathLabel.setVisible(isEnabled);
+        additionalPathError.setVisible(isEnabled);
     }
 }

--- a/src/com/magento/idea/magento2uct/ui/ConfigurationDialog.java
+++ b/src/com/magento/idea/magento2uct/ui/ConfigurationDialog.java
@@ -27,13 +27,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.util.Objects;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.KeyStroke;
+import javax.swing.*;
 import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings({"PMD.TooManyFields", "PMD.ExcessiveImports"})
@@ -44,6 +38,7 @@ public class ConfigurationDialog extends AbstractDialog {
 
     private JCheckBox enable;
     private LabeledComponent<TextFieldWithBrowseButton> modulePath;
+    private LabeledComponent<TextFieldWithBrowseButton> additionalPath;
     private JCheckBox ignoreCurrentVersion;
     private JComboBox<ComboBoxItemData> currentVersion;
     private JComboBox<ComboBoxItemData> targetVersion;
@@ -59,6 +54,9 @@ public class ConfigurationDialog extends AbstractDialog {
     private JLabel modulePathError;//NOPMD
     private JLabel enableComment;//NOPMD
     private JLabel enableCommentPath;//NOPMD
+    private JCheckBox hasAdditionalPath;
+    private JLabel additionalPathLabel;//NOPMD
+    private JLabel additionalPathError;//NOPMD
 
     /**
      * Configuration dialog.
@@ -76,6 +74,7 @@ public class ConfigurationDialog extends AbstractDialog {
         setTitle(ConfigureUctAction.ACTION_NAME);
         getRootPane().setDefaultButton(buttonOk);
 
+        hasAdditionalPath.addActionListener(event -> refreshAdditionalFields(hasAdditionalPath.isSelected()));
         buttonOk.addActionListener(event -> onOK());
         buttonCancel.addActionListener(event -> onCancel());
 
@@ -98,6 +97,9 @@ public class ConfigurationDialog extends AbstractDialog {
         modulePathError.setText("");
         modulePathError.setFont(UIUtil.getLabelFont(UIUtil.FontSize.SMALL));
         modulePathError.setForeground(new Color(252, 119, 83));
+        additionalPathError.setText("");
+        additionalPathError.setFont(UIUtil.getLabelFont(UIUtil.FontSize.SMALL));
+        additionalPathError.setForeground(new Color(252, 119, 83));
         enableComment.setForeground(JBColor.blue);
         enableCommentPath.setForeground(JBColor.blue);
         setDefaultValues();
@@ -120,10 +122,16 @@ public class ConfigurationDialog extends AbstractDialog {
      */
     private void onOK() {
         modulePathError.setText("");
+        additionalPathError.setText("");
 
         if (modulePath.getComponent().getText().isEmpty()
                 || !UctModulePathValidatorUtil.validate(modulePath.getComponent().getText())) {
             modulePathError.setText("The `Path To Analyse` field is empty or invalid");
+            return;
+        }
+        if (additionalPath.getComponent().getText().isEmpty()
+                || !UctModulePathValidatorUtil.validate(additionalPath.getComponent().getText())) {
+            additionalPathError.setText("The `Path To Analyse` field is empty or invalid");
             return;
         }
         settingsService.setEnabled(enable.isSelected());
@@ -155,7 +163,8 @@ public class ConfigurationDialog extends AbstractDialog {
                 )
         );
         settingsService.setIgnoreCurrentVersion(ignoreCurrentVersion.isSelected());
-
+        settingsService.setHasAdditionalPath(hasAdditionalPath.isSelected());
+        settingsService.setAdditionalPath(additionalPath.getComponent().getText());
         exit();
     }
 
@@ -221,6 +230,21 @@ public class ConfigurationDialog extends AbstractDialog {
         }
         final Boolean shouldIgnore = settingsService.shouldIgnoreCurrentVersion();
         ignoreCurrentVersion.setSelected(Objects.requireNonNullElse(shouldIgnore, false));
+
+        final Boolean isShowAdditionalPath = settingsService.getHasAdditionalPath();
+        additionalPath.setEnabled(
+                Objects.requireNonNullElse(isShowAdditionalPath, false)
+        );
+
+        if (settingsService.getAdditionalPath() == null) {
+            final String basePath = Settings.getMagentoPath(project);
+
+            if (basePath != null) {
+                additionalPath.getComponent().setText(basePath);
+            }
+        } else {
+            additionalPath.getComponent().setText(settingsService.getAdditionalPath());
+        }
     }
 
     /**
@@ -271,5 +295,17 @@ public class ConfigurationDialog extends AbstractDialog {
                         new FileChooserDescriptor(false, true, false, false, false, false)
                 )
         );
+
+        additionalPath = new LabeledComponent<>();
+        additionalPath.setComponent(new TextFieldWithBrowseButton());
+        additionalPath.getComponent().addBrowseFolderListener(
+                new TextBrowseFolderListener(
+                        new FileChooserDescriptor(false, true, false, false, false, false)
+                )
+        );
+    }
+
+    private void refreshAdditionalFields(final boolean isEnabled) {
+        additionalPath.setEnabled(isEnabled);
     }
 }


### PR DESCRIPTION
**Description** (*)

Added additional fields to UCT configuration dialog. When you click on checkbox "Add additional path to analyse" an additional field "Path To Analyse" will become available for selection.

<img width="575" alt="Screenshot 2022-03-04 at 19 20 50" src="https://user-images.githubusercontent.com/89141549/156811995-4ac24a85-3486-484e-b6b5-a843d10942d5.png">


**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#1023.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#1023

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
