### PR TITLE
Issue #1085 - Fixing relative path handling for Magento install location

### DIFF
--- a/src/com/magento/idea/magento2plugin/util/magento/MagentoBasePathUtil.java
+++ b/src/com/magento/idea/magento2plugin/util/magento/MagentoBasePathUtil.java
@@ -8,9 +8,9 @@ package com.magento.idea.magento2plugin.util.magento;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.magento.idea.magento2plugin.magento.packages.Package;
-import java.io.File;
 import java.util.Arrays;
 import org.jetbrains.annotations.NotNull;
 
@@ -29,14 +29,15 @@ public final class MagentoBasePathUtil {
             return false;
         }
         final VirtualFile file = LocalFileSystem.getInstance().findFileByPath(path);
+
         if (file != null && file.isDirectory()) {
             return VfsUtil.findRelativeFile(
                     file,
-                    Package.frameworkRootComposer.split(File.separator)
+                    Package.frameworkRootComposer.split(VfsUtilCore.VFS_SEPARATOR)
             ) != null
                 || VfsUtil.findRelativeFile(
                         file,
-                    Package.frameworkRootGit.split(File.separator)) != null;
+                    Package.frameworkRootGit.split(VfsUtilCore.VFS_SEPARATOR)) != null;
         }
         return false;
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

Fixed handling of string splitting in src\com\magento\idea\magento2plugin\magento\packages\Package.java to utilize the file separator specified in the file instead of the generic "File.separator" string. 

**Description** (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Replaced two instances of "File.separator" as the string for breaking apart a path with the correct V_FILE_SEPARATOR string. Additionally I cleaned up the java.io.File import as it was no longer being utilized.

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#1085

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
