### PR TITLE
1035: removed deprecated Function#getReturnType

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/util/FillTextBufferWithPluginMethods.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/util/FillTextBufferWithPluginMethods.java
@@ -13,6 +13,7 @@ import com.jetbrains.php.lang.psi.elements.Method;
 import com.jetbrains.php.lang.psi.elements.Parameter;
 import com.jetbrains.php.lang.psi.elements.PhpReturnType;
 import com.magento.idea.magento2plugin.actions.generation.data.code.PluginMethodData;
+import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
 import com.magento.idea.magento2plugin.actions.generation.references.PhpClassReferenceResolver;
 import com.magento.idea.magento2plugin.util.php.PhpTypeMetadataParserUtil;
 import java.util.ArrayList;
@@ -55,19 +56,19 @@ public class FillTextBufferWithPluginMethods {
             final PsiElement targetClass = (PsiElement) pluginMethod.getTargetMethod()
                     .getUserData(targetClassKey);
             resolver.processElement(targetClass);
-            PhpReturnType returnType = targetMethod.getReturnType();
+
             final String returnTypeFqn =
                     PhpTypeMetadataParserUtil.getMethodReturnType(targetMethod);
 
-            if (returnType == null && returnTypeFqn != null) {
-                returnType = PhpPsiElementFactory.createReturnType(
+            if (returnTypeFqn != null && PhpClassGeneratorUtil.isValidFqn(returnTypeFqn)) {
+                final PhpReturnType returnType = PhpPsiElementFactory.createReturnType(
                         pluginMethod.getTargetMethod().getProject(),
                         returnTypeFqn
                 );
-            }
 
-            if (returnType != null) {
-                resolver.processElement(returnType);
+                if (returnType != null) {
+                    resolver.processElement(returnType);
+                }
             }
 
             textBuf.append('\n');

--- a/src/com/magento/idea/magento2plugin/actions/generation/util/FillTextBufferWithPluginMethods.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/util/FillTextBufferWithPluginMethods.java
@@ -11,7 +11,6 @@ import com.jetbrains.php.lang.documentation.phpdoc.psi.PhpDocComment;
 import com.jetbrains.php.lang.psi.PhpPsiElementFactory;
 import com.jetbrains.php.lang.psi.elements.Method;
 import com.jetbrains.php.lang.psi.elements.Parameter;
-import com.jetbrains.php.lang.psi.elements.PhpReturnType;
 import com.magento.idea.magento2plugin.actions.generation.data.code.PluginMethodData;
 import com.magento.idea.magento2plugin.actions.generation.generator.util.PhpClassGeneratorUtil;
 import com.magento.idea.magento2plugin.actions.generation.references.PhpClassReferenceResolver;
@@ -57,18 +56,18 @@ public class FillTextBufferWithPluginMethods {
                     .getUserData(targetClassKey);
             resolver.processElement(targetClass);
 
-            final String returnTypeFqn =
-                    PhpTypeMetadataParserUtil.getMethodReturnType(targetMethod);
+            final String returnTypeCandidate = PhpTypeMetadataParserUtil.getMethodReturnType(
+                    targetMethod
+            );
 
-            if (returnTypeFqn != null && PhpClassGeneratorUtil.isValidFqn(returnTypeFqn)) {
-                final PhpReturnType returnType = PhpPsiElementFactory.createReturnType(
-                        pluginMethod.getTargetMethod().getProject(),
-                        returnTypeFqn
+            if (returnTypeCandidate != null
+                    && PhpClassGeneratorUtil.isValidFqn(returnTypeCandidate)) {
+                resolver.processElement(
+                        PhpPsiElementFactory.createReturnType(
+                                pluginMethod.getTargetMethod().getProject(),
+                                returnTypeCandidate
+                        )
                 );
-
-                if (returnType != null) {
-                    resolver.processElement(returnType);
-                }
             }
 
             textBuf.append('\n');


### PR DESCRIPTION
**Description** (*)

Eliminated usage of deprecated method Function#getReturnType for class com.magento.idea.magento2plugin.actions.generation.util.FillTextBufferWithPluginMethods.
This functionality works when creating a plugin from the context menu.

https://user-images.githubusercontent.com/89141549/159774081-f0215fe6-ebda-4876-a5fe-8bd56cd767ac.mp4

**Type bool:**
<img width="635" alt="Screenshot 2022-03-24 at 15 20 07" src="https://user-images.githubusercontent.com/89141549/159929964-d223bb4c-0385-44ac-94ed-04e6c7149af4.png">
<img width="597" alt="Screenshot 2022-03-24 at 15 20 23" src="https://user-images.githubusercontent.com/89141549/159929988-a4c5c2a8-13d1-4e11-ad4f-d3cff7c2c7be.png">
<img width="688" alt="Screenshot 2022-03-24 at 15 21 35" src="https://user-images.githubusercontent.com/89141549/159930005-76f27bf2-dfbf-4362-884c-73d3ceda36a6.png">

**Type int:**
<img width="597" alt="Screenshot 2022-03-24 at 15 56 47" src="https://user-images.githubusercontent.com/89141549/159933086-4973cbec-859b-4048-9c17-5f00ebc19c13.png">
<img width="665" alt="Screenshot 2022-03-24 at 15 58 42" src="https://user-images.githubusercontent.com/89141549/159933097-53776154-8a82-4fb3-a493-49b457ad4721.png">
<img width="729" alt="Screenshot 2022-03-24 at 16 00 02" src="https://user-images.githubusercontent.com/89141549/159933107-b539688a-6ba3-401d-8ddd-bac35e48d768.png">

**Type string:**
<img width="726" alt="Screenshot 2022-03-24 at 16 07 05" src="https://user-images.githubusercontent.com/89141549/159934562-a76b68b1-d993-4934-b784-b4069c45b89c.png">
<img width="685" alt="Screenshot 2022-03-24 at 16 05 51" src="https://user-images.githubusercontent.com/89141549/159934571-a4475cc6-32d2-4704-8f22-a52c501432f6.png">
<img width="573" alt="Screenshot 2022-03-24 at 16 05 38" src="https://user-images.githubusercontent.com/89141549/159934578-252bedc0-d49c-4007-b6d7-b941451de797.png">

**Type array:**
<img width="604" alt="Screenshot 2022-03-24 at 16 14 02" src="https://user-images.githubusercontent.com/89141549/159935817-a6d7b6ab-ebc2-4555-a69a-cf48042530a5.png">
<img width="706" alt="Screenshot 2022-03-24 at 16 14 17" src="https://user-images.githubusercontent.com/89141549/159935832-8ee701c6-574b-492f-ad96-23077e71c750.png">
<img width="741" alt="Screenshot 2022-03-24 at 16 14 30" src="https://user-images.githubusercontent.com/89141549/159935844-5883aaa8-c9b9-4f39-9adc-af57eb95c6b3.png">

**Type void:**
<img width="610" alt="Screenshot 2022-03-24 at 16 25 04" src="https://user-images.githubusercontent.com/89141549/159938026-134a534d-7ab3-4f8e-8ae9-b36b470a26a5.png">
<img width="665" alt="Screenshot 2022-03-24 at 16 25 15" src="https://user-images.githubusercontent.com/89141549/159938054-34039a0f-7c70-44d1-b431-c8b3dbbecf1b.png">
<img width="751" alt="Screenshot 2022-03-24 at 16 25 29" src="https://user-images.githubusercontent.com/89141549/159938074-17276aca-a311-4a1e-a589-e1d8a4b3a72e.png">

**Type string with params:**
<img width="1100" alt="Screenshot 2022-03-24 at 16 29 15" src="https://user-images.githubusercontent.com/89141549/159939759-c2a7b604-555c-4baf-a519-409c36f24922.png">
<img width="1244" alt="Screenshot 2022-03-24 at 16 30 17" src="https://user-images.githubusercontent.com/89141549/159939786-40351332-69e6-4fe7-9e83-44a852cc5a2e.png">
<img width="1265" alt="Screenshot 2022-03-24 at 16 31 11" src="https://user-images.githubusercontent.com/89141549/159939816-17c6766d-5cd4-4eb0-bfc6-925a3ccf96ec.png">

**Type array with params:**
<img width="798" alt="Screenshot 2022-03-24 at 17 21 19" src="https://user-images.githubusercontent.com/89141549/159950890-1cc64478-a5a7-4e88-8cd9-5897f28261dd.png">
<img width="895" alt="Screenshot 2022-03-24 at 17 22 17" src="https://user-images.githubusercontent.com/89141549/159950920-ee026b55-cf04-465a-afc1-f99d44b32a76.png">
<img width="913" alt="Screenshot 2022-03-24 at 17 23 13" src="https://user-images.githubusercontent.com/89141549/159950953-2b703faa-1cb3-4ef1-b632-d244612296e2.png">

**Type string with param string:**
<img width="762" alt="Screenshot 2022-03-24 at 17 32 22" src="https://user-images.githubusercontent.com/89141549/159952703-a147903e-ae08-4923-b6f7-514c62a2c465.png">
<img width="843" alt="Screenshot 2022-03-24 at 17 32 36" src="https://user-images.githubusercontent.com/89141549/159952739-f774d9bb-ff43-40d6-b10e-dccc31d3428c.png">
<img width="888" alt="Screenshot 2022-03-24 at 17 32 45" src="https://user-images.githubusercontent.com/89141549/159952771-60424a6c-5411-4451-ab03-c4391e9c1944.png">


**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#1035.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#1035

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
