### PR TITLE
fix ActionUpdateThread.OLD_EDT deprecation on DumbAwareActions

### DIFF
--- a/src/com/magento/idea/magento2plugin/actions/generation/CreateAPluginAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/CreateAPluginAction.java
@@ -5,6 +5,8 @@
 
 package com.magento.idea.magento2plugin.actions.generation;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
+import com.intellij.openapi.actionSystem.ActionUpdateThreadAware;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.editor.Caret;
@@ -24,7 +26,7 @@ import com.magento.idea.magento2plugin.util.GetFirstClassOfFile;
 import com.magento.idea.magento2plugin.util.magento.plugin.IsPluginAllowedForMethodUtil;
 import org.jetbrains.annotations.NotNull;
 
-public class CreateAPluginAction extends DumbAwareAction {
+public class CreateAPluginAction extends DumbAwareAction implements ActionUpdateThreadAware {
 
     public static final String ACTION_NAME = "Create a new Plugin";
     public static final String ACTION_DESCRIPTION = "Create a new Magento 2 Plugin";
@@ -88,6 +90,11 @@ public class CreateAPluginAction extends DumbAwareAction {
     @Override
     public boolean isDumbAware() {
         return false;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     private Pair<PsiFile, PhpClass> findPhpClass(final @NotNull AnActionEvent event) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/CreateAnObserverAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/CreateAnObserverAction.java
@@ -30,7 +30,8 @@ import com.magento.idea.magento2plugin.magento.files.Observer;
 import com.magento.idea.magento2plugin.project.Settings;
 import org.jetbrains.annotations.NotNull;
 
-public class CreateAnObserverAction extends DumbAwareAction implements ActionUpdateThreadAware {
+public class CreateAnObserverAction extends DumbAwareAction
+        implements ActionUpdateThreadAware {
 
     public static final String ACTION_NAME = "Create a new Observer for this event";
     public static final String ACTION_DESCRIPTION = "Create a new Magento 2 Observer";

--- a/src/com/magento/idea/magento2plugin/actions/generation/CreateAnObserverAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/CreateAnObserverAction.java
@@ -6,6 +6,8 @@
 package com.magento.idea.magento2plugin.actions.generation;
 
 import com.intellij.lang.ASTNode;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
+import com.intellij.openapi.actionSystem.ActionUpdateThreadAware;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.editor.Caret;
@@ -28,7 +30,7 @@ import com.magento.idea.magento2plugin.magento.files.Observer;
 import com.magento.idea.magento2plugin.project.Settings;
 import org.jetbrains.annotations.NotNull;
 
-public class CreateAnObserverAction extends DumbAwareAction {
+public class CreateAnObserverAction extends DumbAwareAction implements ActionUpdateThreadAware {
 
     public static final String ACTION_NAME = "Create a new Observer for this event";
     public static final String ACTION_DESCRIPTION = "Create a new Magento 2 Observer";
@@ -85,6 +87,11 @@ public class CreateAnObserverAction extends DumbAwareAction {
     @Override
     public boolean isDumbAware() {
         return false;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     private PsiElement getElement(final @NotNull AnActionEvent event) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/InjectAViewModelAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/InjectAViewModelAction.java
@@ -105,7 +105,7 @@ public class InjectAViewModelAction extends DumbAwareAction implements ActionUpd
         if (xmlTag == null) {
             return null;
         }
-        XmlTag resultTag;
+        final XmlTag resultTag;
 
         if (CommonXml.ATTRIBUTE_ARGUMENTS.equals(xmlTag.getName())) {
             resultTag = PsiTreeUtil.getParentOfType(xmlTag, XmlTag.class);

--- a/src/com/magento/idea/magento2plugin/actions/generation/InjectAViewModelAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/InjectAViewModelAction.java
@@ -5,6 +5,8 @@
 
 package com.magento.idea.magento2plugin.actions.generation;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
+import com.intellij.openapi.actionSystem.ActionUpdateThreadAware;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.editor.Caret;
@@ -21,7 +23,7 @@ import com.magento.idea.magento2plugin.magento.files.LayoutXml;
 import com.magento.idea.magento2plugin.project.Settings;
 import org.jetbrains.annotations.NotNull;
 
-public class InjectAViewModelAction extends DumbAwareAction {
+public class InjectAViewModelAction extends DumbAwareAction implements ActionUpdateThreadAware {
 
     public static final String ACTION_NAME = "Inject a new View Model for this block";
     public static final String ACTION_DESCRIPTION = "Inject a new Magento 2 View Model";
@@ -66,6 +68,11 @@ public class InjectAViewModelAction extends DumbAwareAction {
     @Override
     public boolean isDumbAware() {
         return false;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     /**

--- a/src/com/magento/idea/magento2plugin/actions/generation/OverrideClassByAPreferenceAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/OverrideClassByAPreferenceAction.java
@@ -5,6 +5,8 @@
 
 package com.magento.idea.magento2plugin.actions.generation;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
+import com.intellij.openapi.actionSystem.ActionUpdateThreadAware;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.project.DumbAwareAction;
@@ -19,7 +21,7 @@ import com.magento.idea.magento2plugin.project.Settings;
 import com.magento.idea.magento2plugin.util.GetFirstClassOfFile;
 import org.jetbrains.annotations.NotNull;
 
-public class OverrideClassByAPreferenceAction extends DumbAwareAction {
+public class OverrideClassByAPreferenceAction extends DumbAwareAction implements ActionUpdateThreadAware {
     public static final String ACTION_NAME = "Override this class by a new Preference";
     public static final String ACTION_DESCRIPTION = "Create a new Magento 2 Preference";
     public static final String INTERFACE_ACTION = "Override this interface by a new Preference";
@@ -73,6 +75,11 @@ public class OverrideClassByAPreferenceAction extends DumbAwareAction {
     @Override
     public boolean isDumbAware() {
         return false;
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     private Pair<PsiFile, PhpClass> findPhpClass(@NotNull final AnActionEvent event) {

--- a/src/com/magento/idea/magento2plugin/actions/generation/OverrideClassByAPreferenceAction.java
+++ b/src/com/magento/idea/magento2plugin/actions/generation/OverrideClassByAPreferenceAction.java
@@ -21,7 +21,8 @@ import com.magento.idea.magento2plugin.project.Settings;
 import com.magento.idea.magento2plugin.util.GetFirstClassOfFile;
 import org.jetbrains.annotations.NotNull;
 
-public class OverrideClassByAPreferenceAction extends DumbAwareAction implements ActionUpdateThreadAware {
+public class OverrideClassByAPreferenceAction extends DumbAwareAction
+        implements ActionUpdateThreadAware {
     public static final String ACTION_NAME = "Override this class by a new Preference";
     public static final String ACTION_DESCRIPTION = "Create a new Magento 2 Preference";
     public static final String INTERFACE_ACTION = "Override this interface by a new Preference";


### PR DESCRIPTION
Fixes on classes extending `DumbAwareAction`:
```
com.intellij.diagnostic.PluginException: `ActionUpdateThread.OLD_EDT` is deprecated and going to be removed soon. 'com.magento.idea.magento2plugin.actions.generation.InjectAViewModelAction' must override `getActionUpdateThread()` and chose EDT or BGT. See ActionUpdateThread javadoc. [Plugin: com.magento.idea.magento2plugin]
	at com.intellij.diagnostic.PluginProblemReporterImpl.createPluginExceptionByClass(PluginProblemReporterImpl.java:23)
	at com.intellij.diagnostic.PluginException.createByClass(PluginException.java:90)
	at com.intellij.diagnostic.PluginException.reportDeprecatedUsage(PluginException.java:125)
	at com.intellij.openapi.actionSystem.ActionUpdateThreadAware.getActionUpdateThread(ActionUpdateThreadAware.java:21)
	at com.intellij.openapi.actionSystem.AnAction.getActionUpdateThread(AnAction.java:199)
```	

1. Fixes magento/magento2-phpstorm-plugin#2083
2. Fixes magento/magento2-phpstorm-plugin#2084
3. Fixes magento/magento2-phpstorm-plugin#2085
4. Fixes magento/magento2-phpstorm-plugin#2086
5. Fixes magento/magento2-phpstorm-plugin#2089

**Contribution checklist** (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
