### PR TITLE
1100: Added inspection to check if type attr value in the virtual type tag exists

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -294,6 +294,13 @@
                          implementationClass="com.magento.idea.magento2plugin.inspections.xml.InvalidDependencyInjectionTypeInspection"/>
 
         <localInspection language="XML" groupPath="XML"
+                         shortName="InvalidVirtualTypeSourceClassInspection"
+                         bundle="magento2.inspection" key="inspection.displayName.InvalidVirtualTypeSourceClassInspection"
+                         groupBundle="magento2.inspection" groupKey="inspection.group.name"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="com.magento.idea.magento2plugin.inspections.xml.InvalidVirtualTypeSourceClassInspection"/>
+
+        <localInspection language="XML" groupPath="XML"
                          shortName="PreferenceXmlInspections"
                          bundle="magento2.inspection" key="inspection.displayName.PreferenceXmlInspections"
                          groupBundle="magento2.inspection" groupKey="inspection.group.name"

--- a/resources/inspectionDescriptions/InvalidVirtualTypeSourceClassInspection.html
+++ b/resources/inspectionDescriptions/InvalidVirtualTypeSourceClassInspection.html
@@ -1,0 +1,21 @@
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<html>
+<body>
+<p>
+    Validates if value in the type attribute inside the &lt;virtualType/&gt; tag of di.xml files contains valid class,
+    interface, factory or proxy name.
+</p>
+<p>This inspection checks type attribute of the &lt;virtualType/&gt; tag.</p>
+<p>This inspection supports next types:</p>
+<ul>
+    <li>PHP classes</li>
+    <li>PHP interfaces</li>
+    <li>PHP classes or interfaces with added Factory or \Proxy suffixes</li>
+</ul>
+</body>
+</html>

--- a/resources/magento2/inspection.properties
+++ b/resources/magento2/inspection.properties
@@ -8,6 +8,7 @@ inspection.displayName.ModuleDeclarationInModuleXmlInspection=Inspection for the
 inspection.displayName.AclResourceXmlInspection=Inspection for the Title XML required attribute in the `etc/acl.xml` file
 inspection.displayName.WebApiServiceInspection=Inspection for the Web API XML service declaration
 inspection.displayName.InvalidDiTypeInspection=Invalid type configuration in the `etc/di.xml` file
+inspection.displayName.InvalidVirtualTypeSourceClassInspection=Invalid source type specified for virtual type in the `di.xml` file
 inspection.displayName.PluginAttrTypeInspection=Inspection for the attribute `type` in the `plugin` tag
 inspection.displayName.PreferenceXmlInspections=Inspection for the Preference declaration
 inspection.plugin.duplicateInSameFile=The plugin name already used in this file. For more details see Inspection Description.

--- a/src/com/magento/idea/magento2plugin/inspections/xml/InvalidVirtualTypeSourceClassInspection.java
+++ b/src/com/magento/idea/magento2plugin/inspections/xml/InvalidVirtualTypeSourceClassInspection.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+package com.magento.idea.magento2plugin.inspections.xml;
+
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.codeInspection.XmlSuppressableInspectionTool;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.XmlElementVisitor;
+import com.intellij.psi.xml.XmlAttribute;
+import com.intellij.psi.xml.XmlTag;
+import com.magento.idea.magento2plugin.bundles.InspectionBundle;
+import com.magento.idea.magento2plugin.inspections.validator.InspectionValidator;
+import com.magento.idea.magento2plugin.inspections.validator.NotEmptyValidator;
+import com.magento.idea.magento2plugin.inspections.validator.PhpClassExistenceValidator;
+import com.magento.idea.magento2plugin.magento.files.ModuleDiXml;
+import org.jetbrains.annotations.NotNull;
+
+public class InvalidVirtualTypeSourceClassInspection extends XmlSuppressableInspectionTool {
+
+    @Override
+    public @NotNull PsiElementVisitor buildVisitor(
+            final @NotNull ProblemsHolder problemsHolder,
+            final boolean isOnTheFly
+    ) {
+        return new XmlElementVisitor() {
+
+            private final InspectionBundle inspectionBundle = new InspectionBundle();
+            private final InspectionValidator phpClassExistenceValidator =
+                    new PhpClassExistenceValidator(problemsHolder.getProject());
+            private final InspectionValidator notEmptyValidator = new NotEmptyValidator();
+
+            @Override
+            public void visitXmlAttribute(final XmlAttribute attribute) {
+                final PsiFile file = attribute.getContainingFile();
+                final XmlTag tag = attribute.getParent();
+
+                if (file == null
+                        || tag == null
+                        || !file.getName().equals(ModuleDiXml.FILE_NAME)
+                        || !attribute.getName().equals(ModuleDiXml.TYPE_ATTR)
+                        || !tag.getName().equals(ModuleDiXml.VIRTUAL_TYPE_TAG)
+                ) {
+                    return;
+                }
+
+                if (attribute.getValue() == null
+                        || attribute.getValueElement() == null
+                        || attribute.getValueElement().getText().isEmpty()
+                ) {
+                    return;
+                }
+
+                if (!notEmptyValidator.validate(attribute.getValue())) {
+                    problemsHolder.registerProblem(
+                            attribute.getValueElement(),
+                            inspectionBundle.message(
+                                    "inspection.error.idAttributeCanNotBeEmpty",
+                                    attribute.getName()
+                            ),
+                            ProblemHighlightType.ERROR
+                    );
+                }
+
+                if (!phpClassExistenceValidator.validate(attribute.getValue())) {
+                    problemsHolder.registerProblem(
+                            attribute.getValueElement(),
+                            inspectionBundle.message(
+                                    "inspection.warning.class.does.not.exist",
+                                    attribute.getValue()
+                            ),
+                            ProblemHighlightType.WARNING
+                    );
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
**Description** (*)

Added inspection to check if type attribute value in the virtual type tag exists.

For an empty value:

<img width="1190" alt="Screenshot 2022-09-08 at 21 17 20" src="https://user-images.githubusercontent.com/31848341/189196876-76fe8eaa-9efa-495c-90dd-5ddd7290e289.png">

For an invalid value:

<img width="1190" alt="Screenshot 2022-09-08 at 21 17 01" src="https://user-images.githubusercontent.com/31848341/189196880-427ffb79-ab19-4af0-b2fb-44d95a7b31f9.png">

For a valid value:

<img width="598" alt="Screenshot 2022-09-08 at 21 16 51" src="https://user-images.githubusercontent.com/31848341/189196881-56d4cf76-e357-48b5-8011-a77d8d458c52.png">

**Fixed Issues (if relevant)**

1. Fixes magento/magento2-phpstorm-plugin#1100

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
