### PR TITLE
984: Filtered generated folder from reference resolving results

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -617,5 +617,7 @@
         <frameworkProjectConfigurableProvider implementation="com.magento.idea.magento2plugin.project.ConfigurableProvider"/>
         <frameworkUsageProvider implementation="com.magento.idea.magento2plugin.project.UsagesProvider"/>
         <libraryRoot id="phpstorm.meta.php" path="/.phpstorm.meta.php/" runtime="false"/>
+
+        <referenceResolver2 implementation="com.magento.idea.magento2plugin.lang.php.MagentoProxyDeclarationFilter" order="first"/>
     </extensions>
 </idea-plugin>

--- a/src/com/magento/idea/magento2plugin/lang/php/MagentoProxyDeclarationFilter.java
+++ b/src/com/magento/idea/magento2plugin/lang/php/MagentoProxyDeclarationFilter.java
@@ -32,22 +32,22 @@ public class MagentoProxyDeclarationFilter implements PhpMultipleDeclarationFilt
             return candidates;
         } else if (psiElement.getContainingFile() == null) {
             return candidates;
-        } else {
-            return ContainerUtil.filter(candidates,
-                    (candidate) -> {
-                        final PsiFile file = candidate.getContainingFile();
-
-                        if (file == null) {
-                            return false;
-                        }
-                        final VirtualFile virtualFile = file.getVirtualFile();
-
-                        if (virtualFile == null) {
-                            return false;
-                        }
-
-                        return !virtualFile.getPath().contains("/generated/");
-                    });
         }
+
+        return ContainerUtil.filter(candidates,
+                (candidate) -> {
+                    final PsiFile file = candidate.getContainingFile();
+
+                    if (file == null) {
+                        return false;
+                    }
+                    final VirtualFile virtualFile = file.getVirtualFile();
+
+                    if (virtualFile == null) {
+                        return false;
+                    }
+
+                    return !virtualFile.getPath().contains("/generated/");
+                });
     }
 }

--- a/src/com/magento/idea/magento2plugin/lang/php/MagentoProxyDeclarationFilter.java
+++ b/src/com/magento/idea/magento2plugin/lang/php/MagentoProxyDeclarationFilter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.lang.php;
+
+import com.intellij.openapi.util.registry.Registry;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.containers.ContainerUtil;
+import com.jetbrains.php.lang.psi.PhpMultipleDeclarationFilter;
+import com.jetbrains.php.lang.psi.elements.PhpNamedElement;
+import com.magento.idea.magento2plugin.project.Settings;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
+
+public class MagentoProxyDeclarationFilter implements PhpMultipleDeclarationFilter {
+
+    @SuppressWarnings({"PMD.CognitiveComplexity", "PMD.ConfusingTernary"})
+    @Override
+    public <E extends PhpNamedElement> Collection<E> filter(
+            final @NotNull PsiElement psiElement,
+            final Collection<E> candidates
+    ) {
+        if (!Settings.isEnabled(psiElement.getProject())) {
+            return candidates;
+        } else if (!Registry.is("php.use.multiproject.ref.resolver", true)) {
+            return candidates;
+        } else if (candidates.size() == 1) { // NOPMD
+            return candidates;
+        } else if (psiElement.getContainingFile() == null) {
+            return candidates;
+        } else {
+            return ContainerUtil.filter(candidates,
+                    (candidate) -> {
+                        final PsiFile file = candidate.getContainingFile();
+
+                        if (file == null) {
+                            return false;
+                        }
+                        final VirtualFile virtualFile = file.getVirtualFile();
+
+                        if (virtualFile == null) {
+                            return false;
+                        }
+
+                        return !virtualFile.getPath().contains("/generated/");
+                    });
+        }
+    }
+}


### PR DESCRIPTION
**Description** (*)

Fixed issue with wrong references resolved for a class if Magento 2 proxy was generated for it.
In this case the PHPStorm filters references resolved from the `/vendor/` directory if there is any result from the project itself (`generated` folder in this case).

**Before:**

<img width="1290" alt="Screenshot 2022-03-24 at 13 26 19" src="https://user-images.githubusercontent.com/31848341/159906619-4c860f19-4766-4ca2-93ff-27cf8a6b530a.png">

ℹ️ Additional side affect provided in the related issue: #984.

**After:**

<img width="1290" alt="Screenshot 2022-03-24 at 13 22 41" src="https://user-images.githubusercontent.com/31848341/159906456-4cd4bc72-0de6-4721-abfc-9570046041d2.png">

![Mar-24-2022 13-23-35](https://user-images.githubusercontent.com/31848341/159906476-96b4a823-5360-41b9-86e6-9a354bb54c88.gif)

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#984

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
