### PR TITLE
1141: Add code include, don't show generation action if readme exists

### DIFF
--- a/resources/fileTemplates/includes/MD File Description.md.ft
+++ b/resources/fileTemplates/includes/MD File Description.md.ft
@@ -1,0 +1,8 @@
+<!---
+    You can describe your module here.
+    We recommend that you add the following information:
+     - implementation details: why and how to use the module, preferably with some example scenarios
+     - any dependencies (usually other modules but could be any important dependencies, libraries, etc)
+     - extension points, APIs, plug-ins, etc
+     - any introduced events
+-->

--- a/resources/fileTemplates/includes/MD File Description.md.html
+++ b/resources/fileTemplates/includes/MD File Description.md.html
@@ -1,0 +1,12 @@
+<html>
+<body>
+<table width="100%" border="0" cellpadding="5" cellspacing="0" style="border-collapse: collapse; border-color:#111111">
+    <tr>
+        <td colspan="3"><font face="verdana" size="-1">This is a template is used to describe the MD file. It contains a code fragment that can be included into file templates
+            (<b>Templates</b> tab) with the help of the <b>#parse</b> directive.<br>
+            The template is editable. Along with the static text, code and comments.</font><br>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/resources/fileTemplates/internal/Magento Module Readme File MD.md.ft
+++ b/resources/fileTemplates/internal/Magento Module Readme File MD.md.ft
@@ -1,10 +1,3 @@
 # ${PACKAGE}_${MODULE_NAME} module
 
-<!---
-    You can describe your module here.
-    We recommend that you add the following information:
-     - implementation details: why and how to use the module, preferably with some example scenarios
-     - any dependencies (usually other modules but could be any important dependencies, libraries, etc)
-     - extension points, APIs, plug-ins, etc
-     - any introduced events
--->
+#parse("MD File Description.md")

--- a/src/com/magento/idea/magento2plugin/actions/context/md/NewReadmeMdAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/context/md/NewReadmeMdAction.java
@@ -8,6 +8,7 @@ package com.magento.idea.magento2plugin.actions.context.md;
 import com.intellij.ide.fileTemplates.actions.AttributesDefaults;
 import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiFile;
+import com.intellij.util.IncorrectOperationException;
 import com.magento.idea.magento2plugin.actions.context.AbstractContextAction;
 import com.magento.idea.magento2plugin.indexes.ModuleIndex;
 import com.magento.idea.magento2plugin.magento.files.ModuleReadmeMdFile;
@@ -41,7 +42,8 @@ public class NewReadmeMdAction extends AbstractContextAction {
                 .split(Package.vendorModuleNameSeparator)[1];
 
         return targetDirectory.getName().equals(magentoModuleName)
-                && targetDirectory.equals(moduleDirectory);
+                && targetDirectory.equals(moduleDirectory)
+                && this.isFileCanBeCreated(moduleDirectory);
     }
 
     @Override
@@ -56,5 +58,17 @@ public class NewReadmeMdAction extends AbstractContextAction {
         defaults.addPredefined("MODULE_NAME", templateData[1]);
 
         return defaults;
+    }
+
+    private @NotNull Boolean isFileCanBeCreated(
+            final @NotNull PsiDirectory moduleDirectory
+    ) {
+        try {
+            moduleDirectory.checkCreateFile(ModuleReadmeMdFile.FILE_NAME);
+        } catch (IncorrectOperationException exception) {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description** (*)

Implemented next solutions:

- Added check, if the [README.md](http://readme.md/) file is already generated do not show action.
- Added a new code include, to be able generate project-specific [README.md](http://readme.md/) files

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#1141

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
