### PR TITLE
1220: avoid indexing not existing plugin classes

### DIFF
--- a/src/com/magento/idea/magento2plugin/stubs/indexes/PluginIndex.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/PluginIndex.java
@@ -19,6 +19,7 @@ import com.intellij.util.indexing.ID;
 import com.intellij.util.io.DataExternalizer;
 import com.intellij.util.io.EnumeratorStringDescriptor;
 import com.intellij.util.io.KeyDescriptor;
+import com.jetbrains.php.PhpIndex;
 import com.jetbrains.php.lang.PhpLangUtil;
 import com.magento.idea.magento2plugin.magento.files.ModuleDiXml;
 import com.magento.idea.magento2plugin.project.Settings;
@@ -90,6 +91,7 @@ public class PluginIndex extends FileBasedIndexExtension<String, Set<PluginData>
 
             @SuppressWarnings("checkstyle:LineLength")
             private Set<PluginData> getPluginsForType(final XmlTag typeNode) {
+                final PhpIndex phpIndex = PhpIndex.getInstance(typeNode.getProject());
                 final Set<PluginData> results = new HashSet<>();
 
                 for (final XmlTag pluginTag: typeNode.findSubTags(ModuleDiXml.PLUGIN_TAG_NAME)) {
@@ -99,6 +101,11 @@ public class PluginIndex extends FileBasedIndexExtension<String, Set<PluginData>
                     if (pluginType != null) {
                         pluginSortOrder = pluginSortOrder == null ? "0" : pluginSortOrder;
                         final PluginData pluginData = getPluginDataObject(pluginType,  Integer.parseInt(pluginSortOrder));
+                        try {
+                            phpIndex.getAnyByFQN(pluginData.getType());
+                        } catch (Throwable exception) { //NOPMD
+                            //do nothing
+                        }
                         results.add(pluginData);
                     }
                 }


### PR DESCRIPTION

**Description** (*)
Added check whether plugin PHP class exists before indexing it.

**Fixed Issues (if relevant)**
1. Fixes magento/magento2-phpstorm-plugin#1256
2. Fixes magento/magento2-phpstorm-plugin#1232
3. Fixes magento/magento2-phpstorm-plugin#1241
4. Fixes magento/magento2-phpstorm-plugin#1255
5. Fixes magento/magento2-phpstorm-plugin#1256

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
