### PR TITLE
2487: Add dispatch thread check before applying fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 - Compatibility with PhpStorm/IntelliJ 2025.* [#2495](https://github.com/magento/magento2-phpstorm-plugin/pull/2495)
 - "Copy Path/Reference" does not show the preview value [#2497](https://github.com/magento/magento2-phpstorm-plugin/pull/2497)
+- Must not start write action from within read action in the other thread [#2498](https://github.com/magento/magento2-phpstorm-plugin/pull/2498)
 
 ## 2025.0.0
 

--- a/src/main/java/com/magento/idea/magento2plugin/inspections/php/fix/PhpModuleNameQuickFix.java
+++ b/src/main/java/com/magento/idea/magento2plugin/inspections/php/fix/PhpModuleNameQuickFix.java
@@ -7,6 +7,7 @@ package com.magento.idea.magento2plugin.inspections.php.fix;
 
 import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.project.Project;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
@@ -38,7 +39,9 @@ public class PhpModuleNameQuickFix implements LocalQuickFix {
     ) {
         final StringLiteralExpression expression =
                 (StringLiteralExpression) descriptor.getPsiElement();
-        applyFix(expression);
+        if (ApplicationManager.getApplication().isDispatchThread()) {
+            applyFix(expression);
+        }
     }
 
     private void applyFix(final StringLiteralExpression expression) {


### PR DESCRIPTION
Ensures that `applyFix` is only called on the dispatch thread to prevent potential threading issues. This change improves safety and aligns with IntelliJ threading requirements.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description** (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#2487

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
