### PR TITLE
406: added sorting plugin list marker

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/PluginGenerateMethodHandlerBase.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/PluginGenerateMethodHandlerBase.java
@@ -42,7 +42,6 @@ import com.magento.idea.magento2plugin.util.GetPhpClassByFQN;
 import com.magento.idea.magento2plugin.util.magento.plugin.GetTargetClassNamesByPluginClassName;
 import com.magento.idea.magento2plugin.util.magento.plugin.IsPluginAllowedForMethodUtil;
 import gnu.trove.THashSet;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -88,9 +87,9 @@ public abstract class PluginGenerateMethodHandlerBase implements LanguageCodeIns
             return false;
         }
         final GetTargetClassNamesByPluginClassName targetClassesService
-                = GetTargetClassNamesByPluginClassName.getInstance(editor.getProject());
+                = new GetTargetClassNamesByPluginClassName(editor.getProject());
         final String currentClass = phpClass.getFQN().substring(1);
-        final ArrayList<String> targetClassNames = targetClassesService.execute(currentClass);
+        final List<String> targetClassNames = targetClassesService.execute(currentClass);
         return !targetClassNames.isEmpty();
     }
 
@@ -241,9 +240,9 @@ public abstract class PluginGenerateMethodHandlerBase implements LanguageCodeIns
         final TreeMap<String, PhpNamedElementNode> nodes = new TreeMap();
 
         final GetTargetClassNamesByPluginClassName targetClassesService =
-                GetTargetClassNamesByPluginClassName.getInstance(phpClass.getProject());
+                new GetTargetClassNamesByPluginClassName(phpClass.getProject());
         final String currentClass = phpClass.getFQN().substring(1);
