### PR TITLE
1156: Fixed README.md template include is not working for project level

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/context/CustomGeneratorContextAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/context/CustomGeneratorContextAction.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.actions.context;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.NlsActions;
+import com.intellij.psi.PsiDirectory;
+import com.intellij.psi.PsiFile;
+import com.magento.idea.magento2plugin.MagentoIcons;
+import com.magento.idea.magento2plugin.actions.context.util.GetTargetElementUtil;
+import com.magento.idea.magento2plugin.project.Settings;
+import com.magento.idea.magento2plugin.util.magento.GetMagentoModuleUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public abstract class CustomGeneratorContextAction extends AnAction {
+
+    private @Nullable GetMagentoModuleUtil.MagentoModuleData moduleData;
+    private @Nullable PsiDirectory directory;
+    private @Nullable PsiFile file;
+
+    /**
+     * Abstract context action with custom generation constructor.
+     *
+     * @param text String
+     * @param description String
+     */
+    public CustomGeneratorContextAction(
+            final @Nullable @NlsActions.ActionText String text,
+            final @Nullable @NlsActions.ActionDescription String description
+    ) {
+        super(text, description, MagentoIcons.MODULE);
+    }
+
+    @Override
+    public void update(final @NotNull AnActionEvent event) {
+        setIsAvailableForEvent(event, false);
+        final Project project = event.getProject();
+
+        if (project == null || !Settings.isEnabled(project)) {
+            return;
+        }
+        final PsiDirectory targetDirectory = GetTargetElementUtil.getDirFromEvent(event);
+
+        if (targetDirectory == null) {
+            return;
+        }
+        final GetMagentoModuleUtil.MagentoModuleData magentoModuleData = GetMagentoModuleUtil
+                .getByContext(targetDirectory, project);
+        final PsiFile targetFile = GetTargetElementUtil.getFileFromEvent(event);
+
+        if (magentoModuleData == null
+                || magentoModuleData.getName() == null
+                || !isVisible(magentoModuleData, targetDirectory, targetFile)) {
+            return;
+        }
+        directory = targetDirectory;
+        file = targetFile;
+        moduleData = magentoModuleData;
+        setIsAvailableForEvent(event, true);
+    }
+
+    /**
+     * Get clicked on module data object.
+     *
+     * @return GetMagentoModuleUtil.MagentoModuleData
+     */
+    public @Nullable GetMagentoModuleUtil.MagentoModuleData getModuleData() {
+        return moduleData;
+    }
+
+    public @Nullable PsiDirectory getDirectory() {
+        return directory;
+    }
+
+    public @Nullable PsiFile getFile() {
+        return file;
+    }
+
+    /**
+     * Implement check if an action should be shown in the context defined by the module,
+     * target directory or target file.
+     *
+     * @param moduleData GetMagentoModuleUtil.MagentoModuleData
+     * @param targetDirectory PsiDirectory
+     * @param targetFile PsiFile
+     *
+     * @return boolean
+     */
+    protected abstract boolean isVisible(
+            final @NotNull GetMagentoModuleUtil.MagentoModuleData moduleData,
+            final PsiDirectory targetDirectory,
+            final PsiFile targetFile
+    );
+
+    /**
+     * Set is action available for event.
+     *
+     * @param event AnActionEvent
+     * @param isAvailable boolean
+     */
+    private void setIsAvailableForEvent(
+            final @NotNull AnActionEvent event,
+            final boolean isAvailable
+    ) {
+        event.getPresentation().setVisible(isAvailable);
+        event.getPresentation().setEnabled(isAvailable);
+    }
+}

--- a/src/com/magento/idea/magento2plugin/actions/context/md/NewReadmeMdAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/context/md/NewReadmeMdAction.java
@@ -5,11 +5,13 @@
 
 package com.magento.idea.magento2plugin.actions.context.md;
 
-import com.intellij.ide.fileTemplates.actions.AttributesDefaults;
+import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.IncorrectOperationException;
-import com.magento.idea.magento2plugin.actions.context.AbstractContextAction;
+import com.magento.idea.magento2plugin.actions.context.CustomGeneratorContextAction;
+import com.magento.idea.magento2plugin.actions.generation.data.ModuleReadmeMdData;
+import com.magento.idea.magento2plugin.actions.generation.generator.ModuleReadmeMdGenerator;
 import com.magento.idea.magento2plugin.indexes.ModuleIndex;
 import com.magento.idea.magento2plugin.magento.files.ModuleReadmeMdFile;
 import com.magento.idea.magento2plugin.magento.packages.ComponentType;
@@ -17,13 +19,36 @@ import com.magento.idea.magento2plugin.magento.packages.Package;
 import com.magento.idea.magento2plugin.util.magento.GetMagentoModuleUtil;
 import org.jetbrains.annotations.NotNull;
 
