### PR TITLE
Add v5.3.0 changes to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## 5.3.0
 
+### Added
+
+- Mage-os support [#2081](https://github.com/magento/magento2-phpstorm-plugin/pull/2081)
+
+### Fixed
+
+- Workaround for "thread context was already set" exception [#2082](https://github.com/magento/magento2-phpstorm-plugin/pull/2082)
+- NewObserverDialog form typo [#2087](https://github.com/magento/magento2-phpstorm-plugin/pull/2087)
+- ActionUpdateThread.OLD_EDT deprecation on DumbAwareActions [#2088](https://github.com/magento/magento2-phpstorm-plugin/pull/2088)
+
 ## 5.2.0
 
 ### Fixed


### PR DESCRIPTION
Included Mage-os support and multiple fixes such as a workaround for the "thread context was already set" exception, a typo in NewObserverDialog form, and deprecation of ActionUpdateThread.OLD_EDT on DumbAwareActions. These updates provide critical fixes and new features to enhance the plugin's functionality.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description** (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#<issue_number>

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
