### PR TITLE
1295 add array as type in DataModel properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 ### Added
 
 - Clear notifications for the process status of URN generation [#2486](https://github.com/magento/magento2-phpstorm-plugin/pull/2486)
-- Added array as a type in Data Model properties [#1295](https://github.com/magento/magento2-phpstorm-plugin/pull/1295)
+- Added array as a type in Data Model properties [#2488](https://github.com/magento/magento2-phpstorm-plugin/pull/2488)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 ### Added
 
 - Clear notifications for the process status of URN generation [#2486](https://github.com/magento/magento2-phpstorm-plugin/pull/2486)
+- Added array as a type in Data Model properties [#1295](https://github.com/magento/magento2-phpstorm-plugin/pull/1295)
 
 ### Fixed
 

--- a/src/main/java/com/magento/idea/magento2plugin/magento/packages/PropertiesTypes.java
+++ b/src/main/java/com/magento/idea/magento2plugin/magento/packages/PropertiesTypes.java
@@ -14,7 +14,8 @@ public enum PropertiesTypes {
     INT("int"),
     FLOAT("float"),
     STRING("string"),
-    BOOL("bool");
+    BOOL("bool"),
+    ARRAY("array");
 
     private final String propertyType;
 
@@ -66,7 +67,8 @@ public enum PropertiesTypes {
             valueOf(INT.toString()).getPropertyType(),
             valueOf(FLOAT.toString()).getPropertyType(),
             valueOf(STRING.toString()).getPropertyType(),
-            valueOf(BOOL.toString()).getPropertyType()
+            valueOf(BOOL.toString()).getPropertyType(),
+            valueOf(ARRAY.toString()).getPropertyType()
         };
     }
 

--- a/src/main/resources/fileTemplates/internal/Magento Data Model.php.ft
+++ b/src/main/resources/fileTemplates/internal/Magento Data Model.php.ft
@@ -48,7 +48,7 @@ class ${NAME} #if (${EXTENDS})extends ${EXTENDS} #end #if (${IMPLEMENTS} && $has
              */
             public function get$propertyUpperCamel(): ?$propertyType
             {
-                #if($propertyType == 'string')
+                #if($propertyType == 'string' || $propertyType == 'array')
                 return $this->getData(self::$propertyUpperSnake);
                 #{else}
                 return $this->getData(self::$propertyUpperSnake) === null ? null


### PR DESCRIPTION
**Description** (*)
This PR adds an array as a type in DataModel properties
![1295-add-array-to-datamodel-properties](https://github.com/user-attachments/assets/0b840b98-5d4e-4775-a83d-d9b91fd754e5)

**Fixed Issues (if relevant)**
1. Fixes magento/magento2-phpstorm-plugin#1295

**Questions or comments**

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
