### PR TITLE
1295: Exclude 'ARRAY' property type from the property list because it…

### DIFF
--- a/src/main/java/com/magento/idea/magento2plugin/magento/packages/PropertiesTypes.java
+++ b/src/main/java/com/magento/idea/magento2plugin/magento/packages/PropertiesTypes.java
@@ -81,7 +81,9 @@ public enum PropertiesTypes {
         final List<String> propertyList = new LinkedList<>();
 
         for (final PropertiesTypes property : PropertiesTypes.values()) {
-            propertyList.add(property.getPropertyType());
+            if (!property.getPropertyType().equals(ARRAY.getPropertyType())) {
+                propertyList.add(property.getPropertyType());
+            }
         }
 
         return propertyList;


### PR DESCRIPTION
… breaks entity generator

But still keep it in the Data Model generator.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description** (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#1295

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
