### PR TITLE
Change overwrite templates feature for action menu

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -118,7 +118,10 @@
         <action id="InjectAViewModelAction.Menu" class="com.magento.idea.magento2plugin.actions.generation.InjectAViewModelAction">
             <add-to-group group-id="EditorPopupMenu"/>
         </action>
-        <action id="OverrideInTheme.Menu" class="com.magento.idea.magento2plugin.actions.generation.OverrideInThemeAction">
+        <action id="OverrideTemplateInTheme.Menu" class="com.magento.idea.magento2plugin.actions.generation.OverrideTemplateInThemeAction">
+            <add-to-group group-id="ProjectViewPopupMenu"/>
+        </action>
+        <action id="OverrideLayoutInTheme.Menu" class="com.magento.idea.magento2plugin.actions.generation.OverrideLayoutInThemeAction">
             <add-to-group group-id="ProjectViewPopupMenu"/>
         </action>
         <action id="MagentoCreateAWebApiDeclaration.Menu" class="com.magento.idea.magento2plugin.actions.generation.NewWebApiDeclarationAction">

--- a/src/com/magento/idea/magento2plugin/actions/generation/OverrideFileInThemeAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/OverrideFileInThemeAction.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.actions.generation;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.PlatformDataKeys;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.magento.idea.magento2plugin.magento.packages.ComponentType;
+import com.magento.idea.magento2plugin.magento.packages.Package;
+import com.magento.idea.magento2plugin.project.Settings;
+import com.magento.idea.magento2plugin.util.magento.GetMagentoModuleUtil;
+import javax.swing.Icon;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class OverrideFileInThemeAction extends AnAction {
+
+    protected PsiFile psiFile;
+
+    /**
+     * Override file in theme action constructor.
+     *
+     * @param actionName String
+     * @param actionDescription String
+     * @param module Icon
+     */
+    public OverrideFileInThemeAction(
+            final String actionName,
+            final String actionDescription,
+            final Icon module
+    ) {
+        super(actionName, actionDescription, module);
+    }
+
+    /**
+     * Action entry point.
+     *
+     * @param event AnActionEvent
+     */
+    @Override
+    public void update(final @NotNull AnActionEvent event) {
+        setStatus(event, false);
+        final Project project = event.getData(PlatformDataKeys.PROJECT);
+        final PsiFile targetFile = event.getData(PlatformDataKeys.PSI_FILE);
+
+        if (project == null || targetFile == null) {
+            return;
+        }
+
+        if (Settings.isEnabled(project) && isOverrideAllowed(targetFile, project)) {
+            setStatus(event, true);
+            psiFile = targetFile;
+        }
+    }
+
+    /**
+     * Implement this method to specify if override allowed for particular file types.
+     *
+     * @param file PsiFile
+     * @param project Project
+     *
+     * @return boolean
+     */
+    protected abstract boolean isOverrideAllowed(
+            final @NotNull PsiFile file,
+            final @NotNull Project project
+    );
+
+    /**
+     * Check if file has a path specific to the Magento 2 module or theme.
+     *
+     * @param file PsiFile
+     * @param project Project
+     *
+     * @return boolean
+     */
+    protected boolean isFileInModuleOrTheme(
+            final @NotNull PsiFile file,
+            final @NotNull Project project
+    ) {
+        final GetMagentoModuleUtil.MagentoModuleData moduleData =
+                GetMagentoModuleUtil.getByContext(file.getContainingDirectory(), project);
+
+        if (moduleData == null) {
+            return false;
+        }
+        final VirtualFile virtualFile = file.getVirtualFile();
+
+        if (moduleData.getType().equals(ComponentType.module)) {
+            return virtualFile.getPath().contains("/" + Package.moduleViewDir + "/");
+        } else {
+            return moduleData.getType().equals(ComponentType.theme);
+        }
+    }
+
+    private void setStatus(final AnActionEvent event, final boolean status) {
+        event.getPresentation().setVisible(status);
+        event.getPresentation().setEnabled(status);
+    }
+}

--- a/src/com/magento/idea/magento2plugin/actions/generation/OverrideLayoutInThemeAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/OverrideLayoutInThemeAction.java
@@ -5,91 +5,55 @@
 
 package com.magento.idea.magento2plugin.actions.generation;
 
-import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.xml.XmlFile;
 import com.magento.idea.magento2plugin.MagentoIcons;
 import com.magento.idea.magento2plugin.actions.generation.dialog.OverrideLayoutInThemeDialog;
 import com.magento.idea.magento2plugin.magento.files.LayoutXml;
-import com.magento.idea.magento2plugin.magento.files.UiComponentGridXmlFile;
-import com.magento.idea.magento2plugin.magento.packages.ComponentType;
-import com.magento.idea.magento2plugin.magento.packages.Package;
-import com.magento.idea.magento2plugin.project.Settings;
-import com.magento.idea.magento2plugin.util.magento.GetMagentoModuleUtil;
 import org.jetbrains.annotations.NotNull;
 
