### PR TITLE
1113: Fixed IllegalArgumentException: Argument for @NotNull parameter 'dataKey' must not be null in CompareTemplateAction

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/comparator/CompareTemplateAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/comparator/CompareTemplateAction.java
@@ -49,8 +49,8 @@ public class CompareTemplateAction extends AnAction {
      *
      * @param event AnActionEvent
      */
-    @SuppressWarnings("PMD.NPathComplexity")
     @Override
+    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
     public void update(final @NotNull AnActionEvent event) {
         setStatus(event, false);
         final Project project = event.getData(PlatformDataKeys.PROJECT);

--- a/src/com/magento/idea/magento2plugin/actions/comparator/CompareTemplateAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/comparator/CompareTemplateAction.java
@@ -83,6 +83,9 @@ public class CompareTemplateAction extends AnAction {
         }
         final String originalModuleName = getOriginalModuleName(project, psiFile);
 
+        if (originalModuleName == null) {
+            return;
+        }
         final PsiDirectory originalModuleDirectory =
                 new ModuleIndex(project).getModuleDirectoryByModuleName(originalModuleName);
 


### PR DESCRIPTION
**Description** (*)
Fixed a bug that caused a bug when comparing files

1. Fixes magento/magento2-phpstorm-plugin#1113

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
