### PR TITLE
Upgrade compatibility tool fixes

### DIFF
--- a/src/main/java/com/magento/idea/magento2uct/execution/configurations/UctSettingsEditor.java
+++ b/src/main/java/com/magento/idea/magento2uct/execution/configurations/UctSettingsEditor.java
@@ -320,8 +320,8 @@ public class UctSettingsEditor extends SettingsEditor<UctRunConfiguration> {
     private void initializeComboboxSources() {
         comingVersion.setToolTipText("Choose a target version");
 
-        for (final String version : SupportedVersion.getSupportedVersions()) {
-            comingVersion.addItem(new ComboBoxItemData(version, version));
+        for (final SupportedVersion version : SupportedVersion.getSupportedVersions()) {
+            comingVersion.addItem(new ComboBoxItemData(version.getVersion(), version.getVersion()));
         }
 
         for (final IssueSeverityLevel level : IssueSeverityLevel.getSeverityLabels()) {

--- a/src/main/java/com/magento/idea/magento2uct/packages/IndexRegistry.java
+++ b/src/main/java/com/magento/idea/magento2uct/packages/IndexRegistry.java
@@ -22,17 +22,17 @@ public enum IndexRegistry {
     DEPRECATION(
             DeprecationStateIndex.class,
             new DeprecationIndexProcessor(),
-            SupportedVersion.getSupportedVersions().toArray(new String[0])
+            SupportedVersion.getSupportedVersionStrings()
     ),
     EXISTENCE(
             ExistenceStateIndex.class,
             new ExistenceIndexProcessor(),
-            SupportedVersion.getSupportedVersions().toArray(new String[0])
+            SupportedVersion.getSupportedVersionStrings()
     ),
     API_COVERAGE(
             ApiCoverageStateIndex.class,
             new ApiCoverageIndexProcessor(),
-            SupportedVersion.getSupportedVersions().toArray(new String[0])
+            SupportedVersion.getSupportedVersionStrings()
     );
 
     private final String key;

--- a/src/main/java/com/magento/idea/magento2uct/packages/IndexRegistry.java
+++ b/src/main/java/com/magento/idea/magento2uct/packages/IndexRegistry.java
@@ -13,7 +13,6 @@ import com.magento.idea.magento2uct.versioning.processors.DeprecationIndexProces
 import com.magento.idea.magento2uct.versioning.processors.ExistenceIndexProcessor;
 import com.magento.idea.magento2uct.versioning.processors.IndexProcessor;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/com/magento/idea/magento2uct/packages/IndexRegistry.java
+++ b/src/main/java/com/magento/idea/magento2uct/packages/IndexRegistry.java
@@ -38,16 +38,16 @@ public enum IndexRegistry {
     private final String key;
     private final Class<?> type;
     private final IndexProcessor processor;
-    private final String[] versions;
+    private final List<String> versions;
 
     IndexRegistry(
             final Class<?> type,
             final IndexProcessor processor,
-            final String... versions
+            final List<String> versions
     ) {
         this.type = type;
         this.processor = processor;
-        this.versions = Arrays.copyOf(versions, versions.length);
+        this.versions = versions;
         key = this.toString();
     }
 
@@ -84,7 +84,7 @@ public enum IndexRegistry {
      * @return List[String]
      */
     public List<String> getVersions() {
-        return Arrays.asList(versions);
+        return versions;
     }
 
     /**

--- a/src/main/java/com/magento/idea/magento2uct/packages/SupportedVersion.java
+++ b/src/main/java/com/magento/idea/magento2uct/packages/SupportedVersion.java
@@ -5,6 +5,10 @@
 
 package com.magento.idea.magento2uct.packages;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -12,57 +16,68 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.json.JSONArray;
-import org.json.JSONObject;
+import java.util.concurrent.atomic.AtomicReference;
 
-public enum SupportedVersion {
-    ;
+public final class SupportedVersion {
+
     private final String version;
-    private static final Integer SUCCESS_CODE = 200;
 
-    SupportedVersion(final String version) {
+    private SupportedVersion(final String version) {
         this.version = version;
     }
 
-    /**
-     * Get version.
-     *
-     * @return String
-     */
-    public String getVersion() {
+    public @NotNull String getVersion() {
         return version;
     }
 
-    /**
-     * Get version ENUM by version code.
-     *
-     * @param versionCandidate String
-     *
-     * @return SupportedVersion
-     */
-    public @Nullable static SupportedVersion getVersion(final @NotNull String versionCandidate) {
-        for (final SupportedVersion version : SupportedVersion.values()) {
+    private static final AtomicReference<List<SupportedVersion>> cachedVersions = new AtomicReference<>();
+
+    public static @NotNull List<SupportedVersion> getSupportedVersions() {
+        List<SupportedVersion> versions = cachedVersions.get();
+
+        if (versions == null) {
+            versions = new ArrayList<>();
+
+            try {
+                for (final String versionStr : fetchRemoteSupportedVersions()) {
+                    versions.add(new SupportedVersion(versionStr));
+                }
+            } catch (Exception ignored) {
+            }
+
+            cachedVersions.set(versions);
+        }
+
+        return versions;
+    }
+
+    public static String[] getSupportedVersionStrings() {
+        return getSupportedVersions()
+                .stream()
+                .map(SupportedVersion::toString)
+                .toArray(String[]::new);
+    }
+
+    public static @Nullable SupportedVersion getVersion(final @NotNull String versionCandidate) {
+        for (final SupportedVersion version : getSupportedVersions()) {
             if (version.getVersion().equals(versionCandidate)) {
                 return version;
             }
         }
+
         return null;
     }
 
-    /**
-     * Get supported versions.
-     *
-     * @return List[String]
-     */
-    public static List<String> getSupportedVersions() {
-        try {
-            return fetchSupportedVersions();
-        } catch (Exception e) { //NOPMD - suppressed AvoidCatchingGenericException
-            // Return an empty list or log the exception
-            return List.of();
+    public static List<SupportedVersion> getPriorVersions(final SupportedVersion version) {
+        final List<SupportedVersion> previousVersions = new ArrayList<>();
+
+        for (final SupportedVersion supportedVersion : getSupportedVersions()) {
+            if (supportedVersion.getVersion().compareTo(version.toString()) < 0) {
+                previousVersions.add(supportedVersion);
+            }
         }
+
+        return previousVersions;
     }
 
     /**
@@ -71,22 +86,22 @@ public enum SupportedVersion {
      * from a predefined URL and parses it into a list of version strings.
      *
      * @return List[String] containing supported version strings
-     * @throws IOException if an error occurs during HTTP connection or JSON parsing
      */
-    public static List<String> fetchSupportedVersions() throws IOException {
+    private static List<String> fetchRemoteSupportedVersions() {
         final String url = "https://repo.packagist.org/p2/magento/community-edition.json";
         final List<String> versions = new ArrayList<>();
 
         HttpURLConnection connection = null;
+
         try {
             // Establish HTTP connection
             connection = (HttpURLConnection) new URL(url).openConnection();
             connection.setRequestMethod("GET");
             connection.setRequestProperty("Accept", "application/json");
 
-            if (connection.getResponseCode() != SUCCESS_CODE) {
+            if (connection.getResponseCode() != 200) {
                 throw new IOException(//NOPMD - suppressed AvoidThrowingRawExceptionTypes
-                    "Failed to fetch data, HTTP response code: " + connection.getResponseCode()
+                        "Failed to fetch data, HTTP response code: " + connection.getResponseCode()
                 );
             }
 
@@ -122,6 +137,7 @@ public enum SupportedVersion {
                     versions.add(versionstring);
                 }
             }
+        } catch (IOException ignored) {
         } finally {
             if (connection != null) {
                 connection.disconnect();
@@ -131,22 +147,4 @@ public enum SupportedVersion {
         return versions;
     }
 
-    /**
-     * Get previous versions.
-     *
-     * @param version SupportedVersion
-     *
-     * @return List[SupportedVersion]
-     */
-    public static List<SupportedVersion> getPriorVersions(final SupportedVersion version) {
-        final List<SupportedVersion> previousVersions = new ArrayList<>();
-
-        for (final SupportedVersion supportedVersion : SupportedVersion.values()) {
-            if (supportedVersion.compareTo(version) < 0) {
-                previousVersions.add(supportedVersion);
-            }
-        }
-
-        return previousVersions;
-    }
 }

--- a/src/main/java/com/magento/idea/magento2uct/packages/SupportedVersion.java
+++ b/src/main/java/com/magento/idea/magento2uct/packages/SupportedVersion.java
@@ -51,11 +51,14 @@ public final class SupportedVersion {
         return versions;
     }
 
-    public static String[] getSupportedVersionStrings() {
-        return getSupportedVersions()
-                .stream()
-                .map(SupportedVersion::toString)
-                .toArray(String[]::new);
+    public static List<String> getSupportedVersionStrings() {
+        final List<String> versions = new ArrayList<>();
+
+        for (final SupportedVersion version : getSupportedVersions()) {
+            versions.add(version.getVersion());
+        }
+
+        return versions;
     }
 
     public static @Nullable SupportedVersion getVersion(final @NotNull String versionCandidate) {

--- a/src/main/java/com/magento/idea/magento2uct/settings/UctSettingsService.java
+++ b/src/main/java/com/magento/idea/magento2uct/settings/UctSettingsService.java
@@ -15,6 +15,7 @@ import com.magento.idea.magento2uct.packages.IssueSeverityLevel;
 import com.magento.idea.magento2uct.packages.SupportedVersion;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import java.util.List;
 
 @State(name = "Magento2UctSettings", storages = @Storage(UctSettingsService.M2_UCT_SETTINGS_XML))
 public class UctSettingsService implements PersistentStateComponent<UctSettingsService> {
@@ -164,6 +165,7 @@ public class UctSettingsService implements PersistentStateComponent<UctSettingsS
         if (currentVersion == null) {
             return null;
         }
+
         return SupportedVersion.getVersion(currentVersion);
     }
 
@@ -174,8 +176,9 @@ public class UctSettingsService implements PersistentStateComponent<UctSettingsS
      */
     public @NotNull SupportedVersion getCurrentVersionOrDefault() {
         final SupportedVersion currentVersion = getCurrentVersion();
+        final @NotNull List<SupportedVersion> supportedVersions = SupportedVersion.getSupportedVersions();
 
-        return currentVersion == null ? SupportedVersion.valueOf("2.3.0") : currentVersion;
+        return currentVersion == null ? supportedVersions.get(0) : currentVersion;
     }
 
     /**
@@ -196,6 +199,7 @@ public class UctSettingsService implements PersistentStateComponent<UctSettingsS
         if (targetVersion == null) {
             return null;
         }
+
         return SupportedVersion.getVersion(targetVersion);
     }
 

--- a/src/main/java/com/magento/idea/magento2uct/ui/ConfigurationDialog.form
+++ b/src/main/java/com/magento/idea/magento2uct/ui/ConfigurationDialog.form
@@ -114,7 +114,7 @@
             <properties>
               <enabled value="true"/>
               <font size="12"/>
-              <icon value="general/information.png"/>
+              <icon value="icons/information.png"/>
               <text value="To enable inspections in the real time, also enable inspections by path:"/>
             </properties>
           </component>

--- a/src/main/java/com/magento/idea/magento2uct/ui/ConfigurationDialog.java
+++ b/src/main/java/com/magento/idea/magento2uct/ui/ConfigurationDialog.java
@@ -25,7 +25,6 @@ import com.magento.idea.magento2uct.util.module.UctModulePathValidatorUtil;
 import java.awt.Color;
 import java.awt.event.KeyEvent;
 import java.util.Objects;
-import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
@@ -50,8 +49,6 @@ public class ConfigurationDialog extends AbstractDialog {
     private JComboBox<ComboBoxItemData> issueSeverityLevel;
 
     private JPanel contentPanel;
-    private JButton buttonCancel;
-    private JButton buttonOk;
     private JLabel currentVersionLabel;//NOPMD
     private JLabel modulePathLabel;//NOPMD
     private JLabel targetVersionLabel;//NOPMD
@@ -77,8 +74,6 @@ public class ConfigurationDialog extends AbstractDialog {
 
         hasAdditionalPath.addActionListener(event ->
                 refreshAdditionalFields(hasAdditionalPath.isSelected()));
-        buttonOk.addActionListener(event -> onOK());
-        buttonCancel.addActionListener(event -> onCancel());
 
         // call onCancel() on ESCAPE
         contentPanel.registerKeyboardAction(

--- a/src/main/java/com/magento/idea/magento2uct/ui/ConfigurationDialog.java
+++ b/src/main/java/com/magento/idea/magento2uct/ui/ConfigurationDialog.java
@@ -92,6 +92,8 @@ public class ConfigurationDialog extends AbstractDialog {
         enableCommentPath.setForeground(JBColor.blue);
         setDefaultValues();
         refreshAdditionalFields(hasAdditionalPath.isSelected());
+
+        init();
     }
 
     /**

--- a/src/main/java/com/magento/idea/magento2uct/ui/ConfigurationDialog.java
+++ b/src/main/java/com/magento/idea/magento2uct/ui/ConfigurationDialog.java
@@ -267,14 +267,14 @@ public class ConfigurationDialog extends AbstractDialog {
     private void createUIComponents() {
         targetVersion = new ComboBox<>();
 
-        for (final String version : SupportedVersion.getSupportedVersions()) {
-            targetVersion.addItem(new ComboBoxItemData(version, version));
+        for (final SupportedVersion version : SupportedVersion.getSupportedVersions()) {
+            targetVersion.addItem(new ComboBoxItemData(version.getVersion(), version.getVersion()));
         }
         currentVersion = new ComboBox<>();
         currentVersion.addItem(new ComboBoxItemData("", "Less than 2.3.0"));
 
-        for (final String version : SupportedVersion.getSupportedVersions()) {
-            currentVersion.addItem(new ComboBoxItemData(version, version));
+        for (final SupportedVersion version : SupportedVersion.getSupportedVersions()) {
+            currentVersion.addItem(new ComboBoxItemData(version.getVersion(), version.getVersion()));
         }
         issueSeverityLevel = new ComboBox<>();
 

--- a/src/main/java/com/magento/idea/magento2uct/ui/ReindexDialog.java
+++ b/src/main/java/com/magento/idea/magento2uct/ui/ReindexDialog.java
@@ -16,7 +16,6 @@ import com.magento.idea.magento2uct.execution.process.ReindexHandler;
 import com.magento.idea.magento2uct.packages.IndexRegistry;
 import com.magento.idea.magento2uct.packages.SupportedVersion;
 import java.awt.event.KeyEvent;
-import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
@@ -32,15 +31,13 @@ public class ReindexDialog extends AbstractDialog {
     private JPanel contentPanel;
     private JComboBox<ComboBoxItemData> targetVersion;
     private JComboBox<ComboBoxItemData> targetIndex;
-    private JButton buttonOk;
-    private JButton buttonCancel;
     private JLabel targetVersionLabel;//NOPMD
     private JLabel targetIndexLabel;//NOPMD
 
     /**
      * Reindexing dialog.
      *
-     * @param project Project
+     * @param project   Project
      * @param directory PsiDirectory
      */
     public ReindexDialog(
@@ -53,9 +50,6 @@ public class ReindexDialog extends AbstractDialog {
         this.directory = directory;
 
         setTitle(ReindexVersionedIndexesAction.ACTION_NAME);
-
-        buttonOk.addActionListener(event -> onOK());
-        buttonCancel.addActionListener(event -> onCancel());
 
         // call onCancel() on ESCAPE
         contentPanel.registerKeyboardAction(
@@ -70,7 +64,7 @@ public class ReindexDialog extends AbstractDialog {
     /**
      * Open reindexing dialog window.
      *
-     * @param project Project
+     * @param project   Project
      * @param directory PsiDirectory
      */
     public static void open(

--- a/src/main/java/com/magento/idea/magento2uct/ui/ReindexDialog.java
+++ b/src/main/java/com/magento/idea/magento2uct/ui/ReindexDialog.java
@@ -132,8 +132,8 @@ public class ReindexDialog extends AbstractDialog {
     private void createUIComponents() {
         targetVersion = new ComboBox<>();
 
-        for (final String version : SupportedVersion.getSupportedVersions()) {
-            targetVersion.addItem(new ComboBoxItemData(version, version));
+        for (final SupportedVersion version : SupportedVersion.getSupportedVersions()) {
+            targetVersion.addItem(new ComboBoxItemData(version.getVersion(), version.getVersion()));
         }
         targetIndex = new ComboBox<>();
         targetIndex.addItem(new ComboBoxItemData("", " --- Choose Target Index --- "));

--- a/src/main/java/com/magento/idea/magento2uct/versioning/VersionStateManager.java
+++ b/src/main/java/com/magento/idea/magento2uct/versioning/VersionStateManager.java
@@ -148,22 +148,16 @@ public final class VersionStateManager {
     @SuppressWarnings("PMD.AvoidSynchronizedAtMethodLevel")
     private synchronized void correctSettings(final @NotNull Project project) {
         final UctSettingsService settingsService = UctSettingsService.getInstance(project);
-        final List<String> allVersions = SupportedVersion.getSupportedVersions();
+        final List<SupportedVersion> allVersions = SupportedVersion.getSupportedVersions();
 
-        if (currentVersion == null
-                || SupportedVersion.getVersion(currentVersion.getVersion()) == null) {
-            final SupportedVersion correctCurrentVersion = SupportedVersion.getVersion(
-                    allVersions.get(0)
-            );
+        if (currentVersion == null) {
+            final SupportedVersion correctCurrentVersion = allVersions.get(0);
             settingsService.setCurrentVersion(correctCurrentVersion);
             currentVersion = correctCurrentVersion;
         }
 
-        if (targetVersion == null
-                || SupportedVersion.getVersion(targetVersion.getVersion()) == null) {
-            final SupportedVersion correctTargetVersion = SupportedVersion.getVersion(
-                    allVersions.get(allVersions.size() - 1)
-            );
+        if (targetVersion == null) {
+            final SupportedVersion correctTargetVersion = allVersions.get(allVersions.size() - 1);
             settingsService.setTargetVersion(correctTargetVersion);
             targetVersion = correctTargetVersion;
         }
@@ -201,11 +195,11 @@ public final class VersionStateManager {
         }
 
         if (versionsToLoad.isEmpty()) {
-            for (final SupportedVersion version : SupportedVersion.values()) {
-                if (version.compareTo(targetVersion) <= 0) {
+            for (final SupportedVersion version : SupportedVersion.getSupportedVersions()) {
+                if (version.getVersion().compareTo(targetVersion.getVersion()) <= 0) {
                     if (isSetIgnoreFlag != null && isSetIgnoreFlag) {
                         // If current version is NULL, it is less than minimum supported version.
-                        if (currentVersion == null || version.compareTo(currentVersion) > 0) {
+                        if (currentVersion == null || version.getVersion().compareTo(currentVersion.getVersion()) > 0) {
                             versionsToLoad.add(version);
                         }
                     } else {

--- a/src/main/java/com/magento/idea/magento2uct/versioning/indexes/data/ApiCoverageStateIndex.java
+++ b/src/main/java/com/magento/idea/magento2uct/versioning/indexes/data/ApiCoverageStateIndex.java
@@ -168,7 +168,7 @@ public class ApiCoverageStateIndex implements VersionStateIndex {
                     VersioningDataOperationsUtil.unionVersionDataWithChangelog(
                             versioningData,
                             new ArrayList<>(Collections.singletonList(
-                                    SupportedVersion.valueOf("2.3.0").getVersion()
+                                    SupportedVersion.getSupportedVersions().get(0).getVersion()
                             )),
                             true
                     );

--- a/src/main/java/com/magento/idea/magento2uct/versioning/indexes/data/DeprecationStateIndex.java
+++ b/src/main/java/com/magento/idea/magento2uct/versioning/indexes/data/DeprecationStateIndex.java
@@ -151,7 +151,7 @@ public class DeprecationStateIndex implements VersionStateIndex {
                     VersioningDataOperationsUtil.unionVersionDataWithChangelog(
                             versioningData,
                             new ArrayList<>(Collections.singletonList(
-                                    SupportedVersion.valueOf("2.3.0").getVersion()
+                                    SupportedVersion.getSupportedVersions().get(0).getVersion()
                             )),
                             true
                     );

--- a/src/main/java/com/magento/idea/magento2uct/versioning/indexes/data/ExistenceStateIndex.java
+++ b/src/main/java/com/magento/idea/magento2uct/versioning/indexes/data/ExistenceStateIndex.java
@@ -196,7 +196,7 @@ public class ExistenceStateIndex implements VersionStateIndex {
                     VersioningDataOperationsUtil.unionVersionDataWithChangelog(
                             versioningData,
                             new ArrayList<>(Collections.singletonList(
-                                    SupportedVersion.valueOf("2.3.0").getVersion()
+                                    SupportedVersion.getSupportedVersions().get(0).getVersion()
                             )),
                             false
                     );

--- a/src/main/java/com/magento/idea/magento2uct/versioning/processors/DeprecationIndexProcessor.java
+++ b/src/main/java/com/magento/idea/magento2uct/versioning/processors/DeprecationIndexProcessor.java
@@ -89,8 +89,8 @@ public final class DeprecationIndexProcessor implements IndexProcessor {
     ) {
         final List<SupportedVersion> previousVersions = new ArrayList<>();
 
-        for (final SupportedVersion supportedVersion : SupportedVersion.values()) {
-            if (supportedVersion.compareTo(indexedVersion) < 0) {
+        for (final SupportedVersion supportedVersion : SupportedVersion.getSupportedVersions()) {
+            if (supportedVersion.getVersion().compareTo(indexedVersion.getVersion()) < 0) {
                 previousVersions.add(supportedVersion);
             }
         }

--- a/src/main/java/com/magento/idea/magento2uct/versioning/processors/ExistenceIndexProcessor.java
+++ b/src/main/java/com/magento/idea/magento2uct/versioning/processors/ExistenceIndexProcessor.java
@@ -93,8 +93,8 @@ public final class ExistenceIndexProcessor implements IndexProcessor {
     ) {
         final List<SupportedVersion> previousVersions = new ArrayList<>();
 
-        for (final SupportedVersion supportedVersion : SupportedVersion.values()) {
-            if (supportedVersion.compareTo(indexedVersion) < 0) {
+        for (final SupportedVersion supportedVersion : SupportedVersion.getSupportedVersions()) {
+            if (supportedVersion.getVersion().compareTo(indexedVersion.getVersion()) < 0) {
                 previousVersions.add(supportedVersion);
             }
         }

--- a/src/main/java/com/magento/idea/magento2uct/versioning/processors/util/VersioningDataOperationsUtil.java
+++ b/src/main/java/com/magento/idea/magento2uct/versioning/processors/util/VersioningDataOperationsUtil.java
@@ -83,7 +83,7 @@ public final class VersioningDataOperationsUtil {
                 return 0;
             }
 
-            return version1.compareTo(version2);
+            return version1.getVersion().compareTo(version2.getVersion());
         });
 
         for (final String version : versions) {


### PR DESCRIPTION
**Description**
This pull request resolves runtime errors in the Upgrade Compatibility Tool (UCT):
* ConfigurationDialog
    * Corrected icon path from `general/information.png` to `icons/information.png` to prevent  `java.lang.NullPointerException: Cannot invoke "java.net.URL.toExternalForm()" because "location" is null`.
    * Removed non-existent `this.buttonOk` and `this.buttonCancel` references to resolve `java.lang.NullPointerException`.
    * Added missing `init()` call to ensure the dialog content is properly initialised and is not displayed as a blank modal window.
* ReindexDialog
  * Removed non-existent `this.buttonOk` and `this.buttonCancel` references to resolve `java.lang.NullPointerException`.
* SupportedVersion
  * Changed from `enum` to `class` as the enum no longer had any static values and was relying on realtime calls to Packagist. The UCT tool was erroring when calling `SupportedVersion.values()` and when trying to get enum `2.3.0` (as a default fallback) because the enum didn't have any values. The entire plugin has been updated to use the new class functions.

**Fixed Issues**
1. Fixes magento/magento2-phpstorm-plugin#2503
2. Fixes magento/magento2-phpstorm-plugin#2515
3. Fixes magento/magento2-phpstorm-plugin#2528
4. Fixes magento/magento2-phpstorm-plugin#2557
5. Fixes magento/magento2-phpstorm-plugin#2573

This also resolves the following issue(s) which have been marked as completed/resolved but are still occurring in the latest version of the plugin:
* Fixes magento/magento2-phpstorm-plugin#2464

**Contribution checklist**
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with integration/functional tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