-public class OverrideLayoutInThemeAction extends AnAction {
+public class OverrideLayoutInThemeAction extends OverrideFileInThemeAction {
 
     public static final String ACTION_NAME = "Override this layout in a project theme";
     public static final String ACTION_DESCRIPTION = "Override layout in project theme";
-    private PsiFile psiFile;
 
     public OverrideLayoutInThemeAction() {
         super(ACTION_NAME, ACTION_DESCRIPTION, MagentoIcons.MODULE);
     }
 
-    /**
-     * Action entry point.
-     *
-     * @param event AnActionEvent
-     */
-    @Override
-    public void update(final @NotNull AnActionEvent event) {
-        boolean status = false;
-        final Project project = event.getData(PlatformDataKeys.PROJECT);
-        psiFile = event.getData(PlatformDataKeys.PSI_FILE);
-
-        if (Settings.isEnabled(project)) {
-            try {
-                status = isOverrideAllowed(
-                        psiFile.getVirtualFile(),
-                        project
-                    );
-            } catch (NullPointerException e) { //NOPMD
-                // Ignore
-            }
-        }
-
-        this.setStatus(event, status);
-    }
-
-    private boolean isOverrideAllowed(final VirtualFile file, final Project project) {
-        if (file.isDirectory()) {
-            return false;
-        }
-
-        if (!UiComponentGridXmlFile.FILE_EXTENSION
-                .equals(psiFile.getVirtualFile().getExtension())) {
-            return false;
-        }
-
-        if (!LayoutXml.PARENT_DIR.equals(psiFile.getContainingDirectory().getName())
-                && !LayoutXml.PAGE_LAYOUT_DIR.equals(psiFile.getContainingDirectory().getName())) {
-            return false;
-        }
-        boolean isAllowed = false;
-        final GetMagentoModuleUtil.MagentoModuleData moduleData =
-                GetMagentoModuleUtil.getByContext(psiFile.getContainingDirectory(), project);
-
-        if (moduleData.getType().equals(ComponentType.module)) {
-            isAllowed = file.getPath().contains(Package.moduleViewDir);
-        } else if (moduleData.getType().equals(ComponentType.theme)) {
-            isAllowed = true;
-        }
-
-        return isAllowed;
-    }
-
-    private void setStatus(final AnActionEvent event, final boolean status) {
-        event.getPresentation().setVisible(status);
-        event.getPresentation().setEnabled(status);
-    }
-
     @Override
     public void actionPerformed(final @NotNull AnActionEvent event) {
-        OverrideLayoutInThemeDialog.open(event.getProject(), this.psiFile);
+        final Project project = event.getProject();
+
+        if (project == null || psiFile == null) {
+            return;
+        }
+        OverrideLayoutInThemeDialog.open(project, psiFile);
+    }
+
+    @Override
+    protected boolean isOverrideAllowed(
+            final @NotNull PsiFile file,
+            final @NotNull Project project
+    ) {
+        final VirtualFile virtualFile = file.getVirtualFile();
+
+        if (virtualFile == null || virtualFile.isDirectory()) {
+            return false;
+        }
+
+        if (!(file instanceof XmlFile)) {
+            return false;
+        }
+
+        if (!LayoutXml.PARENT_DIR.equals(file.getContainingDirectory().getName())
+                && !LayoutXml.PAGE_LAYOUT_DIR.equals(file.getContainingDirectory().getName())) {
+            return false;
+        }
+
+        return isFileInModuleOrTheme(file, project);
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/OverrideTemplateInThemeAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/OverrideTemplateInThemeAction.java
@@ -5,93 +5,53 @@
 
 package com.magento.idea.magento2plugin.actions.generation;
 
-import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.magento.idea.magento2plugin.MagentoIcons;
 import com.magento.idea.magento2plugin.actions.CopyMagentoPath;
 import com.magento.idea.magento2plugin.actions.generation.dialog.OverrideTemplateInThemeDialog;
-import com.magento.idea.magento2plugin.magento.packages.ComponentType;
-import com.magento.idea.magento2plugin.magento.packages.Package;
-import com.magento.idea.magento2plugin.project.Settings;
-import com.magento.idea.magento2plugin.util.magento.GetMagentoModuleUtil;
 import org.jetbrains.annotations.NotNull;
 
-public class OverrideTemplateInThemeAction extends AnAction {
+public class OverrideTemplateInThemeAction extends OverrideFileInThemeAction {
 
-    public static final String ACTION_NAME = "Override this in a project theme";
+    public static final String ACTION_NAME = "Override this file in a project theme";
     public static final String ACTION_TEMPLATE_DESCRIPTION = "Override template in project theme";
     public static final String ACTION_STYLES_DESCRIPTION = "Override styles in project theme";
     public static final String LESS_FILE_EXTENSION = "less";
-    private PsiFile psiFile;
 
     public OverrideTemplateInThemeAction() {
         super(ACTION_NAME, ACTION_TEMPLATE_DESCRIPTION, MagentoIcons.MODULE);
     }
 
-    /**
-     * Action entry point.
-     *
-     * @param event AnActionEvent
-     */
     @Override
-    public void update(final @NotNull AnActionEvent event) {
-        boolean status = false;
-        final Project project = event.getData(PlatformDataKeys.PROJECT);
-        psiFile = event.getData(PlatformDataKeys.PSI_FILE);
+    public void actionPerformed(final @NotNull AnActionEvent event) {
+        final Project project = event.getProject();
 
-        if (Settings.isEnabled(project)) {
-            try {
-                status = isOverrideAllowed(
-                        psiFile.getVirtualFile(),
-                        project
-                    );
-            } catch (NullPointerException e) { //NOPMD
-                // Ignore
-            }
+        if (project == null || psiFile == null) {
+            return;
         }
-
-        this.setStatus(event, status);
+        OverrideTemplateInThemeDialog.open(project, psiFile);
     }
 
-    private boolean isOverrideAllowed(final VirtualFile file, final Project project) {
-        if (file.isDirectory()) {
+    @Override
+    protected boolean isOverrideAllowed(
+            final @NotNull PsiFile file,
+            final @NotNull Project project
+    ) {
+        final VirtualFile virtualFile = file.getVirtualFile();
+
+        if (virtualFile == null || virtualFile.isDirectory()) {
             return false;
         }
-        final String fileExtension = psiFile.getVirtualFile().getExtension();
+        final String fileExtension = virtualFile.getExtension();
 
         if (!CopyMagentoPath.PHTML_EXTENSION.equals(fileExtension)
                 && !LESS_FILE_EXTENSION.equals(fileExtension)) {
             return false;
         }
-        boolean isAllowed = false;
-        final GetMagentoModuleUtil.MagentoModuleData moduleData =
-                GetMagentoModuleUtil.getByContext(psiFile.getContainingDirectory(), project);
 
-        if (moduleData.getType().equals(ComponentType.module)) {
-            isAllowed = file.getPath().contains(Package.moduleViewDir);
-        } else if (moduleData.getType().equals(ComponentType.theme)) {
-            isAllowed = true;
-        }
-
-        return isAllowed;
-    }
-
-    private void setStatus(final AnActionEvent event, final boolean status) {
-        event.getPresentation().setVisible(status);
-        event.getPresentation().setEnabled(status);
-    }
-
-    @Override
-    public void actionPerformed(final @NotNull AnActionEvent event) {
-        OverrideTemplateInThemeDialog.open(event.getProject(), this.psiFile);
-    }
-
-    @Override
-    public boolean isDumbAware() {
-        return false;
+        return isFileInModuleOrTheme(file, project);
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/OverrideTemplateInThemeAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/OverrideTemplateInThemeAction.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.actions.generation;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.PlatformDataKeys;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.magento.idea.magento2plugin.MagentoIcons;
+import com.magento.idea.magento2plugin.actions.CopyMagentoPath;
+import com.magento.idea.magento2plugin.actions.generation.dialog.OverrideTemplateInThemeDialog;
+import com.magento.idea.magento2plugin.magento.packages.ComponentType;
+import com.magento.idea.magento2plugin.magento.packages.Package;
+import com.magento.idea.magento2plugin.project.Settings;
+import com.magento.idea.magento2plugin.util.magento.GetMagentoModuleUtil;
+import org.jetbrains.annotations.NotNull;
+
+public class OverrideTemplateInThemeAction extends AnAction {
+
+    public static final String ACTION_NAME = "Override this in a project theme";
+    public static final String ACTION_TEMPLATE_DESCRIPTION = "Override template in project theme";
+    public static final String ACTION_STYLES_DESCRIPTION = "Override styles in project theme";
+    public static final String LESS_FILE_EXTENSION = "less";
+    private PsiFile psiFile;
+
+    public OverrideTemplateInThemeAction() {
+        super(ACTION_NAME, ACTION_TEMPLATE_DESCRIPTION, MagentoIcons.MODULE);
+    }
+
+    /**
+     * Action entry point.
+     *
+     * @param event AnActionEvent
+     */
+    @Override
+    public void update(final @NotNull AnActionEvent event) {
+        boolean status = false;
+        final Project project = event.getData(PlatformDataKeys.PROJECT);
+        psiFile = event.getData(PlatformDataKeys.PSI_FILE);
+
+        if (Settings.isEnabled(project)) {
+            try {
+                status = isOverrideAllowed(
+                        psiFile.getVirtualFile(),
+                        project
+                    );
+            } catch (NullPointerException e) { //NOPMD
+                // Ignore
+            }
+        }
+
+        this.setStatus(event, status);
+    }
+
+    private boolean isOverrideAllowed(final VirtualFile file, final Project project) {
+        if (file.isDirectory()) {
+            return false;
+        }
+        final String fileExtension = psiFile.getVirtualFile().getExtension();
+
+        if (!CopyMagentoPath.PHTML_EXTENSION.equals(fileExtension)
+                && !LESS_FILE_EXTENSION.equals(fileExtension)) {
+            return false;
+        }
+        boolean isAllowed = false;
+        final GetMagentoModuleUtil.MagentoModuleData moduleData =
+                GetMagentoModuleUtil.getByContext(psiFile.getContainingDirectory(), project);
+
+        if (moduleData.getType().equals(ComponentType.module)) {
+            isAllowed = file.getPath().contains(Package.moduleViewDir);
+        } else if (moduleData.getType().equals(ComponentType.theme)) {
+            isAllowed = true;
+        }
+
+        return isAllowed;
+    }
+
+    private void setStatus(final AnActionEvent event, final boolean status) {
+        event.getPresentation().setVisible(status);
+        event.getPresentation().setEnabled(status);
+    }
+
+    @Override
+    public void actionPerformed(final @NotNull AnActionEvent event) {
+        OverrideTemplateInThemeDialog.open(event.getProject(), this.psiFile);
+    }
+
+    @Override
+    public boolean isDumbAware() {
+        return false;
+    }
+}

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideLayoutInTheme.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideLayoutInTheme.form
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.magento.idea.magento2plugin.actions.generation.dialog.OverrideLayoutInThemeDialog">
+  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="10" left="10" bottom="10" right="10"/>
+    <constraints>
+      <xy x="48" y="392" width="584" height="162"/>
+    </constraints>
+    <properties>
+      <minimumSize width="350" height="150"/>
+      <preferredSize width="350" height="150"/>
+      <requestFocusEnabled value="true"/>
+    </properties>
+    <border type="none"/>
+    <children>
+      <grid id="94766" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <grid id="9538f" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="true" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <component id="e7465" class="javax.swing.JButton" binding="buttonOK">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text resource-bundle="magento2/common" key="common.ok"/>
+                </properties>
+              </component>
+              <component id="5723f" class="javax.swing.JButton" binding="buttonCancel">
+                <constraints>
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text resource-bundle="magento2/common" key="common.cancel"/>
+                </properties>
+              </component>
+            </children>
+          </grid>
+          <grid id="5bb09" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <component id="51c12" class="javax.swing.JRadioButton" binding="radioButtonOverride">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <selected value="true"/>
+                  <text value="Override Layout"/>
+                </properties>
+              </component>
+              <component id="d677f" class="javax.swing.JRadioButton" binding="radioButtonExtend">
+                <constraints>
+                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Extend Layout"/>
+                </properties>
+              </component>
+            </children>
+          </grid>
+        </children>
+      </grid>
+      <grid id="e3588" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="5196a" class="javax.swing.JLabel" binding="selectTheme">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="319" height="16"/>
+              </grid>
+            </constraints>
+            <properties>
+              <labelFor value=""/>
+              <text resource-bundle="magento2/common" key="common.theme.target"/>
+            </properties>
+          </component>
+          <component id="bd654" class="javax.swing.JComboBox" binding="theme">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="319" height="30"/>
+              </grid>
+            </constraints>
+            <properties/>
+          </component>
+        </children>
+      </grid>
+    </children>
+  </grid>
+</form>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideLayoutInThemeDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideLayoutInThemeDialog.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.actions.generation.dialog;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiDirectory;
+import com.intellij.psi.PsiFile;
+import com.magento.idea.magento2plugin.actions.generation.OverrideLayoutInThemeAction;
+import com.magento.idea.magento2plugin.actions.generation.dialog.validator.annotation.FieldValidation;
+import com.magento.idea.magento2plugin.actions.generation.dialog.validator.annotation.RuleRegistry;
+import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.NotEmptyRule;
+import com.magento.idea.magento2plugin.actions.generation.generator.OverrideLayoutInThemeGenerator;
+import com.magento.idea.magento2plugin.indexes.ModuleIndex;
+import com.magento.idea.magento2plugin.magento.packages.Areas;
+import com.magento.idea.magento2plugin.magento.packages.ComponentType;
+import com.magento.idea.magento2plugin.magento.packages.Package;
+import com.magento.idea.magento2plugin.util.magento.GetMagentoModuleUtil;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.List;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.KeyStroke;
+import org.jetbrains.annotations.NotNull;
+
+public class OverrideLayoutInThemeDialog extends AbstractDialog {
+    @NotNull
+    private final Project project;
+    private final PsiFile psiFile;
+    private JPanel contentPane;
+    private JButton buttonOK;
+    private JButton buttonCancel;
+    private JLabel selectTheme; //NOPMD
+    private static final String THEME_NAME = "target theme";
+
+    @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
+            message = {NotEmptyRule.MESSAGE, THEME_NAME})
+    private JComboBox theme;
+    private JRadioButton radioButtonOverride;
+    private JRadioButton radioButtonExtend;
+
+    /**
+     * Constructor.
+     *
+     * @param project Project
+     * @param psiFile PsiFile
+     */
+    public OverrideLayoutInThemeDialog(final @NotNull Project project, final PsiFile psiFile) {
+        super();
+
+        this.project = project;
+        this.psiFile = psiFile;
+
+        setContentPane(contentPane);
+        setModal(true);
+        setTitle(OverrideLayoutInThemeAction.ACTION_DESCRIPTION);
+        getRootPane().setDefaultButton(buttonOK);
+        fillThemeOptions();
+
+        buttonOK.addActionListener((final ActionEvent event) -> onOK());
+        buttonCancel.addActionListener((final ActionEvent event) -> onCancel());
+
+        radioButtonOverride.addActionListener((final ActionEvent event) -> onOverride());
+        radioButtonExtend.addActionListener((final ActionEvent event) -> onExtend());
+
+        setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(final WindowEvent event) {
+                onCancel();
+            }
+        });
+
+        contentPane.registerKeyboardAction(
+                (final ActionEvent event) -> onCancel(),
+                KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
+                JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT
+        );
+
+        addComponentListener(new FocusOnAFieldListener(() -> theme.requestFocusInWindow()));
+    }
+
+    private void onOverride() {
+        this.radioButtonOverride.setSelected(true);
+        this.radioButtonExtend.setSelected(false);
+    }
+
+    private void onExtend() {
+        this.radioButtonOverride.setSelected(false);
+        this.radioButtonExtend.setSelected(true);
+    }
+
+    private void onOK() {
+        if (validateFormFields()) {
+            final OverrideLayoutInThemeGenerator overrideLayoutInThemeGenerator =
+                    new OverrideLayoutInThemeGenerator(project);
+
+            overrideLayoutInThemeGenerator.execute(psiFile, this.getTheme(), this.isOverride());
+        }
+        exit();
+    }
+
+    public String getTheme() {
+        return this.theme.getSelectedItem().toString();
+    }
+
+    /**
+     * Is Override.
+     *
+     * @return boolean
+     */
+    public boolean isOverride() {
+        return this.radioButtonOverride.isSelected();
+    }
+
+    /**
+     * Open popup.
+     *
+     * @param project Project
+     * @param psiFile PsiFile
+     */
+    public static void open(final @NotNull Project project, final PsiFile psiFile) {
+        final OverrideLayoutInThemeDialog dialog =
+                new OverrideLayoutInThemeDialog(project, psiFile);
+        dialog.pack();
+        dialog.centerDialog(dialog);
+        dialog.setVisible(true);
+    }
+
+    private void fillThemeOptions() {
+        final GetMagentoModuleUtil.MagentoModuleData moduleData =
+                GetMagentoModuleUtil.getByContext(psiFile.getContainingDirectory(), project);
+
+        if (moduleData == null) {
+            return;
+        }
+        String area = ""; // NOPMD;
+
+        if (moduleData.getType().equals(ComponentType.module)) {
+            final PsiDirectory viewDir = moduleData.getViewDir();
+
+            if (viewDir == null) {
+                return;
+            }
+            final String filePath = psiFile.getVirtualFile().getPath();
+            final String relativePath = filePath.replace(viewDir.getVirtualFile().getPath(), "");
+            area = relativePath.split(Package.V_FILE_SEPARATOR)[1];
+        } else {
+            area = moduleData.getName().split(Package.V_FILE_SEPARATOR)[0];
+        }
+        final List<String> themeNames = new ModuleIndex(project).getEditableThemeNames();
+        for (final String themeName : themeNames) {
+            if (Areas.base.toString().equals(area)
+                    || themeName.split(Package.V_FILE_SEPARATOR)[0].equals(area)) {
+                theme.addItem(themeName);
+            }
+        }
+    }
+}

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideTemplateInThemeDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideTemplateInThemeDialog.form
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.magento.idea.magento2plugin.actions.generation.dialog.OverrideInThemeDialog">
-  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.magento.idea.magento2plugin.actions.generation.dialog.OverrideTemplateInThemeDialog">
+  <grid id="27dc6" binding="contentPane" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
-      <xy x="48" y="392" width="584" height="162"/>
+      <xy x="20" y="20" width="497" height="150"/>
     </constraints>
     <properties>
       <minimumSize width="350" height="150"/>
       <preferredSize width="350" height="150"/>
-      <requestFocusEnabled value="true"/>
     </properties>
     <border type="none"/>
     <children>
-      <grid id="94766" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="99368" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -20,7 +19,7 @@
         <properties/>
         <border type="none"/>
         <children>
-          <grid id="9538f" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="true" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="7170c" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="true" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
               <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -28,7 +27,7 @@
             <properties/>
             <border type="none"/>
             <children>
-              <component id="e7465" class="javax.swing.JButton" binding="buttonOK">
+              <component id="939da" class="javax.swing.JButton" binding="buttonOK">
                 <constraints>
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
@@ -36,7 +35,7 @@
                   <text resource-bundle="magento2/common" key="common.ok"/>
                 </properties>
               </component>
-              <component id="5723f" class="javax.swing.JButton" binding="buttonCancel">
+              <component id="894c3" class="javax.swing.JButton" binding="buttonCancel">
                 <constraints>
                   <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
@@ -46,36 +45,18 @@
               </component>
             </children>
           </grid>
-          <grid id="5bb09" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="88bed" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
             <border type="none"/>
-            <children>
-              <component id="51c12" class="javax.swing.JRadioButton" binding="radioButtonOverride">
-                <constraints>
-                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                </constraints>
-                <properties>
-                  <selected value="true"/>
-                  <text value="Override Layout"/>
-                </properties>
-              </component>
-              <component id="d677f" class="javax.swing.JRadioButton" binding="radioButtonExtend">
-                <constraints>
-                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-                </constraints>
-                <properties>
-                  <text value="Extend Layout"/>
-                </properties>
-              </component>
-            </children>
+            <children/>
           </grid>
         </children>
       </grid>
-      <grid id="e3588" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="b8a26" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -83,7 +64,7 @@
         <properties/>
         <border type="none"/>
         <children>
-          <component id="5196a" class="javax.swing.JLabel" binding="selectTheme">
+          <component id="922a6" class="javax.swing.JLabel" binding="selectTheme">
             <constraints>
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="319" height="16"/>
@@ -94,7 +75,7 @@
               <text resource-bundle="magento2/common" key="common.theme.target"/>
             </properties>
           </component>
-          <component id="bd654" class="javax.swing.JComboBox" binding="theme">
+          <component id="7b530" class="javax.swing.JComboBox" binding="theme">
             <constraints>
               <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
                 <preferred-size width="319" height="30"/>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideTemplateInThemeDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideTemplateInThemeDialog.java
@@ -33,14 +33,15 @@ import javax.swing.KeyStroke;
 import org.jetbrains.annotations.NotNull;
 
 public class OverrideTemplateInThemeDialog extends AbstractDialog {
-    @NotNull
-    private final Project project;
+
+    private static final String THEME_NAME = "target theme";
+
+    private final @NotNull Project project;
     private final PsiFile psiFile;
     private JPanel contentPane;
     private JButton buttonOK;
     private JButton buttonCancel;
     private JLabel selectTheme; //NOPMD
-    private static final String THEME_NAME = "target theme";
 
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
             message = {NotEmptyRule.MESSAGE, THEME_NAME})
@@ -52,7 +53,10 @@ public class OverrideTemplateInThemeDialog extends AbstractDialog {
      * @param project Project
      * @param psiFile PsiFile
      */
-    public OverrideTemplateInThemeDialog(final @NotNull Project project, final PsiFile psiFile) {
+    public OverrideTemplateInThemeDialog(
+            final @NotNull Project project,
+            final @NotNull PsiFile psiFile
+    ) {
         super();
 
         this.project = project;
@@ -89,32 +93,32 @@ public class OverrideTemplateInThemeDialog extends AbstractDialog {
         addComponentListener(new FocusOnAFieldListener(() -> theme.requestFocusInWindow()));
     }
 
-    private void onOK() {
-        if (validateFormFields()) {
-            final OverrideTemplateInThemeGenerator overrideInThemeGenerator =
-                    new OverrideTemplateInThemeGenerator(project);
-
-            overrideInThemeGenerator.execute(psiFile, this.getTheme());
-        }
-        exit();
-    }
-
-    public String getTheme() {
-        return this.theme.getSelectedItem().toString();
-    }
-
     /**
      * Open popup.
      *
      * @param project Project
      * @param psiFile PsiFile
      */
-    public static void open(final @NotNull Project project, final PsiFile psiFile) {
+    public static void open(final @NotNull Project project, final @NotNull PsiFile psiFile) {
         final OverrideTemplateInThemeDialog dialog =
                 new OverrideTemplateInThemeDialog(project, psiFile);
         dialog.pack();
         dialog.centerDialog(dialog);
         dialog.setVisible(true);
+    }
+
+    private void onOK() {
+        if (validateFormFields()) {
+            final OverrideTemplateInThemeGenerator overrideInThemeGenerator =
+                    new OverrideTemplateInThemeGenerator(project);
+
+            overrideInThemeGenerator.execute(psiFile, this.getTheme());
+            exit();
+        }
+    }
+
+    private String getTheme() {
+        return this.theme.getSelectedItem().toString();
     }
 
     private void fillThemeOptions() {
@@ -139,6 +143,7 @@ public class OverrideTemplateInThemeDialog extends AbstractDialog {
             area = moduleData.getName().split(Package.V_FILE_SEPARATOR)[0];
         }
         final List<String> themeNames = new ModuleIndex(project).getEditableThemeNames();
+
         for (final String themeName : themeNames) {
             if (Areas.base.toString().equals(area)
                     || themeName.split(Package.V_FILE_SEPARATOR)[0].equals(area)) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideTemplateInThemeDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/OverrideTemplateInThemeDialog.java
@@ -6,14 +6,19 @@
 package com.magento.idea.magento2plugin.actions.generation.dialog;
 
 import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiFile;
-import com.magento.idea.magento2plugin.actions.generation.OverrideInThemeAction;
+import com.magento.idea.magento2plugin.actions.CopyMagentoPath;
+import com.magento.idea.magento2plugin.actions.generation.OverrideTemplateInThemeAction;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.annotation.FieldValidation;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.annotation.RuleRegistry;
 import com.magento.idea.magento2plugin.actions.generation.dialog.validator.rule.NotEmptyRule;
-import com.magento.idea.magento2plugin.actions.generation.generator.OverrideInThemeGenerator;
+import com.magento.idea.magento2plugin.actions.generation.generator.OverrideTemplateInThemeGenerator;
 import com.magento.idea.magento2plugin.indexes.ModuleIndex;
 import com.magento.idea.magento2plugin.magento.packages.Areas;
+import com.magento.idea.magento2plugin.magento.packages.ComponentType;
+import com.magento.idea.magento2plugin.magento.packages.Package;
+import com.magento.idea.magento2plugin.util.magento.GetMagentoModuleUtil;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
@@ -24,11 +29,10 @@ import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JRadioButton;
 import javax.swing.KeyStroke;
 import org.jetbrains.annotations.NotNull;
 
-public class OverrideInThemeDialog extends AbstractDialog {
+public class OverrideTemplateInThemeDialog extends AbstractDialog {
     @NotNull
     private final Project project;
     private final PsiFile psiFile;
@@ -41,8 +45,6 @@ public class OverrideInThemeDialog extends AbstractDialog {
     @FieldValidation(rule = RuleRegistry.NOT_EMPTY,
             message = {NotEmptyRule.MESSAGE, THEME_NAME})
     private JComboBox theme;
-    private JRadioButton radioButtonOverride;
-    private JRadioButton radioButtonExtend;
 
     /**
      * Constructor.
@@ -50,7 +52,7 @@ public class OverrideInThemeDialog extends AbstractDialog {
      * @param project Project
      * @param psiFile PsiFile
      */
-    public OverrideInThemeDialog(final @NotNull Project project, final PsiFile psiFile) {
+    public OverrideTemplateInThemeDialog(final @NotNull Project project, final PsiFile psiFile) {
         super();
 
         this.project = project;
@@ -58,15 +60,17 @@ public class OverrideInThemeDialog extends AbstractDialog {
 
         setContentPane(contentPane);
         setModal(true);
-        setTitle(OverrideInThemeAction.ACTION_DESCRIPTION);
+
+        if (CopyMagentoPath.PHTML_EXTENSION.equals(psiFile.getVirtualFile().getExtension())) {
+            setTitle(OverrideTemplateInThemeAction.ACTION_TEMPLATE_DESCRIPTION);
+        } else {
+            setTitle(OverrideTemplateInThemeAction.ACTION_STYLES_DESCRIPTION);
+        }
         getRootPane().setDefaultButton(buttonOK);
         fillThemeOptions();
 
         buttonOK.addActionListener((final ActionEvent event) -> onOK());
         buttonCancel.addActionListener((final ActionEvent event) -> onCancel());
-
-        radioButtonOverride.addActionListener((final ActionEvent event) -> onOverride());
-        radioButtonExtend.addActionListener((final ActionEvent event) -> onExtend());
 
         setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
         addWindowListener(new WindowAdapter() {
@@ -85,22 +89,12 @@ public class OverrideInThemeDialog extends AbstractDialog {
         addComponentListener(new FocusOnAFieldListener(() -> theme.requestFocusInWindow()));
     }
 
-    private void onOverride() {
-        this.radioButtonOverride.setSelected(true);
-        this.radioButtonExtend.setSelected(false);
-    }
-
-    private void onExtend() {
-        this.radioButtonOverride.setSelected(false);
-        this.radioButtonExtend.setSelected(true);
-    }
-
     private void onOK() {
         if (validateFormFields()) {
-            final OverrideInThemeGenerator overrideInThemeGenerator =
-                    new OverrideInThemeGenerator(project);
+            final OverrideTemplateInThemeGenerator overrideInThemeGenerator =
+                    new OverrideTemplateInThemeGenerator(project);
 
-            overrideInThemeGenerator.execute(psiFile, this.getTheme(), this.isOverride());
+            overrideInThemeGenerator.execute(psiFile, this.getTheme());
         }
         exit();
     }
@@ -110,33 +104,44 @@ public class OverrideInThemeDialog extends AbstractDialog {
     }
 
     /**
-     * Is Override.
-     *
-     * @return boolean
-     */
-    public boolean isOverride() {
-        return this.radioButtonOverride.isSelected();
-    }
-
-    /**
      * Open popup.
      *
      * @param project Project
      * @param psiFile PsiFile
      */
     public static void open(final @NotNull Project project, final PsiFile psiFile) {
-        final OverrideInThemeDialog dialog = new OverrideInThemeDialog(project, psiFile);
+        final OverrideTemplateInThemeDialog dialog =
+                new OverrideTemplateInThemeDialog(project, psiFile);
         dialog.pack();
         dialog.centerDialog(dialog);
         dialog.setVisible(true);
     }
 
     private void fillThemeOptions() {
-        final String area = psiFile.getVirtualFile().getPath().split("view/")[1].split("/")[0];
-        final List<String> themeNames = new ModuleIndex(project).getEditableThemeNames();
+        final GetMagentoModuleUtil.MagentoModuleData moduleData =
+                GetMagentoModuleUtil.getByContext(psiFile.getContainingDirectory(), project);
 
+        if (moduleData == null) {
+            return;
+        }
+        String area = ""; // NOPMD
+
+        if (moduleData.getType().equals(ComponentType.module)) {
+            final PsiDirectory viewDir = moduleData.getViewDir();
+
+            if (viewDir == null) {
+                return;
+            }
+            final String filePath = psiFile.getVirtualFile().getPath();
+            final String relativePath = filePath.replace(viewDir.getVirtualFile().getPath(), "");
+            area = relativePath.split(Package.V_FILE_SEPARATOR)[1];
+        } else {
+            area = moduleData.getName().split(Package.V_FILE_SEPARATOR)[0];
+        }
+        final List<String> themeNames = new ModuleIndex(project).getEditableThemeNames();
         for (final String themeName : themeNames) {
-            if (Areas.base.toString().equals(area) || themeName.split("/")[0].equals(area)) {
+            if (Areas.base.toString().equals(area)
+                    || themeName.split(Package.V_FILE_SEPARATOR)[0].equals(area)) {
                 theme.addItem(themeName);
             }
         }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/OverrideInThemeGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/OverrideInThemeGenerator.java
@@ -17,11 +17,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
-public class OverrideInThemeGenerator {
+public abstract class OverrideInThemeGenerator {
 
-    public final ValidatorBundle validatorBundle;
-
-    public final Project project;
+    protected final Project project;
+    protected final ValidatorBundle validatorBundle;
 
     /**
      * OverrideInThemeGenerator constructor.
@@ -37,12 +36,12 @@ public class OverrideInThemeGenerator {
      *  Get target directory.
      *
      * @param directory PsiDirectory
-     * @param pathComponents String[]
+     * @param pathComponents List[String]
      *
      * @return PsiDirectory
      */
-    public static PsiDirectory getTargetDirectory(
-            PsiDirectory directory, //NOPMD
+    protected PsiDirectory getTargetDirectory(
+            final PsiDirectory directory,
             final List<String> pathComponents
     ) {
         PsiDirectory result = directory;
@@ -62,13 +61,16 @@ public class OverrideInThemeGenerator {
      *
      * @param file PsiFile
      * @param componentName String
-     * @return String[]
+     *
+     * @return List[String]
      */
-    public static List<String> getModulePathComponents(
+    protected List<String> getModulePathComponents(
             final PsiFile file,
-            final String componentName) {
+            final String componentName
+    ) {
         final List<String> pathComponents = new ArrayList<>();
         PsiDirectory parent = file.getParent();
+
         while (!parent.getName().equals(Areas.frontend.toString())
                 && !parent.getName().equals(Areas.adminhtml.toString())
                 && !parent.getName().equals(Areas.base.toString())
@@ -89,7 +91,7 @@ public class OverrideInThemeGenerator {
      *
      * @return String[]
      */
-    public static List<String> getThemePathComponents(final PsiFile file) {
+    protected List<String> getThemePathComponents(final PsiFile file) {
         final List<String> pathComponents = new ArrayList<>();
         final Pattern pattern = Pattern.compile(RegExUtil.Magento.MODULE_NAME);
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/OverrideInThemeGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/OverrideInThemeGenerator.java
@@ -5,105 +5,68 @@
 
 package com.magento.idea.magento2plugin.actions.generation.generator;
 
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.popup.JBPopupFactory;
 import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiFile;
-import com.maddyhome.idea.copyright.actions.UpdateCopyrightProcessor;
 import com.magento.idea.magento2plugin.actions.generation.generator.util.DirectoryGenerator;
 import com.magento.idea.magento2plugin.bundles.ValidatorBundle;
-import com.magento.idea.magento2plugin.indexes.ModuleIndex;
 import com.magento.idea.magento2plugin.magento.packages.Areas;
-import com.magento.idea.magento2plugin.magento.packages.ComponentType;
 import com.magento.idea.magento2plugin.util.RegExUtil;
-import com.magento.idea.magento2plugin.util.magento.GetComponentNameByDirectoryUtil;
-import com.magento.idea.magento2plugin.util.magento.GetComponentTypeByNameUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
 public class OverrideInThemeGenerator {
-    private final ValidatorBundle validatorBundle;
 
-    private final Project project;
+    public final ValidatorBundle validatorBundle;
 
+    public final Project project;
+
+    /**
+     * OverrideInThemeGenerator constructor.
+     *
+     * @param project Project
+     */
     public OverrideInThemeGenerator(final Project project) {
         this.project = project;
         this.validatorBundle = new ValidatorBundle();
     }
 
     /**
-     * Action entry point.
+     *  Get target directory.
      *
-     * @param baseFile PsiFile
-     * @param themeName String
-     * @param isOverride boolean
+     * @param directory PsiDirectory
+     * @param pathComponents String[]
+     *
+     * @return PsiDirectory
      */
-    public void execute(final PsiFile baseFile, final String themeName, final boolean isOverride) {
-        final String componentType = GetComponentTypeByNameUtil.execute(
-                GetComponentNameByDirectoryUtil
-                    .execute(baseFile.getContainingDirectory(), project));
+    public static PsiDirectory getTargetDirectory(
+            PsiDirectory directory, //NOPMD
+            final List<String> pathComponents
+    ) {
+        PsiDirectory result = directory;
+        PsiDirectory tempDirectory = directory;
+        final DirectoryGenerator generator = DirectoryGenerator.getInstance();
 
-        List<String> pathComponents;
-        if (componentType.equals(ComponentType.module.toString())) {
-            pathComponents = getModulePathComponents(
-                    baseFile,
-                    GetComponentNameByDirectoryUtil.execute(
-                            baseFile.getContainingDirectory(),
-                            project
-                    )
-            );
-            if (isOverride) {
-                pathComponents.add("override");
-                pathComponents.add("base");
-            }
-        } else if (componentType.equals(ComponentType.theme.toString())) {
-            pathComponents = getThemePathComponents(baseFile);
-        } else {
-            return;
+        for (final String directoryName : pathComponents) {
+            result = generator.findOrCreateSubdirectory(tempDirectory, directoryName);
+            tempDirectory = result;
         }
 
-        final ModuleIndex moduleIndex = new ModuleIndex(project);
-        PsiDirectory directory = moduleIndex.getModuleDirectoryByModuleName(themeName);
-
-        if (directory == null) {
-            return;
-        }
-        directory = getTargetDirectory(directory, pathComponents);
-
-        if (directory.findFile(baseFile.getName()) != null) {
-            JBPopupFactory.getInstance()
-                    .createMessage(
-                        validatorBundle.message("validator.file.alreadyExists", baseFile.getName())
-                    )
-                    .showCenteredInCurrentWindow(project);
-            directory.findFile(baseFile.getName()).navigate(true);
-            return;
-        }
-
-        final PsiDirectory finalDirectory = directory;
-        ApplicationManager.getApplication().runWriteAction(() -> {
-            finalDirectory.copyFileFrom(baseFile.getName(), baseFile);
-        });
-
-        final PsiFile newFile = directory.findFile(baseFile.getName());
-        assert newFile != null;
-        final Module module = ModuleUtilCore.findModuleForPsiElement(newFile);
-        final UpdateCopyrightProcessor processor = new UpdateCopyrightProcessor(
-                project,
-                module,
-                newFile
-        );
-        processor.run();
-
-        newFile.navigate(true);
+        return result;
     }
 
-    private List<String> getModulePathComponents(final PsiFile file, final String componentName) {
+    /**
+     * Gt module path components.
+     *
+     * @param file PsiFile
+     * @param componentName String
+     * @return String[]
+     */
+    public static List<String> getModulePathComponents(
+            final PsiFile file,
+            final String componentName) {
         final List<String> pathComponents = new ArrayList<>();
         PsiDirectory parent = file.getParent();
         while (!parent.getName().equals(Areas.frontend.toString())
@@ -119,7 +82,14 @@ public class OverrideInThemeGenerator {
         return pathComponents;
     }
 
-    private List<String> getThemePathComponents(final PsiFile file) {
+    /**
+     * Get theme path components.
+     *
+     * @param file PsiFile
+     *
+     * @return String[]
+     */
+    public static List<String> getThemePathComponents(final PsiFile file) {
         final List<String> pathComponents = new ArrayList<>();
         final Pattern pattern = Pattern.compile(RegExUtil.Magento.MODULE_NAME);
 
@@ -132,19 +102,5 @@ public class OverrideInThemeGenerator {
         Collections.reverse(pathComponents);
 
         return pathComponents;
-    }
-
-    private PsiDirectory getTargetDirectory(
-            PsiDirectory directory, //NOPMD
-            final List<String> pathComponents
-    ) {
-        PsiDirectory result = directory;
-        final DirectoryGenerator generator = DirectoryGenerator.getInstance();
-
-        for (final String directoryName : pathComponents) {
-            result = generator.findOrCreateSubdirectory(directory, directoryName);
-        }
-
-        return result;
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/OverrideInThemeGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/OverrideInThemeGenerator.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
+@SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
 public abstract class OverrideInThemeGenerator {
 
     protected final Project project;

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/OverrideLayoutInThemeGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/OverrideLayoutInThemeGenerator.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.actions.generation.generator;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.psi.PsiDirectory;
+import com.intellij.psi.PsiFile;
+import com.maddyhome.idea.copyright.actions.UpdateCopyrightProcessor;
+import com.magento.idea.magento2plugin.indexes.ModuleIndex;
+import com.magento.idea.magento2plugin.magento.packages.ComponentType;
+import com.magento.idea.magento2plugin.magento.packages.Package;
+import com.magento.idea.magento2plugin.util.magento.GetComponentNameByDirectoryUtil;
+import com.magento.idea.magento2plugin.util.magento.GetMagentoModuleUtil;
+import java.util.List;
+
+public class OverrideLayoutInThemeGenerator extends OverrideInThemeGenerator {
+
+    /**
+     * OverrideLayoutInThemeGenerator constructor.
+     *
+     * @param project Project
+     */
+    public OverrideLayoutInThemeGenerator(final Project project) {
+        super(project);
+    }
+
+    /**
+     * Action entry point.
+     *
+     * @param baseFile PsiFile
+     * @param themeName String
+     * @param isOverride boolean
+     */
+    public void execute(
+            final PsiFile baseFile,
+            final String themeName,
+            final boolean isOverride) {
+        final GetMagentoModuleUtil.MagentoModuleData moduleData =
+                GetMagentoModuleUtil.getByContext(baseFile.getContainingDirectory(), project);
+
+        if (moduleData == null) {
+            return;
+        }
+
+        List<String> pathComponents;
+        if (moduleData.getType().equals(ComponentType.module)) {
+            pathComponents = getModulePathComponents(
+                    baseFile,
+                    GetComponentNameByDirectoryUtil.execute(
+                            baseFile.getContainingDirectory(),
+                            project
+                    )
+            );
+            if (isOverride) {
+                pathComponents.add("override");
+                pathComponents.add("base");
+            }
+        } else if (moduleData.getType().equals(ComponentType.theme)) {
+            pathComponents = getThemePathComponents(baseFile);
+            
+            if (isOverride) {
+                pathComponents.add("override");
+                pathComponents.add("theme");
+                final String[] parentThemeName =
+                        moduleData.getName().split(Package.V_FILE_SEPARATOR);
+                pathComponents.add(parentThemeName[1]);
+                pathComponents.add(parentThemeName[2]);
+            }
+        } else {
+            return;
+        }
+
+        final ModuleIndex moduleIndex = new ModuleIndex(project);
+        PsiDirectory directory = moduleIndex.getModuleDirectoryByModuleName(themeName);
+
+        if (directory == null) {
+            return;
+        }
+        directory = getTargetDirectory(directory, pathComponents);
+
+        if (directory.findFile(baseFile.getName()) != null) {
+            JBPopupFactory.getInstance()
+                    .createMessage(
+                            validatorBundle.message(
+                                    "validator.file.alreadyExists",
+                                    baseFile.getName())
+                    )
+                    .showCenteredInCurrentWindow(project);
+            directory.findFile(baseFile.getName()).navigate(true);
+            return;
+        }
+
+        final PsiDirectory finalDirectory = directory;
+        ApplicationManager.getApplication().runWriteAction(() -> {
+            finalDirectory.copyFileFrom(baseFile.getName(), baseFile);
+        });
+
+        final PsiFile newFile = directory.findFile(baseFile.getName());
+        assert newFile != null;
+        final Module module = ModuleUtilCore.findModuleForPsiElement(newFile);
+        final UpdateCopyrightProcessor processor = new UpdateCopyrightProcessor(
+                project,
+                module,
+                newFile
+        );
+        processor.run();
+
+        newFile.navigate(true);
+    }
+}

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/OverrideLayoutInThemeGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/OverrideLayoutInThemeGenerator.java
@@ -41,15 +41,16 @@ public class OverrideLayoutInThemeGenerator extends OverrideInThemeGenerator {
     public void execute(
             final PsiFile baseFile,
             final String themeName,
-            final boolean isOverride) {
+            final boolean isOverride
+    ) {
         final GetMagentoModuleUtil.MagentoModuleData moduleData =
                 GetMagentoModuleUtil.getByContext(baseFile.getContainingDirectory(), project);
 
         if (moduleData == null) {
             return;
         }
-
         List<String> pathComponents;
+
         if (moduleData.getType().equals(ComponentType.module)) {
             pathComponents = getModulePathComponents(
                     baseFile,

--- a/src/com/magento/idea/magento2plugin/actions/generation/generator/OverrideTemplateInThemeGenerator.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/generator/OverrideTemplateInThemeGenerator.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.actions.generation.generator;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.psi.PsiDirectory;
+import com.intellij.psi.PsiFile;
+import com.maddyhome.idea.copyright.actions.UpdateCopyrightProcessor;
+import com.magento.idea.magento2plugin.indexes.ModuleIndex;
+import com.magento.idea.magento2plugin.magento.packages.ComponentType;
+import com.magento.idea.magento2plugin.util.magento.GetComponentNameByDirectoryUtil;
+import com.magento.idea.magento2plugin.util.magento.GetMagentoModuleUtil;
+import java.util.List;
+
+public class OverrideTemplateInThemeGenerator extends OverrideInThemeGenerator {
+
+    /**
+     * OverrideTemplateInThemeGenerator constructor.
+     *
+     * @param project Project
+     */
+    public OverrideTemplateInThemeGenerator(final Project project) {
+        super(project);
+    }
+
+    /**
+     * Action entry point.
+     *
+     * @param baseFile PsiFile
+     * @param themeName String
+     */
+    public void execute(final PsiFile baseFile, final String themeName) {
+
+        final GetMagentoModuleUtil.MagentoModuleData moduleData =
+                GetMagentoModuleUtil.getByContext(baseFile.getContainingDirectory(), project);
+
+        if (moduleData == null) {
+            return;
+        }
+
+        List<String> pathComponents;
+        if (moduleData.getType().equals(ComponentType.module)) {
+            pathComponents = getModulePathComponents(
+                    baseFile,
+                    GetComponentNameByDirectoryUtil.execute(
+                            baseFile.getContainingDirectory(),
+                            project
+                    )
+            );
+        } else if (moduleData.getType().equals(ComponentType.theme)) {
+            pathComponents = getThemePathComponents(baseFile);
+        } else {
+            return;
+        }
+
+        final ModuleIndex moduleIndex = new ModuleIndex(project);
+        PsiDirectory directory = moduleIndex.getModuleDirectoryByModuleName(themeName);
+
+        if (directory == null) {
+            return;
+        }
+        directory = getTargetDirectory(directory, pathComponents);
+
+        if (directory.findFile(baseFile.getName()) != null) {
+            JBPopupFactory.getInstance()
+                    .createMessage(
+                        validatorBundle.message("validator.file.alreadyExists", baseFile.getName())
+                    )
+                    .showCenteredInCurrentWindow(project);
+            directory.findFile(baseFile.getName()).navigate(true);
+            return;
+        }
+
+        final PsiDirectory finalDirectory = directory;
+        ApplicationManager.getApplication().runWriteAction(() -> {
+            finalDirectory.copyFileFrom(baseFile.getName(), baseFile);
+        });
+
+        final PsiFile newFile = directory.findFile(baseFile.getName());
+        assert newFile != null;
+        final Module module = ModuleUtilCore.findModuleForPsiElement(newFile);
+        final UpdateCopyrightProcessor processor = new UpdateCopyrightProcessor(
+                project,
+                module,
+                newFile
+        );
+        processor.run();
+
+        newFile.navigate(true);
+    }
+}

--- a/src/com/magento/idea/magento2plugin/magento/files/LayoutXml.java
+++ b/src/com/magento/idea/magento2plugin/magento/files/LayoutXml.java
@@ -22,6 +22,7 @@ public class LayoutXml implements ModuleFileInterface {
     public static final String XML_ATTRIBUTE_TEMPLATE = "template";
     public static final String ARGUMENTS_TEMPLATE = "Magento Module Class Arguments In Xml";
     public static final String PARENT_DIR = "layout";
+    public static final String PAGE_LAYOUT_DIR = "page_layout";
     public static final String NAME_ATTRIBUTE = "name";
     public static final String CONTENT_CONTAINER_NAME = "content";
 

--- a/src/com/magento/idea/magento2plugin/util/magento/GetMagentoModuleUtil.java
+++ b/src/com/magento/idea/magento2plugin/util/magento/GetMagentoModuleUtil.java
@@ -10,6 +10,7 @@ import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.SlowOperations;
 import com.jetbrains.php.lang.psi.elements.ClassConstantReference;
 import com.jetbrains.php.lang.psi.elements.MethodReference;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
@@ -108,7 +109,10 @@ public final class GetMagentoModuleUtil {
 
     private static String parseParameterValue(final PsiElement valueHolder) {
         if (valueHolder instanceof ClassConstantReference) {
-            final PsiElement resolved = ((ClassConstantReference) valueHolder).resolve();
+            final ClassConstantReference constantReference = (ClassConstantReference) valueHolder;
+            final PsiElement resolved = SlowOperations.allowSlowOperations(
+                    constantReference::resolve
+            );
 
             if (!(resolved instanceof ClassConstImpl)) {
                 return null;


### PR DESCRIPTION
**Description** (*)
Hello! I changed the behavior for the action menu for overwriting template files.
Now we have one menu and dialog window for templates and less files.
![image](https://user-images.githubusercontent.com/15772032/158818905-d4d1ad6e-cec7-44bb-970f-cd346960db84.png)
![image](https://user-images.githubusercontent.com/15772032/158819071-f4b6aacb-019b-4662-81ea-8d925a17fd23.png)
![image](https://user-images.githubusercontent.com/15772032/158819237-b173ceb4-0a58-45c4-b0d5-5554912b8d4a.png)
![image](https://user-images.githubusercontent.com/15772032/158819323-7f434e84-ec85-48ce-b3d4-7d72b63be5e0.png)
Now plugin copied correctly the files to the selected theme.
![image](https://user-images.githubusercontent.com/15772032/158819595-d54a29b3-6572-4db5-a1cf-d526c1a8cccc.png)
I also changed the gear of overwriting the layout files
![image](https://user-images.githubusercontent.com/15772032/158820064-b8b9dd77-3ee3-41a2-80b6-bfcd6d52a0f2.png)
![image](https://user-images.githubusercontent.com/15772032/158820159-f5b62176-d9ad-4394-bacc-9f5fded27cb5.png)
![image](https://user-images.githubusercontent.com/15772032/158820226-5a493f0b-6386-458c-9c28-44fb61ab6165.png)


**Fixed Issues (if relevant)**
1. Fixes magento/magento2-phpstorm-plugin#1026

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