-public class NewReadmeMdAction extends AbstractContextAction {
+public class NewReadmeMdAction extends CustomGeneratorContextAction {
 
     public static final String ACTION_NAME = "Magento 2 README File";
     public static final String ACTION_DESCRIPTION = "Create a new Magento 2 README file";
 
     public NewReadmeMdAction() {
-        super(ACTION_NAME, ACTION_DESCRIPTION, new ModuleReadmeMdFile());
+        super(ACTION_NAME, ACTION_DESCRIPTION);
+    }
+
+    @Override
+    public void actionPerformed(final @NotNull AnActionEvent event) {
+        final GetMagentoModuleUtil.MagentoModuleData moduleData = getModuleData();
+
+        if (event.getProject() == null || moduleData == null || getDirectory() == null) {
+            return;
+        }
+        final String[] templateData = moduleData.getName().split(Package.vendorModuleNameSeparator);
+
+        if (templateData.length != 2) { //NOPMD
+            return;
+        }
+        final ModuleReadmeMdGenerator generator = new ModuleReadmeMdGenerator(
+                new ModuleReadmeMdData(
+                        templateData[0],
+                        templateData[1],
+                        getDirectory()
+                ),
+                event.getProject()
+        );
+        generator.generate(ACTION_NAME, true);
     }
 
     @Override
@@ -37,27 +62,15 @@ public class NewReadmeMdAction extends AbstractContextAction {
         }
         final PsiDirectory moduleDirectory = new ModuleIndex(targetDirectory.getProject())
                 .getModuleDirectoryByModuleName(moduleData.getName());
-        final String magentoModuleName = moduleData
-                .getName()
-                .split(Package.vendorModuleNameSeparator)[1];
 
-        return targetDirectory.getName().equals(magentoModuleName)
-                && targetDirectory.equals(moduleDirectory)
-                && this.isFileCanBeCreated(moduleDirectory);
-    }
-
-    @Override
-    protected AttributesDefaults getProperties(
-            final @NotNull AttributesDefaults defaults,
-            final @NotNull GetMagentoModuleUtil.MagentoModuleData moduleData,
-            final PsiDirectory targetDirectory,
-            final PsiFile targetFile
-    ) {
+        if (moduleDirectory == null) {
+            return false;
+        }
         final String[] templateData = moduleData.getName().split(Package.vendorModuleNameSeparator);
-        defaults.addPredefined("PACKAGE", templateData[0]);
-        defaults.addPredefined("MODULE_NAME", templateData[1]);
 
-        return defaults;
+        return templateData.length == 2
+                && targetDirectory.equals(moduleDirectory)
+                && isFileCanBeCreated(moduleDirectory);
     }
 
     private @NotNull Boolean isFileCanBeCreated(

--- a/src/com/magento/idea/magento2plugin/actions/context/util/GetTargetElementUtil.java
+++ b/src/com/magento/idea/magento2plugin/actions/context/util/GetTargetElementUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.actions.context.util;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.LangDataKeys;
+import com.intellij.psi.PsiDirectory;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class GetTargetElementUtil {
+
+    private GetTargetElementUtil() {}
+
+    /**
+     * Get clicked on directory from the action event.
+     *
+     * @param event AnActionEvent
+     *
+     * @return PsiDirectory
+     */
+    public static @Nullable PsiDirectory getDirFromEvent(final @NotNull AnActionEvent event) {
+        final PsiElement targetElement = LangDataKeys.PSI_ELEMENT.getData(event.getDataContext());
+
+        if (targetElement == null) {
+            return null;
+        }
+        PsiDirectory targetDirectory = null;
+        PsiFile targetFile;
+
+        if (targetElement instanceof PsiDirectory) {
+            targetDirectory = (PsiDirectory) targetElement;
+        } else if (targetElement instanceof PsiFile) {
+            targetFile = (PsiFile) targetElement;
+            targetDirectory = targetFile.getContainingDirectory();
+        }
+
+        return targetDirectory;
+    }
+
+    /**
+     * Get clicked on file from the action event.
+     *
+     * @param event AnActionEvent
+     *
+     * @return PsiDirectory
+     */
+    public static @Nullable PsiFile getFileFromEvent(final @NotNull AnActionEvent event) {
+        final PsiElement targetElement = LangDataKeys.PSI_ELEMENT.getData(event.getDataContext());
+
+        if (targetElement == null) {
+            return null;
+        }
+
+        return targetElement instanceof PsiFile ? (PsiFile) targetElement : null;
+    }
+}


### PR DESCRIPTION
**Description** (*)

Fixed that README.md template include is not working for project level.

https://user-images.githubusercontent.com/31848341/188676586-cfd7687e-b87d-4928-aa45-2bc1ebd35e42.mp4

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#1156

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
