### PR TITLE
Update RegExUtil.java

### DIFF
--- a/src/com/magento/idea/magento2plugin/util/RegExUtil.java
+++ b/src/com/magento/idea/magento2plugin/util/RegExUtil.java
@@ -64,7 +64,7 @@ public class RegExUtil {
                 = "[A-Z][a-zA-Z0-9]+_[A-Z][a-zA-Z0-9]+";
 
         public static final String THEME_NAME
-                = "[a-z]+/[A-Z][a-zA-Z0-9_]+/[a-z][a-zA-Z0-9_]+";
+                = "[a-z]+/[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+";
 
         public static final String MFTF_CURLY_BRACES
                 = ".*\\{\\{[^\\}]+\\}\\}.*";


### PR DESCRIPTION
Updating theme regex to support dashes.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description** (*)
According to the Magento devdocs:

> The folder name conventionally matches naming used in the theme's code: any alphanumeric set of characters, as the vendor sees fit, is acceptable. This convention is merely a recommendation, so nothing prevents naming this directory in another way.

The current regex limits the themes to:
| match | group | is_participating | start | end | content                        |
|-------|-------|------------------|-------|-----|--------------------------------|
| 1     | 0     | yes              | 0     | 21  | frontend/Vendor/theme          |
| 2     | 0     | yes              | 44    | 74  | frontend/Vendor/custom9_theme9 |
| 3     | 0     | yes              | 106   | 136 | frontend/Vendor/custom9_theme9 |
| 4     | 0     | yes              | 137   | 159 | frontend/Vendor/custom         |
| 5     | 0     | yes              | 196   | 225 | frontend/Vendor/custom9Theme9  |

The adapted regex allows the themes to be:
| match | group | is_participating | start | end | content                        |
|-------|-------|------------------|-------|-----|--------------------------------|
| 1     | 0     | yes              | 0     | 21  | frontend/Vendor/theme          |
| 2     | 0     | yes              | 22    | 43  | frontend/Vendor/Theme          |
| 3     | 0     | yes              | 44    | 74  | frontend/Vendor/custom9_theme9 |
| 4     | 0     | yes              | 75    | 105 | frontend/Vendor/Custom9_theme9 |
| 5     | 0     | yes              | 106   | 136 | frontend/Vendor/custom9_theme9 |
| 6     | 0     | yes              | 137   | 165 | frontend/Vendor/custom-theme   |
| 7     | 0     | yes              | 166   | 195 | frontend/Vendor/Custom9Theme9  |
| 8     | 0     | yes              | 196   | 225 | frontend/Vendor/custom9Theme9  |
| 9     | 0     | yes              | 226   | 247 | frontend/vendor/theme          |
| 10    | 0     | yes              | 248   | 269 | frontend/vendor/Theme          |
| 11    | 0     | yes              | 270   | 300 | frontend/vendor/custom9_theme9 |
| 12    | 0     | yes              | 301   | 331 | frontend/vendor/Custom9_theme9 |
| 13    | 0     | yes              | 332   | 362 | frontend/vendor/custom9_theme9 |
| 14    | 0     | yes              | 363   | 391 | frontend/vendor/custom-theme   |
| 15    | 0     | yes              | 392   | 421 | frontend/vendor/Custom9Theme9  |
| 16    | 0     | yes              | 422   | 451 | frontend/vendor/custom9Theme9  |

Thanks @sdouma for the regex!

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#1517

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with integration/functional tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
