### PR TITLE
UCT custom coming versions

### DIFF
--- a/src/com/magento/idea/magento2uct/execution/configurations/UctRunConfiguration.java
+++ b/src/com/magento/idea/magento2uct/execution/configurations/UctRunConfiguration.java
@@ -5,6 +5,8 @@
 
 package com.magento.idea.magento2uct.execution.configurations;
 
+import static com.magento.idea.magento2uct.execution.configurations.UctSettingsEditor.MAGENTO_VERSION_PATTERN;
+
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.Executor;
 import com.intellij.execution.RunManager;
@@ -32,6 +34,7 @@ import com.magento.idea.magento2uct.packages.IssueSeverityLevel;
 import com.magento.idea.magento2uct.settings.UctSettingsService;
 import com.magento.idea.magento2uct.util.UctExecutableValidatorUtil;
 import com.magento.idea.magento2uct.util.module.UctModulePathValidatorUtil;
+import java.util.regex.Matcher;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -239,6 +242,11 @@ public class UctRunConfiguration extends LocatableConfigurationBase<UctRunConfig
 
                 if (getComingVersion().isEmpty()) {
                     throw new ExecutionException("The coming/target version is not specified");
+                }
+
+                final Matcher matcher = MAGENTO_VERSION_PATTERN.matcher(getComingVersion());
+                if (!matcher.find()) {
+                    throw new ExecutionException("The coming/target version is not correct");
                 }
 
                 if (getProjectRoot().isEmpty()) {

--- a/src/com/magento/idea/magento2uct/execution/configurations/UctRunConfiguration.java
+++ b/src/com/magento/idea/magento2uct/execution/configurations/UctRunConfiguration.java
@@ -263,14 +263,12 @@ public class UctRunConfiguration extends LocatableConfigurationBase<UctRunConfig
                     commandSettingsBuilder.addArgument("--coming-version=" + getComingVersion());
                 }
 
-                commandSettingsBuilder.addArgument(getProjectRoot());
-
                 final GeneralCommandLine commandLine =
                         commandSettingsBuilder.createGeneralCommandLine();
 
                 if (!getModulePath().isEmpty()) {
                     if (UctModulePathValidatorUtil.validate(getModulePath())) {
-                        commandLine.addParameter("--module-path=".concat(getModulePath()));
+                        commandLine.addParameter(getModulePath());
                     } else {
                         throw new ExecutionException("The path to analyse is not valid");
                     }

--- a/src/com/magento/idea/magento2uct/execution/configurations/UctSettingsEditor.form
+++ b/src/com/magento/idea/magento2uct/execution/configurations/UctSettingsEditor.form
@@ -25,7 +25,9 @@
         <constraints>
           <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
-        <properties/>
+        <properties>
+          <editable value="true"/>
+        </properties>
       </component>
       <component id="f6c56" class="javax.swing.JLabel" binding="comingVersionLabel">
         <constraints>

--- a/src/com/magento/idea/magento2uct/execution/configurations/UctSettingsEditor.java
+++ b/src/com/magento/idea/magento2uct/execution/configurations/UctSettingsEditor.java
@@ -163,7 +163,7 @@ public class UctSettingsEditor extends SettingsEditor<UctRunConfiguration> {
         uctRunConfiguration.setProjectRoot(projectRoot.getComponent().getText());
         uctRunConfiguration.setModulePath(modulePath.getComponent().getText());
 
-        ComboBoxItemData selectedComingVersion
+        final ComboBoxItemData selectedComingVersion
                 = getCorrectedSelectedItem(comingVersion.getSelectedItem());
 
         if (selectedComingVersion == null) {
@@ -385,7 +385,7 @@ public class UctSettingsEditor extends SettingsEditor<UctRunConfiguration> {
 
         if (selectedItem != null && selectedItem.getKey().isEmpty()) {
             comingVersionError.setText("Please, specify target version");
-        } else if (!matcher.find()) {
+        } else if (!matcher.find()) { // NOPMD
             comingVersionError.setText("Please, correct target version");
         } else {
             comingVersionError.setText("");


### PR DESCRIPTION


<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description** (*)
Currently CLI UCT implementation uses hardcoded supported versions, which means it takes some time to add new version to the plugin codebase. This PR make able to run UCT for ever possible version. 
More details on what was done:
* Made editable combobox for coming version input.
* Custom coming version will be save in configuration, also it will be available as an option when user previously save it in config.
* Added regular expression (RegEx) to check a SemVer string for coming version input. User will see an error if format of version is incorrect.
* Fix additional issue related to command parameter - module path.

https://user-images.githubusercontent.com/20201927/203714053-55cfbcba-d615-4f8e-80b4-9ab675627e69.mov

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
