### PR TITLE
1145: Removed content jumping from EAV generators forms

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCategoryEavAttributeDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCategoryEavAttributeDialog.form
@@ -7,14 +7,16 @@
     </constraints>
     <properties>
       <enabled value="true"/>
-      <preferredSize width="800" height="800"/>
+      <preferredSize width="800" height="700"/>
     </properties>
     <border type="none"/>
     <children>
       <grid id="6fc7e" layout-manager="GridLayoutManager" row-count="16" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="9" fill="0" indent="0" use-parent-layout="false">
+            <preferred-size width="800" height="-1"/>
+          </grid>
         </constraints>
         <properties>
           <visible value="true"/>
@@ -334,11 +336,6 @@
           </component>
         </children>
       </grid>
-      <hspacer id="75d92">
-        <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-      </hspacer>
       <grid id="181ea" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
@@ -420,6 +417,11 @@
           </component>
         </children>
       </grid>
+      <vspacer id="596dd">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
     </children>
   </grid>
 </form>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCustomerEavAttributeDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCustomerEavAttributeDialog.form
@@ -7,13 +7,14 @@
     </constraints>
     <properties>
       <enabled value="true"/>
+      <preferredSize width="600" height="700"/>
     </properties>
     <border type="none"/>
     <children>
       <grid id="6fc7e" layout-manager="GridLayoutManager" row-count="18" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <visible value="true"/>
@@ -374,11 +375,6 @@
           </component>
         </children>
       </grid>
-      <hspacer id="75d92">
-        <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-      </hspacer>
       <grid id="181ea" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
@@ -460,6 +456,11 @@
           </component>
         </children>
       </grid>
+      <vspacer id="5b2c6">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
     </children>
   </grid>
 </form>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewProductEavAttributeDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewProductEavAttributeDialog.form
@@ -3,7 +3,7 @@
   <grid id="28350" binding="contentPanel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
-      <xy x="-1" y="5" width="764" height="959"/>
+      <xy x="-1" y="5" width="764" height="997"/>
     </constraints>
     <properties>
       <enabled value="true"/>
@@ -14,7 +14,7 @@
       <grid id="6fc7e" layout-manager="GridLayoutManager" row-count="20" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <visible value="true"/>
@@ -197,14 +197,6 @@
                   <text value=""/>
                 </properties>
               </component>
-              <component id="ab01b" class="javax.swing.JTextField" binding="sourceModelNameTextField">
-                <constraints>
-                  <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-                    <preferred-size width="150" height="-1"/>
-                  </grid>
-                </constraints>
-                <properties/>
-              </component>
               <component id="c2c06" class="javax.swing.JLabel">
                 <constraints>
                   <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
@@ -232,6 +224,14 @@
                   <text value="Label"/>
                   <visible value="false"/>
                 </properties>
+              </component>
+              <component id="ab01b" class="javax.swing.JTextField" binding="sourceModelNameTextField">
+                <constraints>
+                  <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                    <preferred-size width="150" height="-1"/>
+                  </grid>
+                </constraints>
+                <properties/>
               </component>
             </children>
           </grid>
@@ -426,11 +426,6 @@
           </component>
         </children>
       </grid>
-      <hspacer id="75d92">
-        <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-      </hspacer>
       <grid id="181ea" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
@@ -512,6 +507,11 @@
           </component>
         </children>
       </grid>
+      <vspacer id="bf635">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
     </children>
   </grid>
 </form>

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/eavattribute/EavAttributeDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/eavattribute/EavAttributeDialog.java
@@ -268,7 +268,7 @@ public abstract class  EavAttributeDialog extends AbstractDialog {
         generateDataPatchFile(eavEntityDataInterface);
         generateExtraFilesAfterDataPatchGeneration(eavEntityDataInterface);
 
-        setVisible(false);
+        exit();
     }
 
     protected void generateSourceModelFile() {


### PR DESCRIPTION
**Description** (*)

Removed content jumps from EAV generators forms.

Product EAV attribute form:

https://user-images.githubusercontent.com/31848341/188474111-59c01c4a-2ec1-474d-bfdb-18f593e68a0b.mp4

Category EAV attribute form:

https://user-images.githubusercontent.com/31848341/188474193-35597fbb-4751-44e0-a97c-9048680cc66b.mp4

Customer EAV attribute form:

https://user-images.githubusercontent.com/31848341/188474365-3af7032a-df9a-4dcd-80fc-a992f9949328.mp4


**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#1145

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
