### PR TITLE
1215: fix parsing of plugin sort order value [backport 5.0.1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 - Throwable: Stub index points to a file without PSI [#1232](https://github.com/magento/magento2-phpstorm-plugin/pull/1232)
 - Create an entity - delete button is displayed in a new entity form [#1268](https://github.com/magento/magento2-phpstorm-plugin/pull/1268)
 - Covered possible NullPointerException in InjectAViewModelDialog.java [#1213](https://github.com/magento/magento2-phpstorm-plugin/pull/1213)
+- MapReduceIndexMappingException: java.lang.NumberFormatException: For input string: "" [#1235](https://github.com/magento/magento2-phpstorm-plugin/pull/1235)
 
 ## 5.0.0
 

--- a/src/com/magento/idea/magento2plugin/stubs/indexes/PluginIndex.java
+++ b/src/com/magento/idea/magento2plugin/stubs/indexes/PluginIndex.java
@@ -96,11 +96,10 @@ public class PluginIndex extends FileBasedIndexExtension<String, Set<PluginData>
 
                 for (final XmlTag pluginTag: typeNode.findSubTags(ModuleDiXml.PLUGIN_TAG_NAME)) {
                     final String pluginType = pluginTag.getAttributeValue(ModuleDiXml.TYPE_ATTR);
-                    String pluginSortOrder = pluginTag.getAttributeValue(ModuleDiXml.SORT_ORDER_ATTR);
+                    final String pluginSortOrder = pluginTag.getAttributeValue(ModuleDiXml.SORT_ORDER_ATTR);
 
                     if (pluginType != null && !pluginType.isEmpty()) {
-                        pluginSortOrder = pluginSortOrder == null ? "0" : pluginSortOrder;
-                        final PluginData pluginData = getPluginDataObject(pluginType,  Integer.parseInt(pluginSortOrder));
+                        final PluginData pluginData = getPluginDataObject(pluginType, getIntegerOrZeroValue(pluginSortOrder));
                         try {
                             phpIndex.getAnyByFQN(pluginData.getType());
                             results.add(pluginData);
@@ -113,7 +112,22 @@ public class PluginIndex extends FileBasedIndexExtension<String, Set<PluginData>
                 return results;
             }
 
-            private PluginData getPluginDataObject(final String pluginType, final Integer sortOrder) {
+            private Integer getIntegerOrZeroValue(final String sortOrder) {
+                if (sortOrder == null || sortOrder.isEmpty()) {
+                    return 0;
+                }
+
+                try {
+                    return Integer.parseInt(sortOrder);
+                } catch (NumberFormatException e) {
+                    return 0;
+                }
+            }
+
+            private PluginData getPluginDataObject(
+                    final String pluginType,
+                    final Integer sortOrder
+            ) {
                 return new PluginData(pluginType,  sortOrder);
             }
         };


### PR DESCRIPTION
Backport 1215

<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description** (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#<issue_number>

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
