### PR TITLE
2728: Fixed KnockoutRegionReferenceProvider.java. Region matching now…

### DIFF
--- a/src/main/java/com/magento/idea/magento2plugin/reference/provider/KnockoutRegionReferenceProvider.java
+++ b/src/main/java/com/magento/idea/magento2plugin/reference/provider/KnockoutRegionReferenceProvider.java
@@ -9,6 +9,7 @@ import com.intellij.lang.javascript.JavascriptLanguage;
 import com.intellij.lang.javascript.psi.JSProperty;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.PsiReferenceProvider;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -85,7 +86,7 @@ public class KnockoutRegionReferenceProvider extends PsiReferenceProvider {
             return;
         }
         final List<KnockoutRegionResolver.RegionMatch> regionMatches = KnockoutRegionResolver.getInstance()
-                .collectGetRegionMatches(referenceHost.getText());
+                .collectGetRegionMatches(getReferenceHostText(referenceHost));
 
         for (final KnockoutRegionResolver.RegionMatch regionMatch : regionMatches) {
             final TextRange referenceRange = getRegionReferenceRange(element, referenceHost, regionMatch);
@@ -125,13 +126,31 @@ public class KnockoutRegionReferenceProvider extends PsiReferenceProvider {
 
         while (current != null && current != containingFile) {
             if (isGetRegionReferenceHost(current)
-                    && current.getText().contains("getRegion")) {
+                    && getReferenceHostText(current).contains("getRegion")) {
                 return current;
             }
             current = current.getParent();
         }
 
         return null;
+    }
+
+    private @NotNull String getReferenceHostText(final @NotNull PsiElement element) {
+        final PsiFile file = element.getContainingFile();
+
+        if (file == null) {
+            return "";
+        }
+        // Embedded JavaScript PSI in PHP templates may fail when reconstructing composite text.
+        // Read the source using the same offsets that are used to build the reference ranges.
+        final CharSequence contents = file.getViewProvider().getContents();
+        final TextRange range = element.getTextRange();
+
+        if (range == null || range.getStartOffset() < 0 || range.getEndOffset() > contents.length()) {
+            return "";
+        }
+
+        return range.subSequence(contents).toString();
     }
 
     private boolean isGetRegionReferenceHost(final @NotNull PsiElement element) {

--- a/src/test/java/com/magento/idea/magento2plugin/reference/js/KnockoutTemplateReferenceRegistrarTest.java
+++ b/src/test/java/com/magento/idea/magento2plugin/reference/js/KnockoutTemplateReferenceRegistrarTest.java
@@ -5,9 +5,15 @@
 
 package com.magento.idea.magento2plugin.reference.js;
 
+import com.intellij.lang.Language;
+import com.intellij.lang.javascript.JavascriptLanguage;
+import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.ResolveResult;
+import com.intellij.psi.impl.FakePsiElement;
+import com.intellij.util.ProcessingContext;
 import com.magento.idea.magento2plugin.navigation.KnockoutRegionGotoDeclarationHandler;
 import com.magento.idea.magento2plugin.reference.provider.KnockoutRegionReferenceProvider;
 import com.magento.idea.magento2plugin.reference.provider.KnockoutTemplateReferenceProvider;
@@ -43,6 +49,45 @@ public class KnockoutTemplateReferenceRegistrarTest extends ReferenceJsFixtureTe
         );
 
         myFixture.doHighlighting();
+    }
+
+    /**
+     * Region references must use source offsets even when embedded PSI cannot reconstruct its text.
+     */
+    public void testGetRegionReferenceMustNotReconstructHostText() {
+        final String prefix = "var qty = 1;\n";
+        final String call = "getRegion('childRegion')";
+        final PsiFile file = myFixture.configureByText("region.js", prefix + call + ";");
+        final PsiElement host = new FakePsiElement() {
+            @Override
+            public PsiElement getParent() {
+                return file;
+            }
+
+            @Override
+            public Language getLanguage() {
+                return JavascriptLanguage.INSTANCE;
+            }
+
+            @Override
+            public TextRange getTextRange() {
+                return TextRange.from(prefix.length(), call.length());
+            }
+
+            @Override
+            public String getText() {
+                throw new AssertionError("Embedded JavaScript text must not be reconstructed");
+            }
+        };
+        final PsiReference[] references = new KnockoutRegionReferenceProvider()
+                .getReferencesByElement(host, new ProcessingContext());
+
+        assertTrue("Expected a region reference", references.length > 0);
+        assertEquals(TextRange.from(0, call.length()), references[0].getRangeInElement());
+        assertReferenceResolvesToFile(
+                references[0],
+                "app/code/Foo/Bar/view/frontend/web/js/knockout-child.js"
+        );
     }
 
     /**


### PR DESCRIPTION
… reads source text by PSI offsets, avoiding the embedded JavaScript text reconstruction that triggers the assertion.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

**Description** (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

**Fixed Issues (if relevant)**
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2-phpstorm-plugin#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2-phpstorm-plugin#2728

**Questions or comments**
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

**Contribution checklist** (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with integration/functional tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
