### PR TITLE
1106: Fixed NullPointerException in the OverrideTemplateInThemeAction.isOverrideAllowed for virtualFile.getCanonicalPath()

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/OverrideTemplateInThemeAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/OverrideTemplateInThemeAction.java
@@ -45,10 +45,16 @@ public class OverrideTemplateInThemeAction extends OverrideFileInThemeAction {
     ) {
         final VirtualFile virtualFile = file.getVirtualFile();
 
-        if (virtualFile == null || virtualFile.isDirectory()) {
+        if (virtualFile == null
+                || virtualFile.isDirectory()
+                || virtualFile.getCanonicalPath() == null) {
             return false;
         }
         final String fileExtension = virtualFile.getExtension();
+
+        if (fileExtension == null) {
+            return false;
+        }
 
         if (!OverridableFileType.getOverwritableFileExtensions().contains(fileExtension)) {
             return false;


### PR DESCRIPTION
**Description** (*)
Fix NullPointerException in the OverrideTemplateInThemeAction.isOverrideAllowed for virtualFile.getCanonicalPath().

**Fixed Issues (if relevant)**
1. Fixes magento/magento2-phpstorm-plugin#1106

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
