### PR TITLE
1048: Fixed bug with wrong text range

### DIFF
--- a/src/com/magento/idea/magento2plugin/reference/provider/FilePathReferenceProvider.java
+++ b/src/com/magento/idea/magento2plugin/reference/provider/FilePathReferenceProvider.java
@@ -33,7 +33,8 @@ public class FilePathReferenceProvider extends PsiReferenceProvider {
             "PMD.CognitiveComplexity",
             "PMD.CyclomaticComplexity",
             "PMD.NPathComplexity",
-            "PMD.AvoidInstantiatingObjectsInLoops"
+            "PMD.AvoidInstantiatingObjectsInLoops",
+            "PMD.AvoidDeeplyNestedIfStmts"
     })
     @NotNull
     @Override
@@ -92,14 +93,13 @@ public class FilePathReferenceProvider extends PsiReferenceProvider {
                     if (null != psiElement) {
                         final int currentPathIndex = currentPath.lastIndexOf('/') == -1
                                 ? 0 : currentPath.lastIndexOf('/') + 1;
+                        final int startOffset = origValue.indexOf(filePath) + currentPathIndex;
+                        final int endOffset = startOffset + pathPart.length();
 
-                        final TextRange pathRange = new TextRange(
-                                origValue.indexOf(filePath)
-                                    + currentPathIndex,
-                                origValue.indexOf(filePath)
-                                    + currentPathIndex
-                                    + pathPart.length()
-                        );
+                        if (!isProperRange(startOffset, endOffset)) {
+                            continue;
+                        }
+                        final TextRange pathRange = new TextRange(startOffset, endOffset);
 
                         if (psiPathElements.containsKey(pathRange)) {
                             psiPathElements.get(pathRange).add(psiElement);
@@ -185,5 +185,9 @@ public class FilePathReferenceProvider extends PsiReferenceProvider {
 
     private boolean isModuleNamePresent(final @NotNull PsiElement element) {
         return GetModuleNameUtil.getInstance().execute(element.getText()) != null;
+    }
+
+    private boolean isProperRange(final int startOffset, final int endOffset) {
+        return startOffset <= endOffset && startOffset >= 0;
     }
 }


### PR DESCRIPTION
**Description** (*)

Fixed bug that appears when trying to instantiate a new TextRange object by providing an invalid startOffset/endOffset values.

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#1048

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
