### PR TITLE
Fix misspelled word in NewCustomerEavAttributeDialog.form

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCustomerEavAttributeDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewCustomerEavAttributeDialog.form
@@ -304,7 +304,7 @@
             <properties>
               <hideActionText value="true"/>
               <selected value="true"/>
-              <text value="Aminhtml Customer"/>
+              <text value="Adminhtml Customer"/>
             </properties>
           </component>
           <component id="ccf9d" class="javax.swing.JCheckBox" binding="useInCustomerAccountCreateCheckBox">


### PR DESCRIPTION
![image](https://github.com/magento/magento2-phpstorm-plugin/assets/1312328/e113a638-d242-4739-91ef-f7ab593f2e51)
