### PR TITLE
1144: Add checks and detailed error messages during plugin activation

### DIFF
--- a/resources/magento2/validation.properties
+++ b/resources/magento2/validation.properties
@@ -1,6 +1,8 @@
 validator.notEmpty=The {0} field must not be empty
 validator.box.notEmpty=The {0} field must contain a valid selection from the dropdown
 validator.package.validPath=Please specify a valid Magento 2 installation path
+validator.package.validPathComposerFiles=File composer.json is missing in the current Magento 2 installation path
+validator.package.validPathVendor=Vendor dir is corrupt or missing in the current Magento 2 installation path
 validator.properties.notEmpty=The properties must not be empty
 validator.alphaNumericCharacters=The {0} field must contain letters and numbers only
 validator.alphaNumericAndUnderscoreCharacters={0} must contain letters, numbers and underscores only

--- a/src/com/magento/idea/magento2plugin/project/validator/SettingsFormValidator.java
+++ b/src/com/magento/idea/magento2plugin/project/validator/SettingsFormValidator.java
@@ -28,11 +28,29 @@ public class SettingsFormValidator {
      *
      * @throws ConfigurationException Exception
      */
+    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.AvoidDeeplyNestedIfStmts"})
     public void validate() throws ConfigurationException {
         if (form.isBeingUsed()) {
-            if (!MagentoBasePathUtil.isMagentoFolderValid(form.getMagentoPath())) {
+            final String magentoRootPath = form.getMagentoPath();
+            final boolean isMagentoFrameworkDirExist =
+                    MagentoBasePathUtil.isMagentoFolderValid(magentoRootPath);
+
+            if (!MagentoBasePathUtil.isComposerJsonExists(magentoRootPath)) {
+
+                if (isMagentoFrameworkDirExist) {
+                    throw new ConfigurationException(
+                            validatorBundle.message("validator.package.validPathComposerFiles")
+                    );
+                }
+
                 throw new ConfigurationException(
                         validatorBundle.message("validator.package.validPath")
+                );
+            }
+
+            if (!isMagentoFrameworkDirExist) {
+                throw new ConfigurationException(
+                        validatorBundle.message("validator.package.validPathVendor")
                 );
             }
 

--- a/src/com/magento/idea/magento2plugin/project/validator/SettingsFormValidator.java
+++ b/src/com/magento/idea/magento2plugin/project/validator/SettingsFormValidator.java
@@ -36,13 +36,11 @@ public class SettingsFormValidator {
                     MagentoBasePathUtil.isMagentoFolderValid(magentoRootPath);
 
             if (!MagentoBasePathUtil.isComposerJsonExists(magentoRootPath)) {
-
                 if (isMagentoFrameworkDirExist) {
                     throw new ConfigurationException(
                             validatorBundle.message("validator.package.validPathComposerFiles")
                     );
                 }
-
                 throw new ConfigurationException(
                         validatorBundle.message("validator.package.validPath")
                 );

--- a/src/com/magento/idea/magento2plugin/util/magento/MagentoBasePathUtil.java
+++ b/src/com/magento/idea/magento2plugin/util/magento/MagentoBasePathUtil.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.magento.idea.magento2plugin.magento.files.ComposerJson;
 import com.magento.idea.magento2plugin.magento.packages.Package;
 import java.util.Arrays;
 import org.jetbrains.annotations.NotNull;
@@ -18,7 +19,7 @@ public final class MagentoBasePathUtil {
     private MagentoBasePathUtil() {}
 
     /**
-     * Method detects Magento Framework Root.
+     * Method detects Magento Framework Root (check if magento framework exists).
      *
      * @param path String
      * @return boolean
@@ -40,6 +41,25 @@ public final class MagentoBasePathUtil {
         }
 
         return false;
+    }
+
+    /**
+     * Check if composer.json exists in directory.
+     *
+     * @param path String
+     * @return boolean
+     */
+    public static Boolean isComposerJsonExists(final String path) {
+        if (StringUtil.isEmptyOrSpaces(path)) {
+            return false;
+        }
+        final VirtualFile magentoRoot = LocalFileSystem.getInstance().findFileByPath(path);
+
+        if (magentoRoot == null || !magentoRoot.isDirectory()) {
+            return false;
+        }
+
+        return magentoRoot.findChild(ComposerJson.FILE_NAME) != null;
     }
 
     /**


### PR DESCRIPTION
**Description** (*)
This fix allow us to show detailed error messages for users when they enabling plugin. 
Current video demonstrates how it will work:

https://user-images.githubusercontent.com/20201927/189652724-bb4a66b1-762f-4ec2-b68a-d2de870e5990.mov

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#1144

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
