### PR TITLE
fix: workaround for "thread context was already set" exception

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewGraphQlResolverDialog.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/dialog/NewGraphQlResolverDialog.java
@@ -113,7 +113,12 @@ public class NewGraphQlResolverDialog extends AbstractDialog {
         final NewGraphQlResolverDialog dialog = new NewGraphQlResolverDialog(project, directory);
         dialog.pack();
         dialog.centerDialog(dialog);
-        dialog.setVisible(true);
+
+        // TODO: It's a workaround. Proper fix should be done as:
+        // https://github.com/magento/magento2-phpstorm-plugin/issues/2080
+        try (var token = com.intellij.concurrency.ThreadContext.resetThreadContext()) {
+            dialog.setVisible(true);
+        }
     }
 
     protected void onOK() {


### PR DESCRIPTION
Fixes "thread context was already set" exception triggered on every popup display.

The proper fix is going to be more involved and is tracked in https://github.com/magento/magento2-phpstorm-plugin/issues/2080.

I'll pick it up at some point in the future. It's going to require reworking a JDialog implementation to DialogWrapper. It will be more time consuming from implementation and testing point of view.

**Contribution checklist** (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
