### PR TITLE
1124: Fixed PatternSyntaxException: MagentoBasePathUtil.isMagentoFolderValid:35 for Windows styled dir path separator

### DIFF
--- a/src/com/magento/idea/magento2plugin/util/magento/MagentoBasePathUtil.java
+++ b/src/com/magento/idea/magento2plugin/util/magento/MagentoBasePathUtil.java
@@ -10,7 +10,6 @@ import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.magento.idea.magento2plugin.magento.packages.Package;
-import java.io.File;
 import java.util.Arrays;
 import org.jetbrains.annotations.NotNull;
 
@@ -29,15 +28,17 @@ public final class MagentoBasePathUtil {
             return false;
         }
         final VirtualFile file = LocalFileSystem.getInstance().findFileByPath(path);
+
         if (file != null && file.isDirectory()) {
             return VfsUtil.findRelativeFile(
                     file,
-                    Package.frameworkRootComposer.split(File.separator)
+                    Package.frameworkRootComposer.split(Package.V_FILE_SEPARATOR)
             ) != null
                 || VfsUtil.findRelativeFile(
                         file,
-                    Package.frameworkRootGit.split(File.separator)) != null;
+                    Package.frameworkRootGit.split(Package.V_FILE_SEPARATOR)) != null;
         }
+
         return false;
     }
 


### PR DESCRIPTION
**Description** (*)
Fix isMagentoFolderValid method in MagentoBasePathUtil class

**Fixed Issues (if relevant)**
1. Fixes magento/magento2-phpstorm-plugin#1124

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
