### PR TITLE
Fix NewObserverDialog form typo

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewObserverDialog.form
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewObserverDialog.form
@@ -71,12 +71,12 @@
               <text value="Directory Path"/>
             </properties>
           </component>
-          <component id="58ad9" class="javax.swing.JLabel" binding="evenNamesLabel">
+          <component id="58ad9" class="javax.swing.JLabel" binding="eventNamesLabel">
             <constraints>
               <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Observer Even Name"/>
+              <text value="Observer Event Name"/>
             </properties>
           </component>
           <component id="be834" class="javax.swing.JLabel" binding="directoryStructureErrorMessage">

--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewObserverDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewObserverDialog.java
@@ -90,7 +90,7 @@ public class NewObserverDialog extends AbstractDialog {
     private JLabel classNameErrorMessage;// NOPMD
     private JLabel directoryStructureLabel;// NOPMD
     private JLabel directoryStructureErrorMessage;// NOPMD
-    private JLabel evenNamesLabel;// NOPMD
+    private JLabel eventNamesLabel;// NOPMD
     private JLabel targetAreaLabel;// NOPMD
 
     /**
@@ -186,7 +186,7 @@ public class NewObserverDialog extends AbstractDialog {
         return className.getText().trim();
     }
 
-    public String getEvenName() {
+    public String getEventName() {
         return eventName.getSelectedItem().toString();
     }
 
@@ -213,7 +213,7 @@ public class NewObserverDialog extends AbstractDialog {
                             modulePackage,
                             moduleName,
                             getObserverClassFqn(),
-                            getEvenName(),
+                            getEventName(),
                             observerDirectory,
                             ModuleObserverFile.resolveClassNameFromInput(getClassName())
                     ),
@@ -227,7 +227,7 @@ public class NewObserverDialog extends AbstractDialog {
                                     Package.fqnSeparator,
                                     Package.vendorModuleNameSeparator
                             ),
-                            getEvenName(),
+                            getEventName(),
                             getObserverName(),
                             getObserverClassFqn().concat(Package.fqnSeparator).concat(
                                     ModuleObserverFile.resolveClassNameFromInput(getClassName())


### PR DESCRIPTION
Fix NewObserverDialog form typo

`Observer Even Name`  -> `Observer Event Name`

![Screenshot from 2024-04-16 17-56-06](https://github.com/magento/magento2-phpstorm-plugin/assets/43544955/55becd71-c9e2-423c-993f-a746529682bd)

