### PR TITLE
2491: Prevent URN map generation during indexing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 
 - Compatibility with PhpStorm/IntelliJ 2025.* [#2495](https://github.com/magento/magento2-phpstorm-plugin/pull/2495)
 - "Copy Path/Reference" does not show the preview value [#2497](https://github.com/magento/magento2-phpstorm-plugin/pull/2497)
+- URN map generation during indexing [#2499](https://github.com/magento/magento2-phpstorm-plugin/pull/2499)
 
 ## 2025.0.0
 

--- a/src/main/java/com/magento/idea/magento2plugin/project/RegenerateUrnMapListener.java
+++ b/src/main/java/com/magento/idea/magento2plugin/project/RegenerateUrnMapListener.java
@@ -10,6 +10,7 @@ import com.intellij.javaee.ExternalResourceManagerEx;
 import com.intellij.notification.NotificationGroupManager;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDirectory;
@@ -52,6 +53,20 @@ class RegenerateUrnMapListener extends MouseAdapter {
         final PsiManager psiManager = PsiManager.getInstance(project);
         final MagentoComponentManager componentManager =
                 MagentoComponentManager.getInstance(project);
+
+        if (DumbService.getInstance(project).isDumb()) {
+            NotificationGroupManager.getInstance()
+                    .getNotificationGroup("Magento Notifications")
+                    .createNotification(
+                            "URN map generation unavailable",
+                            "Indexing is in progress." +
+                                    " Please wait for it to complete" +
+                                    " before running URN mapping generation.",
+                            NotificationType.WARNING
+                    )
+                    .notify(project);
+            return;
+        }
 
         ApplicationManager.getApplication().runWriteAction(
                 new Runnable() {

--- a/src/main/java/com/magento/idea/magento2plugin/project/RegenerateUrnMapListener.java
+++ b/src/main/java/com/magento/idea/magento2plugin/project/RegenerateUrnMapListener.java
@@ -59,9 +59,9 @@ class RegenerateUrnMapListener extends MouseAdapter {
                     .getNotificationGroup("Magento Notifications")
                     .createNotification(
                             "URN map generation unavailable",
-                            "Indexing is in progress." +
-                                    " Please wait for it to complete" +
-                                    " before running URN mapping generation.",
+                            "Indexing is in progress."
+                                    + " Please wait for it to complete"
+                                    + " before running URN mapping generation.",
                             NotificationType.WARNING
                     )
                     .notify(project);

--- a/src/main/java/com/magento/idea/magento2plugin/project/RegenerateUrnMapListener.java
+++ b/src/main/java/com/magento/idea/magento2plugin/project/RegenerateUrnMapListener.java
@@ -47,11 +47,8 @@ class RegenerateUrnMapListener extends MouseAdapter {
      * @param event MouseEvent
      */
     @Override
+    @SuppressWarnings("PMD.UseNotifyAllInsteadOfNotify")
     public void mouseClicked(final MouseEvent event) {
-        final PsiManager psiManager = PsiManager.getInstance(project);
-        final MagentoComponentManager componentManager =
-                MagentoComponentManager.getInstance(project);
-
         if (DumbService.getInstance(project).isDumb()) {
             NotificationGroupManager.getInstance()
                     .getNotificationGroup("Magento Notifications")
@@ -70,6 +67,9 @@ class RegenerateUrnMapListener extends MouseAdapter {
                 new Runnable() {
                     @Override
                     public void run() {
+                        final PsiManager psiManager = PsiManager.getInstance(project);
+                        final MagentoComponentManager componentManager =
+                                MagentoComponentManager.getInstance(project);
                         final ExternalResourceManager manager =
                                 ExternalResourceManager.getInstance();
                         final Collection<VirtualFile> xsdFiles

--- a/src/main/java/com/magento/idea/magento2plugin/project/RegenerateUrnMapListener.java
+++ b/src/main/java/com/magento/idea/magento2plugin/project/RegenerateUrnMapListener.java
@@ -48,8 +48,6 @@ class RegenerateUrnMapListener extends MouseAdapter {
      */
     @Override
     public void mouseClicked(final MouseEvent event) {
-        final ExternalResourceManager manager =
-                ExternalResourceManager.getInstance();
         final PsiManager psiManager = PsiManager.getInstance(project);
         final MagentoComponentManager componentManager =
                 MagentoComponentManager.getInstance(project);
@@ -72,6 +70,8 @@ class RegenerateUrnMapListener extends MouseAdapter {
                 new Runnable() {
                     @Override
                     public void run() {
+                        final ExternalResourceManager manager =
+                                ExternalResourceManager.getInstance();
                         final Collection<VirtualFile> xsdFiles
                                 = FilenameIndex.getAllFilesByExt(project, "xsd");
                         final Collection<MagentoComponent> components


### PR DESCRIPTION
Added a check to avoid URN map generation when the project is in indexing (dumb) mode. A warning notification is shown to inform users that they need to wait until indexing is complete. This prevents potential errors or performance issues.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description** (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#2491

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
