### PR TITLE
1227: fix Create an entity - The translation function is not call on …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 ### Fixed
 
 - Throwable: Stub index points to a file without PSI [#1232](https://github.com/magento/magento2-phpstorm-plugin/pull/1232)
-- Create an entity - delete button is displayed in a new entity form [#1268](https://github.com/magento/magento2-phpstorm-plugin/pull/1268)
+- Create an entity - The delete button is displayed in a new entity form [#1268](https://github.com/magento/magento2-phpstorm-plugin/pull/1268)
+- Create an entity - The translation function is not call on the buttons label [#1273](https://github.com/magento/magento2-phpstorm-plugin/pull/1273)
 - Covered possible NullPointerException in InjectAViewModelDialog.java [#1213](https://github.com/magento/magento2-phpstorm-plugin/pull/1213)
 - AWT events are not allowed inside write action [#1271](https://github.com/magento/magento2-phpstorm-plugin/pull/1271)
 

--- a/resources/fileTemplates/internal/Magento Form Button Block Class.php.ft
+++ b/resources/fileTemplates/internal/Magento Form Button Block Class.php.ft
@@ -27,7 +27,7 @@ class ${NAME} extends ${GENERIC_BUTTON} implements ${DATA_PROVIDER_TYPE}
 
 #end
         return $this->wrapButtonSettings(
-            '${LABEL}',
+            __('${LABEL}'),
             '${CLASS}',
             ${ON_CLICK},
             ${DATA_ATTRS},

--- a/testData/actions/generation/generator/FormButtonBlockGenerator/generateBackButtonBlock/MyBackButton.php
+++ b/testData/actions/generation/generator/FormButtonBlockGenerator/generateBackButtonBlock/MyBackButton.php
@@ -17,7 +17,7 @@ class MyBackButton extends GenericButton implements ButtonProviderInterface
     public function getButtonData(): array
     {
         return $this->wrapButtonSettings(
-            'Back To Grid',
+            __('Back To Grid'),
             'back',
             sprintf("location.href = '%s';", $this->getUrl('*/*/')),
             [],

--- a/testData/actions/generation/generator/FormButtonBlockGenerator/generateCustomButtonBlock/MyCustom.php
+++ b/testData/actions/generation/generator/FormButtonBlockGenerator/generateCustomButtonBlock/MyCustom.php
@@ -17,7 +17,7 @@ class MyCustom extends GenericButton implements ButtonProviderInterface
     public function getButtonData(): array
     {
         return $this->wrapButtonSettings(
-            'Custom Button',
+            __('Custom Button'),
             'custom',
             '',
             [],

--- a/testData/actions/generation/generator/FormButtonBlockGenerator/generateDeleteButtonBlock/DeleteBlock.php
+++ b/testData/actions/generation/generator/FormButtonBlockGenerator/generateDeleteButtonBlock/DeleteBlock.php
@@ -22,7 +22,7 @@ class DeleteBlock extends GenericButton implements ButtonProviderInterface
         }
 
         return $this->wrapButtonSettings(
-            'Delete',
+            __('Delete'),
             'delete',
             sprintf("deleteConfirm('%s', '%s')",
                 __('Are you sure you want to delete this book?'),

--- a/testData/actions/generation/generator/FormButtonBlockGenerator/generateSaveButtonBlock/SaveBlock.php
+++ b/testData/actions/generation/generator/FormButtonBlockGenerator/generateSaveButtonBlock/SaveBlock.php
@@ -17,7 +17,7 @@ class SaveBlock extends GenericButton implements ButtonProviderInterface
     public function getButtonData(): array
     {
         return $this->wrapButtonSettings(
-            'Save',
+            __('Save'),
             'save primary',
             '',
             [


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description** (*)
Fixed translations for buttons.

**Fixed Issues (if relevant)**
1. Fixes magento/magento2-phpstorm-plugin#1227

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
