### PR TITLE
Fix action update thread deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## 5.2.0
 
+### Fixed
+
+- Fixed action update thread deprecation [#2072](https://github.com/magento/magento2-phpstorm-plugin/pull/2072)
+- Fixed compatibility with 2024.1 [#2071](https://github.com/magento/magento2-phpstorm-plugin/pull/2071)
+
 ## 5.1.0
 
 ### Fixed

--- a/src/com/magento/idea/magento2plugin/actions/comparator/CompareTemplateAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/comparator/CompareTemplateAction.java
@@ -8,6 +8,7 @@ package com.magento.idea.magento2plugin.actions.comparator;
 import com.intellij.diff.DiffDialogHints;
 import com.intellij.diff.DiffManager;
 import com.intellij.diff.chains.DiffRequestChain;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.PlatformDataKeys;
@@ -142,5 +143,10 @@ public class CompareTemplateAction extends AnAction {
     private void setStatus(final AnActionEvent event, final boolean status) {
         event.getPresentation().setVisible(status);
         event.getPresentation().setEnabled(status);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/context/AbstractContextAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/context/AbstractContextAction.java
@@ -9,6 +9,7 @@ import com.intellij.ide.fileTemplates.FileTemplate;
 import com.intellij.ide.fileTemplates.FileTemplateManager;
 import com.intellij.ide.fileTemplates.actions.AttributesDefaults;
 import com.intellij.ide.fileTemplates.actions.CreateFromTemplateActionBase;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.actionSystem.DataKey;
@@ -68,6 +69,11 @@ public abstract class AbstractContextAction extends CreateFromTemplateActionBase
     ) {
         super(title, description, icon);
         this.moduleFile = moduleFile;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     @Override

--- a/src/com/magento/idea/magento2plugin/actions/context/CustomGeneratorContextAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/context/CustomGeneratorContextAction.java
@@ -5,6 +5,7 @@
 
 package com.magento.idea.magento2plugin.actions.context;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
@@ -80,6 +81,11 @@ public abstract class CustomGeneratorContextAction extends AnAction {
 
     public @Nullable PsiFile getFile() {
         return file;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/context/xml/NewLayoutXmlAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/context/xml/NewLayoutXmlAction.java
@@ -5,6 +5,7 @@
 
 package com.magento.idea.magento2plugin.actions.context.xml;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DataContext;
@@ -92,6 +93,11 @@ public class NewLayoutXmlAction extends AnAction {
         }
 
         NewLayoutTemplateDialog.open(event.getProject(), targetDirectory);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/InjectConstructorArgumentAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/InjectConstructorArgumentAction.java
@@ -5,6 +5,7 @@
 
 package com.magento.idea.magento2plugin.actions.generation;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
@@ -90,6 +91,11 @@ public class InjectConstructorArgumentAction extends AnAction {
                 currentPhpClass,
                 currentParameter
         );
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewBlockAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewBlockAction.java
@@ -6,6 +6,7 @@
 package com.magento.idea.magento2plugin.actions.generation;
 
 import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -51,5 +52,10 @@ public class NewBlockAction extends AnAction {
     @Override
     public boolean isDumbAware() {
         return false;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewCLICommandAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewCLICommandAction.java
@@ -6,6 +6,7 @@
 package com.magento.idea.magento2plugin.actions.generation;
 
 import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -50,5 +51,10 @@ public class NewCLICommandAction extends AnAction {
     @Override
     public boolean isDumbAware() {
         return false;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewControllerAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewControllerAction.java
@@ -6,6 +6,7 @@
 package com.magento.idea.magento2plugin.actions.generation;
 
 import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -15,6 +16,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDirectory;
 import com.magento.idea.magento2plugin.MagentoIcons;
 import com.magento.idea.magento2plugin.actions.generation.dialog.NewControllerDialog;
+import org.jetbrains.annotations.NotNull;
 
 public class NewControllerAction extends AnAction {
 
@@ -53,5 +55,10 @@ public class NewControllerAction extends AnAction {
     @Override
     public boolean isDumbAware() {
         return false;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewCronjobAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewCronjobAction.java
@@ -6,6 +6,7 @@
 package com.magento.idea.magento2plugin.actions.generation;
 
 import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -50,5 +51,10 @@ public class NewCronjobAction extends AnAction {
     @Override
     public boolean isDumbAware() {
         return false;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewDbSchemaAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewDbSchemaAction.java
@@ -6,6 +6,7 @@
 package com.magento.idea.magento2plugin.actions.generation;
 
 import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -53,5 +54,10 @@ public class NewDbSchemaAction extends AnAction {
     @Override
     public boolean isDumbAware() {
         return false;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewEmailTemplateAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewEmailTemplateAction.java
@@ -6,6 +6,7 @@
 package com.magento.idea.magento2plugin.actions.generation;
 
 import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -15,6 +16,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDirectory;
 import com.magento.idea.magento2plugin.MagentoIcons;
 import com.magento.idea.magento2plugin.actions.generation.dialog.NewEmailTemplateDialog;
+import org.jetbrains.annotations.NotNull;
 
 public class NewEmailTemplateAction extends AnAction {
 
@@ -52,5 +54,10 @@ public class NewEmailTemplateAction extends AnAction {
     @Override
     public boolean isDumbAware() {
         return false;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewEntityAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewEntityAction.java
@@ -6,6 +6,7 @@
 package com.magento.idea.magento2plugin.actions.generation;
 
 import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -15,6 +16,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDirectory;
 import com.magento.idea.magento2plugin.MagentoIcons;
 import com.magento.idea.magento2plugin.actions.generation.dialog.NewEntityDialog;
+import org.jetbrains.annotations.NotNull;
 
 public class NewEntityAction extends AnAction {
     public static final String ACTION_NAME = "Magento 2 Entity";
@@ -52,5 +54,10 @@ public class NewEntityAction extends AnAction {
     @Override
     public boolean isDumbAware() {
         return false;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewGraphQlResolverAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewGraphQlResolverAction.java
@@ -6,6 +6,7 @@
 package com.magento.idea.magento2plugin.actions.generation;
 
 import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -50,6 +51,11 @@ public class NewGraphQlResolverAction extends AnAction {
     @Override
     public boolean isDumbAware() {
         return false;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 }
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewMessageQueueAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewMessageQueueAction.java
@@ -6,6 +6,7 @@
 package com.magento.idea.magento2plugin.actions.generation;
 
 import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -53,5 +54,10 @@ public class NewMessageQueueAction extends AnAction {
     @Override
     public boolean isDumbAware() {
         return false;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewModelsAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewModelsAction.java
@@ -6,6 +6,7 @@
 package com.magento.idea.magento2plugin.actions.generation;
 
 import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -15,6 +16,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDirectory;
 import com.magento.idea.magento2plugin.MagentoIcons;
 import com.magento.idea.magento2plugin.actions.generation.dialog.NewModelsDialog;
+import org.jetbrains.annotations.NotNull;
 
 public class NewModelsAction extends AnAction {
 
@@ -52,5 +54,10 @@ public class NewModelsAction extends AnAction {
     @Override
     public boolean isDumbAware() {
         return false;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewModuleAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewModuleAction.java
@@ -6,6 +6,7 @@
 package com.magento.idea.magento2plugin.actions.generation;
 
 import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
@@ -110,5 +111,10 @@ public class NewModuleAction extends com.intellij.openapi.actionSystem.AnAction 
         }
 
         event.getPresentation().setVisible(false);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewUiComponentFormAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewUiComponentFormAction.java
@@ -6,6 +6,7 @@
 package com.magento.idea.magento2plugin.actions.generation;
 
 import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -15,6 +16,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDirectory;
 import com.magento.idea.magento2plugin.MagentoIcons;
 import com.magento.idea.magento2plugin.actions.generation.dialog.NewUiComponentFormDialog;
+import org.jetbrains.annotations.NotNull;
 
 public class NewUiComponentFormAction extends AnAction {
 
@@ -52,5 +54,10 @@ public class NewUiComponentFormAction extends AnAction {
     @Override
     public boolean isDumbAware() {
         return false;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewUiComponentGridAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewUiComponentGridAction.java
@@ -6,6 +6,7 @@
 package com.magento.idea.magento2plugin.actions.generation;
 
 import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -15,6 +16,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDirectory;
 import com.magento.idea.magento2plugin.MagentoIcons;
 import com.magento.idea.magento2plugin.actions.generation.dialog.NewUiComponentGridDialog;
+import org.jetbrains.annotations.NotNull;
 
 public class NewUiComponentGridAction extends AnAction {
 
@@ -57,5 +59,10 @@ public class NewUiComponentGridAction extends AnAction {
     @Override
     public boolean isDumbAware() {
         return false;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 }

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewViewModelAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewViewModelAction.java
@@ -6,6 +6,7 @@
 package com.magento.idea.magento2plugin.actions.generation;
 
 import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -50,6 +51,11 @@ public class NewViewModelAction extends AnAction {
     @Override
     public boolean isDumbAware() {
         return false;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 }
 

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewWebApiDeclarationAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewWebApiDeclarationAction.java
@@ -5,6 +5,7 @@
 
 package com.magento.idea.magento2plugin.actions.generation;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
@@ -74,6 +75,11 @@ public class NewWebApiDeclarationAction extends AnAction {
         final String methodName = currentPhpMethod.getName();
 
         NewWebApiDeclarationDialog.open(event.getProject(), directory, classFqn, methodName);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/NewWebApiInterfaceAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/NewWebApiInterfaceAction.java
@@ -5,6 +5,7 @@
 
 package com.magento.idea.magento2plugin.actions.generation;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
@@ -73,6 +74,11 @@ public class NewWebApiInterfaceAction extends AnAction {
                 directory,
                 currentPhpClass
         );
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/OverrideFileInThemeAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/OverrideFileInThemeAction.java
@@ -5,6 +5,7 @@
 
 package com.magento.idea.magento2plugin.actions.generation;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.PlatformDataKeys;
@@ -56,6 +57,11 @@ public abstract class OverrideFileInThemeAction extends AnAction {
             setStatus(event, true);
             psiFile = targetFile;
         }
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/eavattribute/NewEavAttributeAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/eavattribute/NewEavAttributeAction.java
@@ -6,6 +6,7 @@
 package com.magento.idea.magento2plugin.actions.generation.eavattribute;
 
 import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -46,6 +47,11 @@ public abstract class NewEavAttributeAction extends AnAction {
 
         final EavAttributeDialog eavAttributeDialog = getDialogWindow(project, directory);
         eavAttributeDialog.open();
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     @Override

--- a/src/com/magento/idea/magento2plugin/actions/groups/ContextActionsGroup.java
+++ b/src/com/magento/idea/magento2plugin/actions/groups/ContextActionsGroup.java
@@ -6,6 +6,7 @@
 package com.magento.idea.magento2plugin.actions.groups;
 
 import com.intellij.ide.actions.NonEmptyActionGroup;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import java.util.Arrays;
@@ -31,6 +32,11 @@ public class ContextActionsGroup extends NonEmptyActionGroup {
         }
 
         super.update(event);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     private static class ContextActionsComparator implements Comparator<AnAction> {

--- a/src/com/magento/idea/magento2uct/actions/ConfigureUctAction.java
+++ b/src/com/magento/idea/magento2uct/actions/ConfigureUctAction.java
@@ -6,6 +6,7 @@
 package com.magento.idea.magento2uct.actions;
 
 import com.intellij.icons.AllIcons;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
@@ -44,6 +45,11 @@ public class ConfigureUctAction extends AnAction {
             return;
         }
         ConfigurationDialog.open(project);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     /**

--- a/src/com/magento/idea/magento2uct/actions/ReindexVersionedIndexesAction.java
+++ b/src/com/magento/idea/magento2uct/actions/ReindexVersionedIndexesAction.java
@@ -7,6 +7,7 @@ package com.magento.idea.magento2uct.actions;
 
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.IdeView;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.LangDataKeys;
@@ -57,6 +58,11 @@ public class ReindexVersionedIndexesAction extends AnAction {
             return;
         }
         ReindexDialog.open(project, directory);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     /**

--- a/src/com/magento/idea/magento2uct/actions/RunUpgradeCompatibilityToolAction.java
+++ b/src/com/magento/idea/magento2uct/actions/RunUpgradeCompatibilityToolAction.java
@@ -6,6 +6,7 @@
 package com.magento.idea.magento2uct.actions;
 
 import com.intellij.icons.AllIcons;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
@@ -55,6 +56,11 @@ public class RunUpgradeCompatibilityToolAction extends AnAction {
                 new DefaultAnalysisHandler(project)
         );
         executor.run();
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     /**


### PR DESCRIPTION
Fixes multiple:

```
com.intellij.diagnostic.PluginException: `ActionUpdateThread.OLD_EDT` is deprecated and going to be removed soon.
```

Fixes: https://github.com/magento/magento2-phpstorm-plugin/issues/2032 and possible most of the 90 bug reports in the issue tracker.


Depends on https://github.com/magento/magento2-phpstorm-plugin/pull/2071 which should be merged first.

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