-        final ArrayList<String> targetClassNames = targetClassesService.execute(currentClass);
+        final List<String> targetClassNames = targetClassesService.execute(currentClass);
         for (final String targetClassName : targetClassNames) {
             final PhpClass targetClass = GetPhpClassByFQN.getInstance(
                     phpClass.getProject()

--- a/src/com/magento/idea/magento2plugin/inspections/php/PluginInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/php/PluginInspection.java
@@ -27,7 +27,7 @@ import com.magento.idea.magento2plugin.magento.packages.MagentoPhpClass;
 import com.magento.idea.magento2plugin.magento.packages.Package;
 import com.magento.idea.magento2plugin.util.GetPhpClassByFQN;
 import com.magento.idea.magento2plugin.util.magento.plugin.GetTargetClassNamesByPluginClassName;
-import java.util.ArrayList;
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings({"PMD.ExcessiveMethodLength", "PMD.NPathComplexity", "PMD.CognitiveComplexity"})
@@ -75,10 +75,8 @@ public class PluginInspection extends PhpInspection {
                         ((PhpClass) parentClass).getNameIdentifier();
                 final String currentClass = ((PhpClass) parentClass).getFQN().substring(1);
                 final GetTargetClassNamesByPluginClassName targetClassesService =
-                        GetTargetClassNamesByPluginClassName.getInstance(
-                                problemsHolder.getProject()
-                        );
-                final ArrayList<String> targetClassNames =
+                        new GetTargetClassNamesByPluginClassName(problemsHolder.getProject());
+                final List<String> targetClassNames =
                         targetClassesService.execute(currentClass);
 
                 for (final String targetClassName : targetClassNames) {

--- a/src/com/magento/idea/magento2plugin/linemarker/php/PluginLineMarkerProvider.java
+++ b/src/com/magento/idea/magento2plugin/linemarker/php/PluginLineMarkerProvider.java
@@ -15,12 +15,13 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.indexing.FileBasedIndex;
-import com.jetbrains.php.PhpIndex;
 import com.jetbrains.php.lang.psi.elements.Method;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.magento.idea.magento2plugin.linemarker.SearchGutterIconNavigationHandler;
+import com.magento.idea.magento2plugin.linemarker.php.data.PluginMethodData;
 import com.magento.idea.magento2plugin.project.Settings;
 import com.magento.idea.magento2plugin.stubs.indexes.PluginIndex;
+import com.magento.idea.magento2plugin.stubs.indexes.data.PluginData;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -94,12 +95,13 @@ public class PluginLineMarkerProvider implements LineMarkerProvider {
         }
     }
 
+    @SuppressWarnings("checkstyle:LineLength")
     private static class PluginClassCache {
 
-        private final Map<String, List<PhpClass>> classPluginsMap = new HashMap<>();
+        private final Map<String, List<PluginData>> classPluginsMap = new HashMap<>();
 
-        public List<PhpClass> getPluginsForClass(final @NotNull PhpClass phpClass) {
-            final List<PhpClass> pluginsForClass = getPluginsForClass(
+        public List<PluginData> getPluginsForClass(final @NotNull PhpClass phpClass) {
+            final List<PluginData> pluginsForClass = getPluginsForClass(
                     phpClass,
                     phpClass.getPresentableFQN()
             );
@@ -114,7 +116,7 @@ public class PluginLineMarkerProvider implements LineMarkerProvider {
             return pluginsForClass;
         }
 
-        public List<PhpClass> getPluginsForClass(
+        public List<PluginData> getPluginsForClass(
                 final @NotNull PhpClass phpClass,
                 final @NotNull String classFQN
         ) {
@@ -122,24 +124,24 @@ public class PluginLineMarkerProvider implements LineMarkerProvider {
                 return classPluginsMap.get(classFQN);
             }
 
-            final List<Set<String>> plugins = FileBasedIndex.getInstance()
+            final List<Set<PluginData>> plugins = FileBasedIndex.getInstance()
                     .getValues(
                             PluginIndex.KEY,
                             classFQN,
                             GlobalSearchScope.allScope(phpClass.getProject())
                     );
-            final List<PhpClass> results = new ArrayList<>();
+            final List<PluginData> results = new ArrayList<>();
 
             if (plugins.isEmpty()) {
                 classPluginsMap.put(classFQN, results);
 
                 return results;
             }
-            final PhpIndex phpIndex = PhpIndex.getInstance(phpClass.getProject());
 
-            for (final Set<String> pluginClassNames : plugins) {
-                for (final String pluginClassName: pluginClassNames) {
-                    results.addAll(phpIndex.getClassesByFQN(pluginClassName));
+            for (final Set<PluginData> pluginDataList : plugins) {
+                for (final PluginData pluginData: pluginDataList) {
+                    pluginData.setPhpClass(phpClass);
+                    results.add(pluginData);
                 }
             }
             classPluginsMap.put(classFQN, results);
@@ -147,25 +149,29 @@ public class PluginLineMarkerProvider implements LineMarkerProvider {
             return results;
         }
 
-        public List<Method> getPluginMethods(final List<PhpClass> plugins) {
-            final List<Method> methodList = new ArrayList<>();
+        public List<PluginMethodData> getPluginMethods(final List<PluginData> pluginDataList) {
+            List<PluginMethodData> result = new ArrayList<>();
 
-            for (final PhpClass plugin: plugins) {
-                methodList.addAll(getPluginMethods(plugin));
+            for (PluginData pluginData: pluginDataList) {
+                for (final PhpClass plugin: pluginData.getPhpClassCollection()) {
+                    //@todo add module sequence ID if sortOrder equal zero. It should be negative value.
+                    result.addAll(getPluginMethods(plugin, pluginData.getSortOrder()));
+                }
             }
 
-            return methodList;
+            return result;
         }
 
-        public List<Method> getPluginMethods(final @NotNull PhpClass pluginClass) {
-            final List<Method> methodList = new ArrayList<>();
+        public List<PluginMethodData> getPluginMethods(final @NotNull PhpClass pluginClass, int sortOrder) {
+            final List<PluginMethodData> methodList = new ArrayList<>();
 
             for (final Method method : pluginClass.getMethods()) {
                 if (method.getAccess().isPublic()) {
                     final String pluginMethodName = method.getName();
 
                     if (pluginMethodName.length() > MIN_PLUGIN_METHOD_NAME_LENGTH) {
-                        methodList.add(method);
+                        //@todo module sequence value should be set here instead of zero.
+                        methodList.add(new PluginMethodData(method, sortOrder, 0));
                     }
                 }
             }
@@ -186,41 +192,133 @@ public class PluginLineMarkerProvider implements LineMarkerProvider {
 
         @Override
         public List<PhpClass> collect(final @NotNull PhpClass psiElement) {
-            return pluginClassCache.getPluginsForClass(psiElement);
+            List<PluginData> pluginDataList = pluginClassCache.getPluginsForClass(psiElement);
+            List<PhpClass> phpClassList =  new ArrayList<>();
+
+            for (PluginData pluginData: pluginDataList) {
+                phpClassList.addAll(pluginData.getPhpClassCollection());
+            }
+
+            return phpClassList;
         }
     }
 
     private static class MethodPluginCollector implements Collector<Method, Method> {
 
         private final PluginLineMarkerProvider.PluginClassCache pluginClassCache;
+        private final Map<String, Integer> pluginMethodsSortOrder;
 
         public MethodPluginCollector(
                 final PluginLineMarkerProvider.PluginClassCache pluginClassCache
         ) {
             this.pluginClassCache = pluginClassCache;
+            pluginMethodsSortOrder = new HashMap<>();
+            pluginMethodsSortOrder.put("before", 1);
+            pluginMethodsSortOrder.put("around", 2);
+            pluginMethodsSortOrder.put("after", 3);
         }
 
+        @SuppressWarnings("checkstyle:LineLength")
         @Override
         public List<Method> collect(final @NotNull Method psiElement) {
             final List<Method> results = new ArrayList<>();
-
             final PhpClass methodClass = psiElement.getContainingClass();
 
             if (methodClass == null) {
                 return results;
             }
-            final List<PhpClass> pluginsList = pluginClassCache.getPluginsForClass(methodClass);
-            final List<Method> pluginMethods = pluginClassCache.getPluginMethods(pluginsList);
 
+            final List<PluginData> pluginDataList = pluginClassCache.getPluginsForClass(methodClass);
+            final List<PluginMethodData> pluginMethods = pluginClassCache.getPluginMethods(pluginDataList);
             final String classMethodName = WordUtils.capitalize(psiElement.getName());
 
-            for (final Method pluginMethod: pluginMethods) {
-                if (isPluginMethodName(pluginMethod.getName(), classMethodName)) {
-                    results.add(pluginMethod);
+            pluginMethods.removeIf(pluginMethod -> !isPluginMethodName(pluginMethod.getMethodName(), classMethodName));
+            sortMethods(pluginMethods, results);
+
+            return results;
+        }
+
+        @SuppressWarnings({"checkstyle:Indentation", "checkstyle:OperatorWrap", "checkstyle:LineLength"})
+        private void sortMethods(final @NotNull List<PluginMethodData> methodDataList, List<Method> results) {
+            List<Integer> bufferSortOrderList = new ArrayList<>();
+            int biggestSortOrder = 0;
+
+            for (PluginMethodData pluginMethodData: methodDataList) {
+                String methodName = pluginMethodData.getMethodName();
+
+                if (methodName.startsWith("around")) {
+                    bufferSortOrderList.add(pluginMethodData.getSortOrder());
+                }
+
+                if (pluginMethodData.getSortOrder() > biggestSortOrder) {
+                    biggestSortOrder = pluginMethodData.getSortOrder();
                 }
             }
 
-            return results;
+            final int biggestSortOrderValue = biggestSortOrder;
+
+            methodDataList.sort(
+                (PluginMethodData method1, PluginMethodData method2) -> {
+                    final String firstMethodName =  method1.getMethodName();
+                    final String secondMethodName =  method2.getMethodName();
+                    final int firstIndexEnd = firstMethodName.startsWith("after") ? 5 : 6;
+                    final int secondIndexEnd = secondMethodName.startsWith("after") ? 5 : 6;
+                    String firstMethodPrefix =  firstMethodName.substring(0,firstIndexEnd);
+                    String secondMethodPrefix =  secondMethodName.substring(0,secondIndexEnd);
+
+                    if (!pluginMethodsSortOrder.containsKey(firstMethodPrefix)
+                        || !pluginMethodsSortOrder.containsKey(secondMethodPrefix)) {
+                        return firstMethodName.compareTo(secondMethodName);
+                    }
+
+                    final Integer firstNameSortOrder = pluginMethodsSortOrder.get(firstMethodPrefix);
+                    final Integer secondNameSortOrder = pluginMethodsSortOrder.get(secondMethodPrefix);
+
+                    if (firstNameSortOrder.compareTo(secondNameSortOrder) != 0) {
+                        return firstNameSortOrder.compareTo(secondNameSortOrder);
+                    }
+
+                    Integer firstBuffer = 0;
+                    Integer secondBuffer = 0;
+                    Integer firstModuleSequence = (method1.getModuleSequence() + biggestSortOrderValue) * -1;
+                    Integer secondModuleSequence = (method2.getModuleSequence() + biggestSortOrderValue) * -1;
+                    Integer firstSortOrder = method1.getSortOrder() != 0 ?
+                        method1.getSortOrder() :
+                        firstModuleSequence;
+                    Integer secondSortOrder = method2.getSortOrder() != 0 ?
+                        method2.getSortOrder() :
+                        secondModuleSequence;
+
+                    if (!bufferSortOrderList.isEmpty() && firstMethodPrefix.equals("after")) {
+                        for (Integer bufferSortOrder : bufferSortOrderList) {
+                            if (bufferSortOrder < firstSortOrder && firstBuffer < bufferSortOrder + 1) {
+                                firstBuffer = bufferSortOrder + 1;
+                            }
+
+                            if (bufferSortOrder < secondSortOrder && secondBuffer < bufferSortOrder + 1) {
+                                secondBuffer = bufferSortOrder + 1;
+                            }
+                        }
+                    }
+
+                    firstBuffer = firstBuffer.equals(0) ? firstSortOrder : firstBuffer * -1;
+                    secondBuffer = secondBuffer.equals(0) ? secondSortOrder : secondBuffer * -1;
+
+                    if (firstBuffer.compareTo(secondBuffer) == 0 && firstSortOrder.compareTo(secondSortOrder) != 0) {
+                        return firstSortOrder.compareTo(secondSortOrder);
+                    }
+
+                    if (firstBuffer.compareTo(secondBuffer) == 0 && firstSortOrder.compareTo(secondSortOrder) == 0) {
+                        return firstModuleSequence.compareTo(secondModuleSequence);
+                    }
+
+                    return firstBuffer.compareTo(secondBuffer);
+                }
+            );
+
+            for (PluginMethodData pluginMethodData: methodDataList) {
+                results.add(pluginMethodData.getMethod());
+            }
         }
 
         private boolean isPluginMethodName(

--- a/src/com/magento/idea/magento2plugin/linemarker/php/PluginTargetLineMarkerProvider.java
+++ b/src/com/magento/idea/magento2plugin/linemarker/php/PluginTargetLineMarkerProvider.java
@@ -97,8 +97,8 @@ public class PluginTargetLineMarkerProvider implements LineMarkerProvider {
             }
 
             final GetTargetClassNamesByPluginClassName targetClassesService =
-                    GetTargetClassNamesByPluginClassName.getInstance(phpClass.getProject());
-            final ArrayList<String> targetClassNames = targetClassesService.execute(classFQN);
+                    new GetTargetClassNamesByPluginClassName(phpClass.getProject());
+            final List<String> targetClassNames = targetClassesService.execute(classFQN);
 
             final List<PhpClass> results = new ArrayList<>();
 

--- a/src/com/magento/idea/magento2plugin/linemarker/php/data/PluginMethodData.java
+++ b/src/com/magento/idea/magento2plugin/linemarker/php/data/PluginMethodData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */

--- a/src/com/magento/idea/magento2plugin/linemarker/php/data/PluginMethodData.java
+++ b/src/com/magento/idea/magento2plugin/linemarker/php/data/PluginMethodData.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.linemarker.php.data;
+
+import com.jetbrains.php.lang.psi.elements.Method;
+
+public class PluginMethodData {
+
+    private final Method method;
+    private final int sortOrder;
+    private final int moduleSequence;
+
+    /**
+     * Plugin method data class.
+     *
+     * @param method Plugin method
+     * @param sortOrder Plugin SortOrder integer value
+     * @param moduleSequence PHP class placed module sequence integer value
+     */
+    public PluginMethodData(final Method method, final int sortOrder, final int moduleSequence) {
+        this.method = method;
+        this.sortOrder = sortOrder;
+        this.moduleSequence = moduleSequence;
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+
+    public int getSortOrder() {
+        return sortOrder;
+    }
+
+    public int getModuleSequence() {
+        return moduleSequence;
+    }
+
+    public String getMethodName() {
+        return method.getName();
+    }
+}

--- a/src/com/magento/idea/magento2plugin/magento/files/ModuleDiXml.java
+++ b/src/com/magento/idea/magento2plugin/magento/files/ModuleDiXml.java
@@ -46,6 +46,7 @@ public class ModuleDiXml implements ModuleFileInterface {
 
     // attributes
     public static String NAME_ATTR = "name";
+    public static String SORT_ORDER_ATTR = "sortOrder";
     public static String TYPE_ATTR = "type";
     public static String PREFERENCE_ATTR_FOR = "for";
     public static String CLI_COMMAND_ATTR_COMMANDS = "commands";

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/PluginIndex.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/PluginIndex.java
@@ -2,6 +2,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 package com.magento.idea.magento2plugin.stubs.indexes;
 
 import com.intellij.ide.highlighter.XmlFileType;
@@ -15,34 +16,35 @@ import com.intellij.util.io.DataExternalizer;
 import com.intellij.util.io.EnumeratorStringDescriptor;
 import com.intellij.util.io.KeyDescriptor;
 import com.jetbrains.php.lang.PhpLangUtil;
-import com.jetbrains.php.lang.psi.stubs.indexes.StringSetDataExternalizer;
+import com.magento.idea.magento2plugin.magento.files.ModuleDiXml;
 import com.magento.idea.magento2plugin.project.Settings;
-import org.jetbrains.annotations.NotNull;
-
+import com.magento.idea.magento2plugin.stubs.indexes.data.PluginData;
+import com.magento.idea.magento2plugin.stubs.indexes.data.PluginSetDataExternalizer;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.jetbrains.annotations.NotNull;
 
-public class PluginIndex extends FileBasedIndexExtension<String, Set<String>> {
-    public static final ID<String, Set<String>> KEY
+public class PluginIndex extends FileBasedIndexExtension<String, Set<PluginData>> {
+    public static final ID<String, Set<PluginData>> KEY
             = ID.create("com.magento.idea.magento2plugin.stubs.indexes.plugin_to_type");
     private final KeyDescriptor<String> myKeyDescriptor = new EnumeratorStringDescriptor();
 
     @NotNull
     @Override
-    public ID<String, Set<String>> getName() {
+    public ID<String, Set<PluginData>> getName() {
         return KEY;
     }
 
     @NotNull
     @Override
-    public DataIndexer<String, Set<String>, FileContent> getIndexer() {
-        return new DataIndexer<String, Set<String>, FileContent>() {
+    public DataIndexer<String, Set<PluginData>, FileContent> getIndexer() {
+        return new DataIndexer<>() {
             @NotNull
             @Override
-            public Map<String, Set<String>> map(@NotNull FileContent fileContent) {
-                Map<String, Set<String>> map = new HashMap<>();
+            public Map<String, Set<PluginData>> map(@NotNull FileContent fileContent) {
+                Map<String, Set<PluginData>> map = new HashMap<>();
 
                 PsiFile psiFile = fileContent.getPsiFile();
                 if (!Settings.isEnabled(psiFile.getProject())) {
@@ -67,7 +69,7 @@ public class PluginIndex extends FileBasedIndexExtension<String, Set<String>> {
                         for (XmlTag typeNode: xmlTag.findSubTags("type")) {
                             String typeName = typeNode.getAttributeValue("name");
                             if (typeName != null) {
-                                Set<String> plugins = getPluginsForType(typeNode);
+                                Set<PluginData> plugins = getPluginsForType(typeNode);
                                 if (plugins.size() > 0) {
                                     map.put(PhpLangUtil.toPresentableFQN(typeName), plugins);
                                 }
@@ -79,15 +81,20 @@ public class PluginIndex extends FileBasedIndexExtension<String, Set<String>> {
                 return map;
             }
 
-            private Set<String> getPluginsForType(XmlTag typeNode) {
-                Set<String> results = new HashSet<String>();
+            private Set<PluginData> getPluginsForType(XmlTag typeNode) {
+                Set<PluginData> results = new HashSet<>();
 
-                for (XmlTag pluginTag: typeNode.findSubTags("plugin")) {
-                    String pluginType = pluginTag.getAttributeValue("type");
+                for (XmlTag pluginTag: typeNode.findSubTags(ModuleDiXml.PLUGIN_TAG_NAME)) {
+                    String pluginType = pluginTag.getAttributeValue(ModuleDiXml.TYPE_ATTR);
+                    String pluginSortOrder = pluginTag.getAttributeValue(ModuleDiXml.SORT_ORDER_ATTR);
+
                     if (pluginType != null) {
-                        results.add(PhpLangUtil.toPresentableFQN(pluginType));
+                        pluginSortOrder = pluginSortOrder == null ? "0" : pluginSortOrder;
+                        PluginData pluginData = new PluginData(pluginType,  Integer.parseInt(pluginSortOrder));
+                        results.add(pluginData);
                     }
                 }
+
                 return results;
             }
         };
@@ -101,8 +108,8 @@ public class PluginIndex extends FileBasedIndexExtension<String, Set<String>> {
 
     @NotNull
     @Override
-    public DataExternalizer<Set<String>> getValueExternalizer() {
-        return new StringSetDataExternalizer();
+    public DataExternalizer<Set<PluginData>> getValueExternalizer() {
+        return PluginSetDataExternalizer.INSTANCE;
     }
 
     @NotNull

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/PluginIndex.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/PluginIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/data/PluginData.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/data/PluginData.java
@@ -48,7 +48,7 @@ public class PluginData {
      *
      * @param phpClass collection PHP plugin class
      */
-    public void setPhpClass(@NotNull PhpClass phpClass) {
+    public void setPhpClass(final @NotNull PhpClass phpClass) {
         final PhpIndex phpIndex = PhpIndex.getInstance(phpClass.getProject());
 
         phpClassCollection = phpIndex.getClassesByFQN(getType());

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/data/PluginData.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/data/PluginData.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.stubs.indexes.data;
+
+import com.jetbrains.php.PhpIndex;
+import com.jetbrains.php.lang.psi.elements.PhpClass;
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
+
+public class PluginData {
+
+    private final String type;
+    private final int sortOrder;
+    private Collection<PhpClass> phpClassCollection;
+
+    /**
+     * Plugin data class.
+     *
+     * @param type Type class
+     * @param sortOrder Sort order value.
+     */
+    public PluginData(final String type, final int sortOrder) {
+        this.type = type;
+        this.sortOrder = sortOrder;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public int getSortOrder() {
+        return sortOrder;
+    }
+
+    public @NotNull Collection<PhpClass> getPhpClass() {
+        return phpClassCollection;
+    }
+
+    public Collection<PhpClass> getPhpClassCollection() {
+        return phpClassCollection;
+    }
+
+    /**
+     * Setting PHP plugin class.
+     *
+     * @param phpClass collection PHP plugin class
+     */
+    public void setPhpClass(@NotNull PhpClass phpClass) {
+        final PhpIndex phpIndex = PhpIndex.getInstance(phpClass.getProject());
+
+        phpClassCollection = phpIndex.getClassesByFQN(getType());
+    }
+}

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/data/PluginData.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/data/PluginData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
@@ -33,10 +33,6 @@ public class PluginData {
 
     public int getSortOrder() {
         return sortOrder;
-    }
-
-    public @NotNull Collection<PhpClass> getPhpClass() {
-        return phpClassCollection;
     }
 
     public Collection<PhpClass> getPhpClassCollection() {

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/data/PluginData.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/data/PluginData.java
@@ -53,4 +53,35 @@ public class PluginData {
 
         phpClassCollection = phpIndex.getClassesByFQN(getType());
     }
+
+    /**
+     * Overridden hashCode check.
+     *
+     * @return boolean
+     */
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + this.sortOrder;
+
+        return prime * result + ((this.getType() == null) ? 0 : this.getType().hashCode());
+    }
+
+    /**
+     * Overridden quality check.
+     *
+     * @param object PluginData
+     *
+     * @return boolean
+     */
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof PluginData)) {
+            return false;
+        }
+        final PluginData compareTo = (PluginData) object;
+
+        return type.equals(compareTo.getType()) && sortOrder == compareTo.getSortOrder();
+    }
 }

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/data/PluginData.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/data/PluginData.java
@@ -76,7 +76,7 @@ public class PluginData {
      * @return boolean
      */
     @Override
-    public boolean equals(Object object) {
+    public boolean equals(final Object object) {
         if (!(object instanceof PluginData)) {
             return false;
         }

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/data/PluginSetDataExternalizer.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/data/PluginSetDataExternalizer.java
@@ -16,29 +16,30 @@ import org.jetbrains.annotations.NotNull;
 public class PluginSetDataExternalizer  implements DataExternalizer<Set<PluginData>> {
     public static final PluginSetDataExternalizer INSTANCE = new PluginSetDataExternalizer();
 
-    public PluginSetDataExternalizer() {
-    }
-
+    @SuppressWarnings("checkstyle:LineLength")
     @Override
-    public synchronized void save(@NotNull DataOutput out, Set<PluginData> value) throws IOException {
+    public void save(final @NotNull DataOutput out, final Set<PluginData> value) throws IOException {
         out.writeInt(value.size());
 
-        for (PluginData plugin : value) {
+        for (final PluginData plugin : value) {
             out.writeUTF(plugin.getType());
             out.writeInt(plugin.getSortOrder());
         }
     }
 
     @Override
-    public synchronized Set<PluginData> read(@NotNull DataInput in) throws IOException {
-        int size = in.readInt();
-        HashSet<PluginData> result = new HashSet<>(size);
+    public Set<PluginData> read(final @NotNull DataInput income) throws IOException {
+        final int size = income.readInt();
+        final HashSet<PluginData> result = new HashSet<>(size);
 
         for (int r = size; r > 0; --r) {
-            PluginData pluginData = new PluginData(in.readUTF(), in.readInt());
-            result.add(pluginData);
+            result.add(getPluginDataObject(income.readUTF(), income.readInt()));
         }
 
         return result;
+    }
+
+    private PluginData getPluginDataObject(final String pluginType, final Integer sortOrder) {
+        return new PluginData(pluginType,  sortOrder);
     }
 }

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/data/PluginSetDataExternalizer.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/data/PluginSetDataExternalizer.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.stubs.indexes.data;
+
+import com.intellij.util.io.DataExternalizer;
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+
+public class PluginSetDataExternalizer  implements DataExternalizer<Set<PluginData>> {
+    public static final PluginSetDataExternalizer INSTANCE = new PluginSetDataExternalizer();
+
+    public PluginSetDataExternalizer() {
+    }
+
+    @Override
+    public synchronized void save(@NotNull DataOutput out, Set<PluginData> value) throws IOException {
+        out.writeInt(value.size());
+
+        for (PluginData plugin : value) {
+            out.writeUTF(plugin.getType());
+            out.writeInt(plugin.getSortOrder());
+        }
+    }
+
+    @Override
+    public synchronized Set<PluginData> read(@NotNull DataInput in) throws IOException {
+        int size = in.readInt();
+        HashSet<PluginData> result = new HashSet<>(size);
+
+        for (int r = size; r > 0; --r) {
+            PluginData pluginData = new PluginData(in.readUTF(), in.readInt());
+            result.add(pluginData);
+        }
+
+        return result;
+    }
+}

--- a/src/com/magento/idea/magento2plugin/util/magento/plugin/GetTargetClassNamesByPluginClassName.java
+++ b/src/com/magento/idea/magento2plugin/util/magento/plugin/GetTargetClassNamesByPluginClassName.java
@@ -16,33 +16,38 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Returns all targets class names for the plugin
+ * Returns all targets class names for the plugin.
  */
 public class GetTargetClassNamesByPluginClassName {
-    private static GetTargetClassNamesByPluginClassName INSTANCE = null;
-    private Project project;
+    private final Project project;
 
-    public static GetTargetClassNamesByPluginClassName getInstance(Project project) {
-        if (null == INSTANCE) {
-            INSTANCE = new GetTargetClassNamesByPluginClassName();
-        }
-        INSTANCE.project = project;
-        return INSTANCE;
+    public GetTargetClassNamesByPluginClassName(final Project project) {
+        this.project = project;
     }
 
-    public ArrayList<String> execute(String currentClassName) {
-        ArrayList<String> targetClassNames = new ArrayList<>();
-        Collection<String> allKeys = FileBasedIndex.getInstance()
+    /**
+     * Get current class names for the plugin.
+     *
+     * @param currentClassName plugin class name.
+     * @return list of plugin classes
+     */
+    public List<String> execute(final String currentClassName) {
+        final List<String> targetClassNames = new ArrayList<>();
+        final Collection<String> allKeys = FileBasedIndex.getInstance()
                 .getAllKeys(PluginIndex.KEY, project);
 
-        for (String targetClassName : allKeys) {
-            List<Set<PluginData>> pluginsList = FileBasedIndex.getInstance()
-                    .getValues(com.magento.idea.magento2plugin.stubs.indexes.PluginIndex.KEY, targetClassName, GlobalSearchScope.allScope(project));
+        for (final String targetClassName : allKeys) {
+            final List<Set<PluginData>> pluginsList = FileBasedIndex.getInstance()
+                    .getValues(
+                        PluginIndex.KEY,
+                        targetClassName,
+                        GlobalSearchScope.allScope(project)
+                    );
             if (pluginsList.isEmpty()) {
                 continue;
             }
-            for (Set<PluginData> plugins : pluginsList) {
-                for (PluginData plugin : plugins) {
+            for (final Set<PluginData> plugins : pluginsList) {
+                for (final PluginData plugin : plugins) {
                     if (!plugin.getType().equals(currentClassName)) {
                         continue;
                     }

--- a/src/com/magento/idea/magento2plugin/util/magento/plugin/GetTargetClassNamesByPluginClassName.java
+++ b/src/com/magento/idea/magento2plugin/util/magento/plugin/GetTargetClassNamesByPluginClassName.java
@@ -2,13 +2,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 package com.magento.idea.magento2plugin.util.magento.plugin;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.util.indexing.FileBasedIndex;
 import com.magento.idea.magento2plugin.stubs.indexes.PluginIndex;
-
+import com.magento.idea.magento2plugin.stubs.indexes.data.PluginData;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -35,14 +36,14 @@ public class GetTargetClassNamesByPluginClassName {
                 .getAllKeys(PluginIndex.KEY, project);
 
         for (String targetClassName : allKeys) {
-            List<Set<String>> pluginsList = FileBasedIndex.getInstance()
+            List<Set<PluginData>> pluginsList = FileBasedIndex.getInstance()
                     .getValues(com.magento.idea.magento2plugin.stubs.indexes.PluginIndex.KEY, targetClassName, GlobalSearchScope.allScope(project));
             if (pluginsList.isEmpty()) {
                 continue;
             }
-            for (Set<String> plugins : pluginsList) {
-                for (String plugin : plugins) {
-                    if (!plugin.equals(currentClassName)) {
+            for (Set<PluginData> plugins : pluginsList) {
+                for (PluginData plugin : plugins) {
+                    if (!plugin.getType().equals(currentClassName)) {
                         continue;
                     }
                     targetClassNames.add(targetClassName);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description** (*)
It was added by sorting the plugin parkers depending on it's "before" "around" or "after" plugin, and by the sortOrder attribute value.

But it was not included in sorting by the module sequence. Here we should add the parsing `config.php` file and provide an array with the module name and sequence value. Please to implement it was added the note `@TODO` at the the `com.magento.idea.magento2plugin.linemarker.php.PluginLineMarkerProvider.PluginClassCache#getPluginMethods(java.util.List<com.magento.idea.magento2plugin.stubs.indexes.data.PluginData>)`

**Actual results:**
In the first file, you can see the list sorted by sortOrder value and the correct list for the `after` plugin after around.
In the second file, you can see that the vendor plugin, which has no `sortOrder` attribute has the highest priority.

https://user-images.githubusercontent.com/74533818/176269960-61f9786b-11fe-4955-a56b-3b1fdf31a920.mov

**Questions or comments**
To compleat this part we here need add the module sequence condition: the logic to sort is implemented, need just add module sequence value.

Also in the future will be good mark the area of plugins list: 
- around before/after proceed;
- methods wich where disabled or not working, because callable was not callable.

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
