### PR TITLE
1179: moved graphql dependent actions to the withJsGraphQl.xml config…

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -60,7 +60,6 @@
             <separator/>
             <!-- Context dependent actions -->
             <action id="MagentoCreateAclFile" class="com.magento.idea.magento2plugin.actions.context.xml.NewAclXmlAction"/>
-            <action id="MagentoCreateGraphQlSchemaFile" class="com.magento.idea.magento2plugin.actions.context.xml.NewGraphQLSchemaAction"/>
             <action id="MagentoCreateConfigFile" class="com.magento.idea.magento2plugin.actions.context.xml.NewConfigXmlAction"/>
             <action id="MagentoCreateCrontabFile" class="com.magento.idea.magento2plugin.actions.context.xml.NewCrontabXmlAction"/>
             <action id="MagentoCreateDiFile" class="com.magento.idea.magento2plugin.actions.context.xml.NewDiXmlAction"/>
@@ -91,7 +90,6 @@
             <action id="MagentoCreateACronjob" class="com.magento.idea.magento2plugin.actions.generation.NewCronjobAction" />
             <action id="MagentoCreateACronGroup" class="com.magento.idea.magento2plugin.actions.generation.NewCronGroupAction" />
             <action id="MagentoCreateAViewModel" class="com.magento.idea.magento2plugin.actions.generation.NewViewModelAction" />
-            <action id="MagentoCreateAGraphQlResolver" class="com.magento.idea.magento2plugin.actions.generation.NewGraphQlResolverAction" />
             <action id="MagentoCreateCLICommand" class="com.magento.idea.magento2plugin.actions.generation.NewCLICommandAction" />
             <action id="MagentoCreateEmailTemplate" class="com.magento.idea.magento2plugin.actions.generation.NewEmailTemplateAction" />
             <action id="MagentoCreateUiComponentGrid" class="com.magento.idea.magento2plugin.actions.generation.NewUiComponentGridAction" />
@@ -621,7 +619,6 @@
         <internalFileTemplate name="Magento Regular Class"/>
         <internalFileTemplate name="Magento Observer Class"/>
         <internalFileTemplate name="Magento Events XML"/>
-        <internalFileTemplate name="Magento GraphQL Resolver Class"/>
         <internalFileTemplate name="Magento Cron Job Class"/>
         <internalFileTemplate name="Magento Cron Tab XML"/>
         <internalFileTemplate name="Magento CLI Command Class"/>
@@ -635,7 +632,6 @@
         <internalFileTemplate name="Magento Routes XML"/>
         <internalFileTemplate name="Magento Layout XML"/>
         <internalFileTemplate name="Magento ACL XML"/>
-        <internalFileTemplate name="Magento GraphQL Schema"/>
         <internalFileTemplate name="Magento Collection Class"/>
         <internalFileTemplate name="Magento Model Class"/>
         <internalFileTemplate name="Magento Resource Model Class"/>

--- a/resources/META-INF/withJsGraphQl.xml
+++ b/resources/META-INF/withJsGraphQl.xml
@@ -6,6 +6,19 @@
 -->
 
 <idea-plugin>
+    <actions>
+        <group id="GraphQL.MagentoContextBasedActionsGroup">
+            <add-to-group group-id="MagentoContextBasedActionsGroup" anchor="last"/>
+            <action id="MagentoCreateGraphQlSchemaFile"
+                    class="com.magento.idea.magento2plugin.actions.context.xml.NewGraphQLSchemaAction"/>
+        </group>
+        <group id="GraphQL.MagentoNewModuleFileGroup"
+               text="GraphQL"
+               popup="false">
+            <add-to-group group-id="MagentoNewModuleFileGroup" anchor="last"/>
+            <action id="MagentoCreateAGraphQlResolver" class="com.magento.idea.magento2plugin.actions.generation.NewGraphQlResolverAction" />
+        </group>
+    </actions>
     <extensions defaultExtensionNs="com.intellij">
         <fileBasedIndex implementation="com.magento.idea.magento2plugin.stubs.indexes.graphql.GraphQlResolverIndex" />
         <codeInsight.lineMarkerProvider language="PHP" implementationClass="com.magento.idea.magento2plugin.linemarker.php.GraphQlResolverUsageLineMarkerProvider"/>
@@ -22,5 +35,8 @@
                          enabledByDefault="true"
                          level="ERROR"
                          implementationClass="com.magento.idea.magento2plugin.inspections.graphqls.SchemaResolverInspection"/>
+
+        <internalFileTemplate name="Magento GraphQL Resolver Class"/>
+        <internalFileTemplate name="Magento GraphQL Schema"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
… to avoid fatal errors if GraphqlJs plugin is not installed

**Description** (*)
GraphQl-dependent functionality should be declared in withJsGraphQl.xml file

**Fixed Issues (if relevant)**
1. Fixes magento/magento2-phpstorm-plugin#1179


**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
